### PR TITLE
replaced all np.ndarray[TYPE,ndim=#] with np.ndarray

### DIFF
--- a/tenpy/linalg/charges.pxd
+++ b/tenpy/linalg/charges.pxd
@@ -8,9 +8,9 @@ cdef class ChargeInfo(object):
     cdef readonly list names
     cpdef np.ndarray make_valid(ChargeInfo self, charges=?)
     cdef np.ndarray[QTYPE_t,ndim=1] _make_valid_1D(ChargeInfo self,
-                                                   np.ndarray[QTYPE_t,ndim=1] charges)
+                                                   np.ndarray charges)
     cdef np.ndarray[QTYPE_t,ndim=2] _make_valid_2D(ChargeInfo self,
-                                                   np.ndarray[QTYPE_t,ndim=2] charges)
+                                                   np.ndarray charges)
     cpdef void test_sanity(ChargeInfo self) except *
 
 cdef class LegCharge(object):
@@ -28,8 +28,8 @@ cdef class LegCharge(object):
     cpdef void test_contractible(LegCharge self, LegCharge other) except *
     cpdef void test_equal(LegCharge self, LegCharge other) except *
     cpdef slice get_slice(LegCharge self, int qindex)
-    cpdef void _set_charges(LegCharge self, np.ndarray[QTYPE_t,ndim=2] charges)
-    cpdef void _set_slices(LegCharge self, np.ndarray[np.intp_t,ndim=1] slices)
+    cpdef void _set_charges(LegCharge self, np.ndarray charges)
+    cpdef void _set_slices(LegCharge self, np.ndarray slices)
     cpdef _set_block_sizes(self, block_sizes)
     cpdef _get_block_sizes(self)
     cpdef void __setstate__(LegCharge self, tuple state)
@@ -49,7 +49,7 @@ cdef class LegPipe(LegCharge):
     cdef void _init_from_legs(LegPipe self, bint sort=?, bint bunch=?) except *
     cpdef void __setstate__(LegPipe self, tuple state)
 
-cdef np.ndarray _c_find_row_differences(np.ndarray[QTYPE_t,ndim=2] qflat)
-cdef np.ndarray[QTYPE_t,ndim=2] _partial_qtotal(ChargeInfo chinfo,
+cdef np.ndarray _c_find_row_differences(np.ndarray qflat)
+cdef np.ndarray _partial_qtotal(ChargeInfo chinfo,
                                                 list legs,
-                                                np.ndarray[np.intp_t, ndim=2] qdata)
+                                                np.ndarray qdata)

--- a/tenpy/linalg/np_conserved.pyx
+++ b/tenpy/linalg/np_conserved.pyx
@@ -2351,7 +2351,7 @@ cdef class Array(object):
 
         # get new qdata
         cdef np.ndarray[np.intp_t, ndim=2] qdata = np.empty((self.stored_blocks, res.rank),
-                                                            dtype=self._qdata.dtype)
+                                                            dtype=np.intp)
         qdata[:, non_new_axes] = self._qdata[:, non_combined_legs]
         for na, p, qmap_ind in zip(new_axes, pipes, qmap_inds):
             np.take(
@@ -3705,7 +3705,7 @@ cdef inline np.ndarray _np_zeros(np.PyArray_Dims dims, int type):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef np.ndarray _iter_common_sorted(
-        np.ndarray[np.intp_t, ndim=1] a, np.ndarray[np.intp_t, ndim=1] b):
+        np.ndarray a, np.ndarray b):
     """Yield indices ``i, j`` for which ``a[i] == b[j]``.
 
     *Assumes* that ``a[i_start:i_stop]`` and ``b[j_start:j_stop]`` are strictly ascending.
@@ -3814,8 +3814,8 @@ cdef _tensordot_pre_sort(Array a, Array b, int cut_a, int cut_b, np.dtype calc_d
 cdef _tensordot_match_charges(int n_rows_a,
                               int n_cols_b,
                               int qnumber,
-                              np.ndarray[QTYPE_t, ndim=2] a_charges_keep,
-                              np.ndarray[QTYPE_t, ndim=2] b_charges_match):
+                              np.ndarray a_charges_keep,
+                              np.ndarray b_charges_match):
     """Estimate number of blocks in res and get order for iteration over row_a and col_b
 
     Parameters


### PR DESCRIPTION
On my computer, this seems to fix the memory leaks...
A few things to address before merging this into master:
- [ ] Confirmation from other sides that this helps
- [ ] Are there any other reports on memory leaks in Cython when using the np.ndarray[typd,ndim] syntax?
- [ ] How much does it affect speed???
- [ ] Does it suffice to remove only some of them?
