### PR TITLE
tdmrg.py added, tdvp.py separated into tdvp1.py, tdvp2.py

### DIFF
--- a/tenpy/algorithms/tdmrg.py
+++ b/tenpy/algorithms/tdmrg.py
@@ -1,0 +1,200 @@
+r"""Time-dependent DMRG (tDMRG).
+
+The summary of tDMRG method goes here.
+
+"""
+# Copyright 2019 TeNPy Developers
+from tqdm import trange  # trange = range with waitbar
+
+import numpy as np
+import time
+import copy
+
+from tenpy.tools.params import get_parameter
+from tenpy.tools.process import memory_usage
+from tenpy.networks.mps import MPSEnvironment
+
+# python 3.7 or above
+#from tenpy.soshi.spectra_data import Crt, Srt, Xrt
+#from tenpy.soshi.postprocess import FourierTransform
+
+
+class Engine():
+    """Time-dependent DMRG(tDMRG) 'engine'.
+
+    Parameters
+    ----------
+    psi : :class:`~tenpy.networks.mps.MPS`
+        the ground state of the model. It usually needs to be computed with DMRG in advance.
+    model : :class:`~tenpy.models.MPOModel`
+        The model representing the Hamiltonian for which we want to find the ground state.
+    tdmrg_params : dict
+        macro params controlling tDMRG algorithm
+        ============== ========= ===============================================================
+        key            type      description
+        ============== ========= ===============================================================
+        Nt             int       Number of measurements for time-dependent correlation functions
+
+        -------------- --------- ---------------------------------------------------------------
+        E0             float     groundstate energy (energy of psi), which needs to be computed
+                                 with DMRG in advance.
+        -------------- --------- ---------------------------------------------------------------
+        opA            operator  tDMRG will compute <psi|opA(r,t)opB(0,0)|psi>.
+        opB                        (ex) opA=Sp, opB=Sm to compute <psi|S^+(r,t)S^-(0,0)|psi>
+        ============== ========= ===============================================================
+
+    tevol_params : dict
+        micro params controlling the time-evolution during tDMRG. Need to be valid parameters for the tevol-method used.
+
+    tevol_method : algorithm
+        time-evol algorithm. Currently {tebd, tdvp1, tdvp2} are supported options.
+
+    Attributes
+    ----------
+    psi : :class:`~tenpy.networks.mps.MPS`
+        The groundstate MPS, not changed after initialization.
+
+    phi_t: :class:`~tenpy.networks.mps.MPS`
+        The time-dependent MPS, |phi(t)>=e^{-iHt}opB(0,0)|psi>
+
+    tDMRG_results: dict
+        A dictionary with keys ``'Crt', 'Xrt', 'Srt'``
+    """
+
+    # tevol_method={tebd, tdvp1, tdvp2}
+    def __init__(self, psi, model, tdmrg_params, tevol_params, tevol_method):
+
+        self.psi = psi
+        self.model = model
+        self.tdmrg_params = tdmrg_params
+        self.tevol_params = tevol_params
+        self.tevol_method = tevol_method
+
+        self.L = psi.L
+        self.Nt = get_parameter(self.tdmrg_params, 'Nt', 50, 'tDMRG')
+        self.E0 = get_parameter(self.tdmrg_params, 'E0', {}, 'tDMRG')
+        self.opA = get_parameter(self.tdmrg_params, 'opA', {}, 'tDMRG')
+        self.opB = get_parameter(self.tdmrg_params, 'opB', {}, 'tDMRG')
+
+    # =====main function================
+    def run(self):
+        """run tDMRG calculation. C(r,t)
+
+        Returns
+        -------
+        tDMRG_results: dict
+            A dictionary with keys ``'Crt', 'Xrt', 'Srt'``
+        """
+
+        # setup tdmrg
+        self._prepare_tdmrg()
+
+        # =====run tDMRG=================
+        # measurement at t=0
+        self._measure()
+
+        for nt in trange(self.Nt, desc='tDMRG'):  # trange=range + waitbar
+            # evolve phi_t by 1 step (dt_measure=dt*N_steps)
+            self.tevol.run()
+
+            # measurement at t
+            self._measure()
+
+        self._store_result()
+        # ===============================
+
+        return self.tDMRG_result
+
+    # =====helper functions================
+
+    def _set_phi_t(self):
+        """phi_t=opB(r=i0)|psi>, where i0 is a center site i0=L/2"""
+
+        i0 = self.psi.L // 2
+        phi_t = copy.deepcopy(self.psi)
+        phi_t.apply_local_op(i0, self.opB, unitary=False)
+
+        self.phi_t = phi_t
+
+    def _set_tevol(self):
+        """set time-evolution (TEBD) engine"""
+
+        self.tevol = self.tevol_method.Engine(self.phi_t, self.model, self.tevol_params)
+
+    def _prepare_tdmrg(self):
+        """all preparation for tdmrg"""
+        self._set_phi_t()
+        self._set_tevol()
+
+        self.t_list = []
+        self.C_rt = []  # <opA(r, t) opB(0, 0)>
+        self.S_rt = []  # S^{ent}(r, t)
+        self.X_rt = []  # Chi(r, t)
+
+        self.tevol_stats = {'time': [], 'memory': []}
+        self.last_time = time.time()
+        #self.tevol_stats['memory'].append(memory_usage())
+        #self.tevol_stats['time'].append(self.now_time)
+
+    # =========================
+    def _update_env(self):
+        """update environment (psi, phi_t)"""
+        self.env = MPSEnvironment(self.psi, self.phi_t)
+
+    def _get_Crt(self):
+        """compute corr function, C(r,t)= env(opA)= <psi| opA| phi_t>"""
+
+        return self.env.expectation_value(self.opA) * self.phase
+
+    def _get_Srt(self):
+        """compute Entanglement Entropy at each bond, S(r,t)"""
+
+        return self.phi_t.entanglement_entropy()
+
+    def _get_Xrt(self):
+        """compute bond dimension at each bond, X(r,t)"""
+
+        return self.phi_t.chi
+
+    def _measure(self):
+        """update env and do measurements at each t. """
+        self._update_env()
+        t = self.tevol.evolved_time
+        self.phase = np.exp(1j * self.E0 * t)
+        self.t_list.append(t)
+        self.C_rt.append(self._get_Crt())
+        self.S_rt.append(self._get_Srt())
+        self.X_rt.append(self._get_Xrt())
+
+        self.tevol_stats['memory'].append(memory_usage())
+        self.now_time = time.time()
+        self.tevol_stats['time'].append(self.now_time - self.last_time)
+        self.last_time = self.now_time
+
+    def _store_result(self):
+        """store all tDMRG result"""
+        tevol_name = (self.tevol_method.__name__).split('.')[-1]  # extract tevol name from tevol object
+        r_list = np.arange(self.L) - int(self.L / 2)
+        t_list = np.asarray(self.t_list)
+        C_rt = np.asarray(self.C_rt)
+        S_rt = np.asarray(self.S_rt)
+        X_rt = np.asarray(self.X_rt)
+
+        tDMRG_result = dict()
+        tDMRG_result['tevol_name'] = tevol_name.upper()  # capitalize all letters
+        tDMRG_result['tevol_stats'] = self.tevol_stats
+        
+        tDMRG_result['Crt'] = C_rt  # corr function
+        tDMRG_result['Srt'] = S_rt  # entanglement entropy
+        tDMRG_result['Xrt'] = X_rt  # bond dim
+        tDMRG_result['r'] = r_list
+        tDMRG_result['t'] = t_list
+        
+#        #for python 3.7 (@dataclass) with (spectra_data.py, postprocess.py)
+#        tDMRG_result['Crt'] = Crt(C_rt, r_list, t_list)
+#        tDMRG_result['Srt'] = Srt(S_rt, r_list[:-1], t_list)
+#        tDMRG_result['Xrt'] = Xrt(X_rt, r_list[:-1], t_list)
+#        tDMRG_result['Sqt'], tDMRG_result['Sqw'] = FourierTransform.Crt_to_Sqt_to_Sqw(
+#            tDMRG_result['Crt'])
+
+        self.tDMRG_result = tDMRG_result

--- a/tenpy/algorithms/tdvp1.py
+++ b/tenpy/algorithms/tdvp1.py
@@ -1,0 +1,380 @@
+"""Time Dependant Variational Principle (TDVP) with MPS (finite version only).
+
+The TDVP MPS algorithm was first proposed by [Haegeman2011]_. However the stability of the
+algorithm was later improved in [Haegeman2016]_, that we are following in this implementation.
+The general idea of the algorithm is to project the quantum time evolution in the manyfold of MPS
+with a given bond dimension. Compared to e.g. TEBD, the algorithm has several advantages:
+e.g. it conserves the unitarity of the time evolution and the energy (for the single-site version),
+and it is suitable for time evolution of Hamiltonian with arbitrary long range in the form of MPOs.
+We have implemented the one-site formulation which **does not** allow for growth of the bond dimension,
+and the two-site algorithm which does allow the bond dimension to grow - but requires truncation as in the TEBD case.
+
+.. todo ::
+    This is still a beta version, use with care.
+    The interface might still change.
+
+.. todo ::
+    long-term: Much of the code is similar as in DMRG. To avoid too much duplicated code,
+    we should have a general way to sweep through an MPS and updated one or two sites, used in both
+    cases.
+"""
+
+import numpy as np
+from tenpy.networks.mpo import MPOEnvironment
+import tenpy.linalg.np_conserved as npc
+from tenpy.tools.params import get_parameter
+from tenpy.linalg.lanczos import LanczosEvolution
+
+class Engine:
+    """Time dependant variational principle 'Engine'
+
+    You can call :meth:`run_one_site` for single-site TDVP, or
+    :meth:`run_two_sites` for two-site TDVP.
+
+    Parameters
+    ----------
+    psi : :class:`~tenpy.networks.mps.MPS`
+        Initial state to be time evolved. Modified in place.
+    model : :class:`~tenpy.models.model.MPOModel`
+        The model representing the Hamiltonian for which we want to find the ground state.
+    TDVP_params : dict
+        Further optional parameters as described in the following table.
+        Use ``verbose>0`` to print the used parameters during runtime.
+
+        ============== ========= ===============================================================
+        key            type      description
+        ============== ========= ===============================================================
+        start_time     float     Initial value for :attr:`evolved_time`
+        -------------- --------- ---------------------------------------------------------------
+        dt             float     Time step of the Trotter error
+        -------------- --------- ---------------------------------------------------------------
+        trunc_params   dict      Truncation parameters as described in
+                                 :func:`~tenpy.algorithms.truncation.truncate`
+        ============== ========= ===============================================================
+    environment :  :class:'~tenpy.networks.mpo.MPOEnvironment` | None
+        Initial environment. If ``None`` (default), it will be calculated at the beginning.
+
+    Attributes
+    ----------
+    verbose : int
+        Level of verbosity (i.e. how much status information to print); higher=more output.
+    evolved_time : float | complex
+        Indicating how long `psi` has been evolved, ``psi = exp(-i * evolved_time * H) psi(t=0)``.
+    psi : :class:`~tenpy.networks.mps.MPS`
+        The MPS, time evolved in-place.
+    TDVP_params: dict
+        Optional parameters, see :func:`run` and :func:`run_GS` for more details.
+    environment : :class:`~tenpy.networks.mpo.MPOEnvironment`
+        The environment, storing the `LP` and `RP` to avoid recalculations.
+    """
+
+    def __init__(self, psi, model, TDVP_params, environment=None):
+        self.verbose = get_parameter(TDVP_params, 'verbose', 1, 'TDVP')
+        self.TDVP_params = TDVP_params
+        if environment is None:
+            environment = MPOEnvironment(psi, model.H_MPO, psi)
+        self.evolved_time = get_parameter(TDVP_params, 'start_time', 0., 'TDVP')
+        self.H_MPO = model.H_MPO
+        self.environment = environment
+        if not psi.finite:
+            raise ValueError("TDVP is only implemented for finite boundary conditions")
+        self.psi = psi
+        self.L = self.psi.L
+        self.dt = get_parameter(TDVP_params, 'dt', 2, 'TDVP')
+        self.trunc_params = get_parameter(TDVP_params, 'trunc_params', {}, 'TDVP')
+        self.N_steps = get_parameter(TDVP_params, 'N_steps', 10, 'TDVP')
+
+
+    # Actual calculation
+    def run(self, N_steps=None):
+        """Run the TDVP algorithm with the one site algorithm.
+
+        .. warning ::
+            Be aware that the bond dimension will not increase!
+
+        Parameters
+        ----------
+        N_steps : integer. Number of steps
+        """
+        if N_steps != None:
+            self.N_steps = N_steps
+        D = self.H_MPO._W[0].shape[0]
+        #Initialize in the correct order
+        for i in range(self.L):
+            self.psi.get_B(i).itranspose(('vL', 'p', 'vR'))
+        for i in range(self.N_steps):
+            self.sweep_left_right()
+            self.sweep_right_left()
+            self.evolved_time = self.evolved_time + self.dt
+
+
+    def _del_correct(self, i):
+        """Delete correctly the environment once the tensor at site i is updated.
+
+        Parameters
+        ----------
+        i : int
+            Site at which the tensor has been updated
+        """
+
+        if i + 1 < self.L:
+            self.environment.del_LP(i + 1)
+        if i - 1 > -1:
+            self.environment.del_RP(i - 1)
+
+    def sweep_left_right(self):
+        """Performs the sweep left->right of the second order TDVP scheme with one site update.
+
+        Evolve from 0.5*dt.
+        """
+        for j in range(self.L):
+            B = self.psi.get_B(j)
+            # Get theta
+            if j == 0:
+                theta = B
+            else:
+                theta = npc.tensordot(B, s,
+                                      axes=('vL',
+                                            'vR'))  #theta[vL,p,vR]=s[vL,vR]*self.psi[p,vL,vR]
+            Lp = self.environment.get_LP(j)
+            Rp = self.environment.get_RP(j)
+            W1 = self.environment.H.get_W(j)
+            theta = self.update_theta_h1(Lp, Rp, theta, W1, -1j * 0.5 * self.dt)
+            # SVD and update environment
+            U, s, V = self.theta_svd_left_right(theta)
+            self.psi.set_B(j, U, form='A')
+            self.psi.set_SR(j, np.diag(s.to_ndarray()))
+            self._del_correct(j)
+            if j < self.L - 1:
+                # Apply expm (-dt H) for 0-site
+
+                B = self.psi.get_B(j + 1)
+                B_jp1 = npc.tensordot(V, B, axes=['vR', 'vL'])
+                self.psi.set_B(j + 1, B_jp1, form='B')
+                Lpp = self.environment.get_LP(j + 1)
+                Rp = npc.tensordot(Rp, V, axes=['vL', 'vR'])
+                Rp = npc.tensordot(Rp, V.conj(), axes=['vL*', 'vR*'])
+                H = H0_mixed(Lpp, Rp)
+
+                s = self.update_s_h0(s, H, 1j * 0.5 * self.dt)
+                s = s / np.linalg.norm(s.to_ndarray())
+
+    def sweep_right_left(self):
+        """Performs the sweep right->left of the second order TDVP scheme with one site update.
+
+        Evolve from 0.5*dt"""
+        expectation_O = []
+        for j in range(self.L - 1, -1, -1):
+            B = self.psi.get_B(j, form='A')
+            # Get theta
+            if j == self.L - 1:
+                theta = B
+            else:
+                theta = npc.tensordot(B, s,
+                                      axes=('vR',
+                                            'vL'))  #theta[vL,p,vR]=s[vL,vR]*self.psi[p,vL,vR]
+
+            # Apply expm (-dt H) for 1-site
+            chiB, chiA, d = theta.to_ndarray().shape
+            Lp = self.environment.get_LP(j)
+            Rp = self.environment.get_RP(j)
+            W1 = self.environment.H.get_W(j)
+            theta = self.update_theta_h1(Lp, Rp, theta, W1, -1j * 0.5 * self.dt)
+            # SVD and update environment
+            U, s, V = self.theta_svd_right_left(theta)
+            self.psi.set_B(j, U, form='B')
+            self.psi.set_SL(j, np.diag(s.to_ndarray()))
+            self._del_correct(j)
+            if j > 0:
+                # Apply expm (-dt H) for 0-site
+
+                B = self.psi.get_B(j - 1, form='A')
+                B_jm1 = npc.tensordot(V, B, axes=['vL', 'vR'])
+                self.psi.set_B(j - 1, B_jm1, form='A')
+                Lp = npc.tensordot(Lp, V, axes=['vR', 'vL'])
+                Lp = npc.tensordot(Lp, V.conj(), axes=['vR*', 'vL*'])
+                H = H0_mixed(Lp, self.environment.get_RP(j - 1))
+
+                s = self.update_s_h0(s, H, 1j * 0.5 * self.dt)
+                s = s / np.linalg.norm(s.to_ndarray())
+
+    def update_theta_h1(self, Lp, Rp, theta, W, dt):
+        """Update with the one site Hamiltonian.
+
+        Parameters
+        ----------
+        Lp : :class:`~tenpy.linalg.np_conserved.Array`
+            tensor representing the left environment
+        Rp :  :class:`~tenpy.linalg.np_conserved.Array`
+            tensor representing the right environment
+        theta :  :class:`~tenpy.linalg.np_conserved.Array`
+            the theta tensor which needs to be updated
+        W : :class:`~tenpy.linalg.np_conserved.Array`
+            MPO which is applied to the 'p' leg of theta
+        """
+        H = H1_mixed(Lp, Rp, W)
+        theta = theta.combine_legs(['vL', 'p', 'vR'])
+        #Initialize Lanczos
+        parameters_lanczos_h1 = {'delta': dt}
+        lanczos_h1 = LanczosEvolution(H=H, psi0=theta, params=parameters_lanczos_h1)
+        theta, N_h1 = lanczos_h1.run(dt)
+        theta = theta.split_legs(['(vL.p.vR)'])
+        return theta
+
+
+    def theta_svd_left_right(self, theta):
+        """Performs the SVD from left to right
+
+        Parameters
+        ----------
+        theta: :class:`tenpy.linalg.np_conserved.Array`
+            the theta tensor on which the SVD is applied
+        """
+        theta = theta.combine_legs(['vL', 'p'])
+        U, s, V = npc.svd(theta, full_matrices=0)
+        U = U.split_legs(['(vL.p)'])
+        U = self.set_anonymous_svd(U, 'vR')
+        V = self.set_anonymous_svd(V, 'vL')
+        s_ndarray = np.diag(s)
+        vR_U = U.get_leg('vR')
+        vL_V = V.get_leg('vL')
+        s = npc.Array.from_ndarray(s_ndarray, [vR_U.conj(), vL_V.conj()],
+                                   dtype=None,
+                                   qtotal=None,
+                                   cutoff=None)
+        s.iset_leg_labels(['vL', 'vR'])
+        return U, s, V
+
+    def set_anonymous_svd(self, U, new_label):
+        """Relabel the svd
+
+        Parameters
+        ----------
+        U : :class:`tenpy.linalg.np_conserved.Array`
+            the tensor which lacks a leg_label
+        """
+        list_labels = list(U.get_leg_labels())
+        for i in range(len(list_labels)):
+            if list_labels[i] == None:
+                list_labels[i] = 'None'
+        U = U.iset_leg_labels(list_labels)
+        U = U.replace_label('None', new_label)
+        return U
+
+    def theta_svd_right_left(self, theta):
+        """Performs the SVD from right to left
+
+        Parameters
+        ----------
+        theta : :class:`tenpy.linalg.np_conserved.Array`,
+            The theta tensor on which the SVD is applied
+        """
+        theta = theta.combine_legs(['p', 'vR'])
+        V, s, U = npc.svd(theta, full_matrices=0)
+        U = U.split_legs(['(p.vR)'])
+        U = self.set_anonymous_svd(U, 'vL')
+        V = self.set_anonymous_svd(V, 'vR')
+        s_ndarray = np.diag(s)
+        vL_U = U.get_leg('vL')
+        vR_V = V.get_leg('vR')
+        s = npc.Array.from_ndarray(s_ndarray, [vR_V.conj(), vL_U.conj()],
+                                   dtype=None,
+                                   qtotal=None,
+                                   cutoff=None)
+        s.iset_leg_labels(['vL', 'vR'])
+        return U, s, V
+
+    def update_s_h0(self, s, H, dt):
+        """Update with the zero site Hamiltonian (update of the singular value)
+
+        Parameters
+        ----------
+        s : :class:`tenpy.linalg.np_conserved.Array`
+            representing the singular value matrix which is updated
+        H : H0_mixed
+            zero site Hamiltonian that we need to apply on the singular value matrix
+        dt : complex number
+            time step of the evolution
+        """
+        #Initialize Lanczos
+        parameters_lanczos_h1 = {'delta': dt}
+        lanczos_h0 = LanczosEvolution(H=H,
+                                      psi0=s.combine_legs(['vL', 'vR']),
+                                      params=parameters_lanczos_h1)
+        s_new, N_h0 = lanczos_h0.run(dt)
+        s_new = s_new.split_legs(['(vL.vR)'])
+        return s_new
+
+
+class H0_mixed:
+    """Class defining the zero site Hamiltonian for Lanczos
+
+    Parameters
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+
+    Attributes
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    """
+
+    def __init__(self, Lp, Rp):
+        self.Lp = Lp
+        self.Rp = Rp
+
+    def matvec(self, x):
+        x = x.split_legs(['(vL.vR)'])
+        x = npc.tensordot(self.Lp, x, axes=('vR', 'vL'))
+        x = npc.tensordot(x, self.Rp, axes=(['vR', 'wR'], ['vL', 'wL']))
+        #TODO:next line not needed. Since the transpose does not do anything, should not cost anything. Keep for safety ?
+        x = x.transpose(['vR*', 'vL*'])
+        x = x.iset_leg_labels(['vL', 'vR'])
+        x = x.combine_legs(['vL', 'vR'])
+        return (x)
+
+
+class H1_mixed:
+    """Class defining the one site Hamiltonian for Lanczos
+
+    Parameters
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    M : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p' leg of theta
+
+    Attributes
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    W : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p0' leg of theta
+    """
+
+    def __init__(self, Lp, Rp, W):
+        self.Lp = Lp  # a,ap,m
+        self.Rp = Rp  # b,bp,n
+        self.W = W  # m,n,i,ip
+
+    def matvec(self, theta):
+        theta = theta.split_legs(['(vL.p.vR)'])
+        Lp = self.Lp
+        Rp = self.Rp
+        x = npc.tensordot(Lp, theta, axes=('vR', 'vL'))
+        x = npc.tensordot(x, self.W, axes=(['p', 'wR'], ['p*', 'wL']))
+        x = npc.tensordot(x, Rp, axes=(['vR', 'wR'], ['vL', 'wL']))
+        #TODO:next line not needed. Since the transpose does not do anything, should not cost anything. Keep for safety ?
+        x = x.transpose(['vR*', 'p', 'vL*'])
+        x = x.iset_leg_labels(['vL', 'p', 'vR'])
+        h = x.combine_legs(['vL', 'p', 'vR'])
+        return h

--- a/tenpy/algorithms/tdvp2.py
+++ b/tenpy/algorithms/tdvp2.py
@@ -1,0 +1,452 @@
+"""Time Dependant Variational Principle (TDVP) with MPS (finite version only).
+
+The TDVP MPS algorithm was first proposed by [Haegeman2011]_. However the stability of the
+algorithm was later improved in [Haegeman2016]_, that we are following in this implementation.
+The general idea of the algorithm is to project the quantum time evolution in the manyfold of MPS
+with a given bond dimension. Compared to e.g. TEBD, the algorithm has several advantages:
+e.g. it conserves the unitarity of the time evolution and the energy (for the single-site version),
+and it is suitable for time evolution of Hamiltonian with arbitrary long range in the form of MPOs.
+We have implemented the one-site formulation which **does not** allow for growth of the bond dimension,
+and the two-site algorithm which does allow the bond dimension to grow - but requires truncation as in the TEBD case.
+
+.. todo ::
+    This is still a beta version, use with care.
+    The interface might still change.
+
+.. todo ::
+    long-term: Much of the code is similar as in DMRG. To avoid too much duplicated code,
+    we should have a general way to sweep through an MPS and updated one or two sites, used in both
+    cases.
+"""
+
+import numpy as np
+from tenpy.networks.mpo import MPOEnvironment
+import tenpy.linalg.np_conserved as npc
+from tenpy.tools.params import get_parameter
+from tenpy.linalg.lanczos import LanczosEvolution
+from tenpy.algorithms.truncation import svd_theta
+
+
+class Engine:
+    """Time dependant variational principle 'Engine'
+
+    You can call :meth:`run_one_site` for single-site TDVP, or
+    :meth:`run_two_sites` for two-site TDVP.
+
+    Parameters
+    ----------
+    psi : :class:`~tenpy.networks.mps.MPS`
+        Initial state to be time evolved. Modified in place.
+    model : :class:`~tenpy.models.model.MPOModel`
+        The model representing the Hamiltonian for which we want to find the ground state.
+    TDVP_params : dict
+        Further optional parameters as described in the following table.
+        Use ``verbose>0`` to print the used parameters during runtime.
+
+        ============== ========= ===============================================================
+        key            type      description
+        ============== ========= ===============================================================
+        start_time     float     Initial value for :attr:`evolved_time`
+        -------------- --------- ---------------------------------------------------------------
+        dt             float     Time step of the Trotter error
+        -------------- --------- ---------------------------------------------------------------
+        trunc_params   dict      Truncation parameters as described in
+                                 :func:`~tenpy.algorithms.truncation.truncate`
+        ============== ========= ===============================================================
+    environment :  :class:'~tenpy.networks.mpo.MPOEnvironment` | None
+        Initial environment. If ``None`` (default), it will be calculated at the beginning.
+
+    Attributes
+    ----------
+    verbose : int
+        Level of verbosity (i.e. how much status information to print); higher=more output.
+    evolved_time : float | complex
+        Indicating how long `psi` has been evolved, ``psi = exp(-i * evolved_time * H) psi(t=0)``.
+    psi : :class:`~tenpy.networks.mps.MPS`
+        The MPS, time evolved in-place.
+    TDVP_params: dict
+        Optional parameters, see :func:`run` and :func:`run_GS` for more details.
+    environment : :class:`~tenpy.networks.mpo.MPOEnvironment`
+        The environment, storing the `LP` and `RP` to avoid recalculations.
+    """
+
+    def __init__(self, psi, model, TDVP_params, environment=None):
+        self.verbose = get_parameter(TDVP_params, 'verbose', 1, 'TDVP')
+        self.TDVP_params = TDVP_params
+        if environment is None:
+            environment = MPOEnvironment(psi, model.H_MPO, psi)
+        self.evolved_time = get_parameter(TDVP_params, 'start_time', 0., 'TDVP')
+        self.H_MPO = model.H_MPO
+        self.environment = environment
+        if not psi.finite:
+            raise ValueError("TDVP is only implemented for finite boundary conditions")
+        self.psi = psi
+        self.L = self.psi.L
+        self.dt = get_parameter(TDVP_params, 'dt', 2, 'TDVP')
+        self.trunc_params = get_parameter(TDVP_params, 'trunc_params', {}, 'TDVP')
+        self.N_steps = get_parameter(TDVP_params, 'N_steps', 10, 'TDVP')
+
+
+
+    def run(self, N_steps=None):
+        """Run the TDVP algorithm with two sites update.
+
+        The bond dimension will increase. Truncation happens at every step of the
+        sweep, according to the parameters set in trunc_params.
+
+        Parameters
+        ----------
+        N_steps : integer. Number of steps
+        """
+        if N_steps != None:
+            self.N_steps = N_steps
+        D = self.H_MPO._W[0].shape[0]
+        #Initialize in the correct order
+        for i in range(self.L):
+            self.psi.get_B(i).itranspose(('vL', 'p', 'vR'))
+        for i in range(self.N_steps):
+            self.sweep_left_right_two()
+            self.sweep_right_left_two()
+            self.evolved_time = self.evolved_time + self.dt
+
+    def _del_correct(self, i):
+        """Delete correctly the environment once the tensor at site i is updated.
+
+        Parameters
+        ----------
+        i : int
+            Site at which the tensor has been updated
+        """
+
+        if i + 1 < self.L:
+            self.environment.del_LP(i + 1)
+        if i - 1 > -1:
+            self.environment.del_RP(i - 1)
+
+
+    def sweep_left_right_two(self):
+        """Performs the sweep left->right of the second order TDVP scheme with two sites update.
+
+        Evolve from 0.5*dt"""
+        theta_old = self.psi.get_theta(0, 1)
+        for j in range(self.L - 1):
+
+            theta = npc.tensordot(theta_old, self.psi.get_B(j + 1), ('vR', 'vL'))
+            theta.ireplace_label('p', 'p1')
+            Lp = self.environment.get_LP(j)
+            Rp = self.environment.get_RP(j + 1)
+            W1 = self.environment.H.get_W(j)
+            W2 = self.environment.H.get_W(j + 1)
+            theta = self.update_theta_h2(Lp, Rp, theta, W1, W2, -0.5 * 1j * self.dt)
+            theta = theta.combine_legs([['vL', 'p0'], ['vR', 'p1']], qconj=[+1, -1])
+            # SVD and update environment
+            U, s, V, err, renorm = svd_theta(theta, self.trunc_params)
+            s = s / npc.norm(s)
+            U = U.split_legs('(vL.p0)')
+            U.ireplace_label('p0', 'p')
+            V = V.split_legs('(vR.p1)')
+            V.ireplace_label('p1', 'p')
+            self.psi.set_B(j, U, form='A')
+            self._del_correct(j)
+            self.psi.set_SR(j, s)
+            self.psi.set_B(j + 1, V, form='B')
+            self._del_correct(j + 1)
+            if j < self.L - 2:
+                # Apply expm (-dt H) for 1-site
+                theta = self.psi.get_theta(j + 1, 1)
+                theta.ireplace_label('p0', 'p')
+                Lp = self.environment.get_LP(j + 1)
+                Rp = self.environment.get_RP(j + 1)
+                theta = self.update_theta_h1(Lp, Rp, theta, W2, 1j * 0.5 * self.dt)
+                theta_old = theta
+                theta_old.ireplace_label('p', 'p0')
+
+
+    def sweep_right_left_two(self):
+        """Performs the sweep left->right of the second order TDVP scheme with two sites update.
+
+        Evolve from 0.5*dt"""
+        theta_old = self.psi.get_theta(self.L - 1, 1)
+        for j in range(self.L - 2, -1, -1):
+            theta = npc.tensordot(theta_old, self.psi.get_B(j, form='A'), ('vL', 'vR'))
+            theta.ireplace_label('p0', 'p1')
+            theta.ireplace_label('p', 'p0')
+            #theta=self.psi.get_theta(j,2)
+            Lp = self.environment.get_LP(j)
+            Rp = self.environment.get_RP(j + 1)
+            W1 = self.environment.H.get_W(j)
+            W2 = self.environment.H.get_W(j + 1)
+            theta = self.update_theta_h2(Lp, Rp, theta, W1, W2, -1j * 0.5 * self.dt)
+            theta = theta.combine_legs([['vL', 'p0'], ['vR', 'p1']], qconj=[+1, -1])
+            # SVD and update environment
+            U, s, V, err, renorm = svd_theta(theta, self.trunc_params)
+            s = s / npc.norm(s)
+            U = U.split_legs('(vL.p0)')
+            U.ireplace_label('p0', 'p')
+            V = V.split_legs('(vR.p1)')
+            V.ireplace_label('p1', 'p')
+            self.psi.set_B(j, U, form='A')
+            self._del_correct(j)
+            self.psi.set_SR(j, s)
+            self.psi.set_B(j + 1, V, form='B')
+            self._del_correct(j + 1)
+            if j > 0:
+                # Apply expm (-dt H) for 1-site
+                theta = self.psi.get_theta(j, 1)
+                theta.ireplace_label('p0', 'p')
+                Lp = self.environment.get_LP(j)
+                Rp = self.environment.get_RP(j)
+                theta = self.update_theta_h1(Lp, Rp, theta, W1, 1j * 0.5 * self.dt)
+                theta_old = theta
+                theta.ireplace_label('p', 'p0')
+
+    def update_theta_h1(self, Lp, Rp, theta, W, dt):
+        """Update with the one site Hamiltonian.
+
+        Parameters
+        ----------
+        Lp : :class:`~tenpy.linalg.np_conserved.Array`
+            tensor representing the left environment
+        Rp :  :class:`~tenpy.linalg.np_conserved.Array`
+            tensor representing the right environment
+        theta :  :class:`~tenpy.linalg.np_conserved.Array`
+            the theta tensor which needs to be updated
+        W : :class:`~tenpy.linalg.np_conserved.Array`
+            MPO which is applied to the 'p' leg of theta
+        """
+        H = H1_mixed(Lp, Rp, W)
+        theta = theta.combine_legs(['vL', 'p', 'vR'])
+        #Initialize Lanczos
+        parameters_lanczos_h1 = {'delta': dt}
+        lanczos_h1 = LanczosEvolution(H=H, psi0=theta, params=parameters_lanczos_h1)
+        theta, N_h1 = lanczos_h1.run(dt)
+        theta = theta.split_legs(['(vL.p.vR)'])
+        return theta
+
+    def update_theta_h2(self, Lp, Rp, theta, W0, W1, dt):
+        """Update with the two sites Hamiltonian
+
+        Parameters
+        ----------
+        Lp : :class:`tenpy.linalg.np_conserved.Array`
+            tensor representing the left environment
+        Rp : :class:`tenpy.linalg.np_conserved.Array`
+            tensor representing the right environment
+        theta : :class:`tenpy.linalg.np_conserved.Array`
+            the theta tensor which needs to be updated
+        W : :class:`tenpy.linalg.np_conserved.Array`
+            MPO which is applied to the 'p0' leg of theta
+        W1 : :class:`tenpy.linalg.np_conserved.Array`
+            MPO which is applied to the 'p1' leg of theta
+        """
+        H = H2_mixed(Lp, Rp, W0, W1)
+        theta = theta.combine_legs(['vL', 'p0', 'p1', 'vR'])
+        #Initialize Lanczos
+        parameters_lanczos_h1 = {'delta': dt}
+        lanczos_h1 = LanczosEvolution(H=H, psi0=theta, params=parameters_lanczos_h1)
+        theta, N_h1 = lanczos_h1.run(dt)
+        theta = theta.split_legs(['(vL.p0.p1.vR)'])
+        return theta
+
+    def theta_svd_left_right(self, theta):
+        """Performs the SVD from left to right
+
+        Parameters
+        ----------
+        theta: :class:`tenpy.linalg.np_conserved.Array`
+            the theta tensor on which the SVD is applied
+        """
+        theta = theta.combine_legs(['vL', 'p'])
+        U, s, V = npc.svd(theta, full_matrices=0)
+        U = U.split_legs(['(vL.p)'])
+        U = self.set_anonymous_svd(U, 'vR')
+        V = self.set_anonymous_svd(V, 'vL')
+        s_ndarray = np.diag(s)
+        vR_U = U.get_leg('vR')
+        vL_V = V.get_leg('vL')
+        s = npc.Array.from_ndarray(s_ndarray, [vR_U.conj(), vL_V.conj()],
+                                   dtype=None,
+                                   qtotal=None,
+                                   cutoff=None)
+        s.iset_leg_labels(['vL', 'vR'])
+        return U, s, V
+
+    def set_anonymous_svd(self, U, new_label):
+        """Relabel the svd
+
+        Parameters
+        ----------
+        U : :class:`tenpy.linalg.np_conserved.Array`
+            the tensor which lacks a leg_label
+        """
+        list_labels = list(U.get_leg_labels())
+        for i in range(len(list_labels)):
+            if list_labels[i] == None:
+                list_labels[i] = 'None'
+        U = U.iset_leg_labels(list_labels)
+        U = U.replace_label('None', new_label)
+        return U
+
+    def theta_svd_right_left(self, theta):
+        """Performs the SVD from right to left
+
+        Parameters
+        ----------
+        theta : :class:`tenpy.linalg.np_conserved.Array`,
+            The theta tensor on which the SVD is applied
+        """
+        theta = theta.combine_legs(['p', 'vR'])
+        V, s, U = npc.svd(theta, full_matrices=0)
+        U = U.split_legs(['(p.vR)'])
+        U = self.set_anonymous_svd(U, 'vL')
+        V = self.set_anonymous_svd(V, 'vR')
+        s_ndarray = np.diag(s)
+        vL_U = U.get_leg('vL')
+        vR_V = V.get_leg('vR')
+        s = npc.Array.from_ndarray(s_ndarray, [vR_V.conj(), vL_U.conj()],
+                                   dtype=None,
+                                   qtotal=None,
+                                   cutoff=None)
+        s.iset_leg_labels(['vL', 'vR'])
+        return U, s, V
+
+    def update_s_h0(self, s, H, dt):
+        """Update with the zero site Hamiltonian (update of the singular value)
+
+        Parameters
+        ----------
+        s : :class:`tenpy.linalg.np_conserved.Array`
+            representing the singular value matrix which is updated
+        H : H0_mixed
+            zero site Hamiltonian that we need to apply on the singular value matrix
+        dt : complex number
+            time step of the evolution
+        """
+        #Initialize Lanczos
+        parameters_lanczos_h1 = {'delta': dt}
+        lanczos_h0 = LanczosEvolution(H=H,
+                                      psi0=s.combine_legs(['vL', 'vR']),
+                                      params=parameters_lanczos_h1)
+        s_new, N_h0 = lanczos_h0.run(dt)
+        s_new = s_new.split_legs(['(vL.vR)'])
+        return s_new
+
+
+class H0_mixed:
+    """Class defining the zero site Hamiltonian for Lanczos
+
+    Parameters
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+
+    Attributes
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    """
+
+    def __init__(self, Lp, Rp):
+        self.Lp = Lp
+        self.Rp = Rp
+
+    def matvec(self, x):
+        x = x.split_legs(['(vL.vR)'])
+        x = npc.tensordot(self.Lp, x, axes=('vR', 'vL'))
+        x = npc.tensordot(x, self.Rp, axes=(['vR', 'wR'], ['vL', 'wL']))
+        #TODO:next line not needed. Since the transpose does not do anything, should not cost anything. Keep for safety ?
+        x = x.transpose(['vR*', 'vL*'])
+        x = x.iset_leg_labels(['vL', 'vR'])
+        x = x.combine_legs(['vL', 'vR'])
+        return (x)
+
+
+class H1_mixed:
+    """Class defining the one site Hamiltonian for Lanczos
+
+    Parameters
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    M : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p' leg of theta
+
+    Attributes
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    W : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p0' leg of theta
+    """
+
+    def __init__(self, Lp, Rp, W):
+        self.Lp = Lp  # a,ap,m
+        self.Rp = Rp  # b,bp,n
+        self.W = W  # m,n,i,ip
+
+    def matvec(self, theta):
+        theta = theta.split_legs(['(vL.p.vR)'])
+        Lp = self.Lp
+        Rp = self.Rp
+        x = npc.tensordot(Lp, theta, axes=('vR', 'vL'))
+        x = npc.tensordot(x, self.W, axes=(['p', 'wR'], ['p*', 'wL']))
+        x = npc.tensordot(x, Rp, axes=(['vR', 'wR'], ['vL', 'wL']))
+        #TODO:next line not needed. Since the transpose does not do anything, should not cost anything. Keep for safety ?
+        x = x.transpose(['vR*', 'p', 'vL*'])
+        x = x.iset_leg_labels(['vL', 'p', 'vR'])
+        h = x.combine_legs(['vL', 'p', 'vR'])
+        return h
+
+
+class H2_mixed:
+    """Class defining the two sites Hamiltonian for Lanczos
+
+    Parameters
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    W : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p0' leg of theta
+
+    Attributes
+    ----------
+    Lp : :class:`tenpy.linalg.np_conserved.Array`
+        left part of the environment
+    Rp : :class:`tenpy.linalg.np_conserved.Array`
+        right part of the environment
+    W0 : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p0' leg of theta
+    W1 : :class:`tenpy.linalg.np_conserved.Array`
+        MPO which is applied to the 'p1' leg of theta
+    """
+
+    def __init__(self, Lp, Rp, W0, W1):
+        self.Lp = Lp  # a,ap,m
+        self.Rp = Rp  # b,bp,n
+        self.H_MPO0 = W0  # m,n,i,ip
+        self.H_MPO1 = W1
+
+    def matvec(self, theta):
+        theta = theta.split_legs(['(vL.p0.p1.vR)'])
+        Lp = self.Lp
+        Rp = self.Rp
+        x = npc.tensordot(Lp, theta, axes=('vR', 'vL'))
+        x = npc.tensordot(x, self.H_MPO0, axes=(['p0', 'wR'], ['p*', 'wL']))
+        x.ireplace_label('p', 'p0')
+        x = npc.tensordot(x, self.H_MPO1, axes=(['p1', 'wR'], ['p*', 'wL']))
+        x.ireplace_label('p', 'p1')
+        x = npc.tensordot(x, Rp, axes=(['vR', 'wR'], ['vL', 'wL']))
+        x.ireplace_label('vL*', 'vR')
+        x.ireplace_label('vR*', 'vL')
+        h = x.combine_legs(['vL', 'p0', 'p1', 'vR'])
+        return h


### PR DESCRIPTION
tdmrg.py : 
tqdm : extra package for a nice waitbar. . Nice to be used anywhere there is a for loop you need to wait at. 
I commented out the backward-incompatible parts, which require Python 3.7 (namely @dataclass decorator). I've made many custom modules & examples with python 3.7, but only tdmrg.py was easy enough to fix. If you are willing to upgrade to python 3.7, then I can share all the others

tdvp1.py, tdvp2.py : 
Just modified tdvp.py into two separate files, so that I can choose different time-evol methods easily during tDMRG.
(i.e.,   tevol={tebd, tdvp1, tdvp2},  tevol.run() )
