### PR TITLE
'shelve' parameter should be set as an attribute,…

### DIFF
--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -448,7 +448,7 @@ class Engine(NpcLinearOperator):
                               "disable mixer and continue")
                         self.mixer = None
             if time.time() - start_time > max_seconds:
-                shelve = True
+                self.shelve = True
                 warnings.warn("DMRG: maximum time limit reached. Shelve simulation.")
                 break
             # --------- the main work --------------


### PR DESCRIPTION
… to allow other code to check if run ended because it ran out of time.

Note this is a _very_ minor change. However, I am working on some code to shelve and restart simulations without changing any of the parameters. Usecase for example: code run on a machine which limits job run time. I believe this is not implemented at the moment (please confirm). This could potentially be rolled into this pull request once done.