### PR TITLE
bosonic Haldane model & FCI benchmark (+ issues #44, #65)

### DIFF
--- a/doc/literature.rst
+++ b/doc/literature.rst
@@ -6,20 +6,70 @@ They can be cited from the python doc-strings using the format ``[Author####]_``
 If you're looking for introductory notes, don't forget the 'official' [TeNPyNotes]_. The review by [Schollwoeck2011]_ is
 also a classic introduction.
 
+**General reading**
 
+.. Density matrix formulation for quantum renormalization groups
 .. [White1992] S. White, Phys. Rev. Lett. 69, 2863 (1992) :doi:`10.1103/PhysRevLett.69.2863`,
                S. White, Phys. Rev. B 84, 10345 (1992) :doi:`10.1103/PhysRevB.48.10345`
-.. [Resta1997] R. Rest, Phys. Rev. Lett. 80, 1800 (1997) :doi:`10.1103/PhysRevLett.80.1800`
-.. [Vidal2004] G. Vidal, Phys. Rev. Lett. 93, 040502 (2004), :arxiv:`quant-ph/0310089` :doi:`10.1103/PhysRevLett.93.040502`
-.. [White2005] S. White, Phys. Rev. B 72, 180403(R) (2005), :arxiv:`cond-mat/0508709` :doi:`10.1103/PhysRevB.72.180403`
-.. [Singh2009] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. A 82, 050301(R), :arxiv:`0907.2994` :doi:`10.1103/PhysRevA.82.050301`
-.. [Singh2010] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. B 83, 115125, :arxiv:`1008.4774` :doi:`10.1103/PhysRevB.83.115125`
-.. [Haegeman2011] J. Haegeman, J. I. Cirac, T. J. Osborne, I. Pizorn, H. Verschelde, F. Verstraete, Phys. Rev. Lett. 107, 070601 (2011), :arxiv:`1103.0936` :doi:`10.1103/PhysRevLett.107.070601`
+.. The density-matrix renormalization group
+.. [Schollwoeck2005] U. Schollwöck, Rev. Mod. Phys. 77, 259 (2005), :arxiv:`0409292` :doi:`10.1103/RevModPhys.77.259`
+.. Matrix Product States, Projected Entangled Pair States, and variational renormalization group methods for quantum spin systems
+.. [Verstraete2009] F. Verstraete  and  V. Murg  and  J.I. Cirac, Advances in Physics 57 2, 143-224 (2009) :arxiv:`0907.2796` :doi:`10.1080/14789940801912366`
+.. Renormalization and tensor product states in spin chains and lattices
+.. [Cirac2009]  J. I. Cirac and F. Verstraete, Journal of Physics A: Mathematical and Theoretical, 42, 50 (2009) :arxiv:`0910.1130` :doi:`10.1088/1751-8113/42/50/504004`
+.. The density-matrix renormalization group in the age of matrix product states
 .. [Schollwoeck2011] U. Schollwoeck, Annals of Physics 326, 96 (2011), :arxiv:`1008.3477` :doi:`10.1016/j.aop.2010.09.012`
-.. [PollmannTurner2012] F. Pollmann, A. Turner, Phys. Rev. B 86, 125441 (2012), :arxiv:`1204.0704` :doi:`10.1103/PhysRevB.86.125441`
+.. Characterizing Topological Order by Studying the Ground States on an Infinite Cylinder
 .. [CincioVidal2013] L. Cincio, G. Vidal, Phys. Rev. Lett. 110, 067208 (2013), :arxiv:`1208.2623` :doi:`10.1103/PhysRevLett.110.067208`
-.. [Karrasch2013] C. Karrasch, J. H. Bardarson, J. E. Moore, New J. Phys. 15, 083031 (2013), :arxiv:`1303.3942` :doi:`10.1088/1367-2630/15/8/083031`
+.. Entanglement and tensor network states
+.. [Eisert2013]  J. Eisert, Modeling and Simulation 3, 520 (2013) :arxiv:`1308.3318`
+.. A Practical Introduction to Tensor Networks: Matrix Product States and Projected Entangled Pair States
+.. [Orus2014]  R. Orus, Annals of Physics 349, 117-158 (2014) :arxiv:`1306.2164` :doi:`10.1016/j.aop.2014.06.013`
+
+**Related theory**
+
+.. Quantum-Mechanical Position Operator in Extended Systems
+.. [Resta1997] R. Resta, Phys. Rev. Lett. 80, 1800 (1997) :doi:`10.1103/PhysRevLett.80.1800`
+
+**Algorithm developments**
+
+.. Density matrix renormalization group algorithms with a single center site
+.. [White2005] S. White, Phys. Rev. B 72, 180403(R) (2005), :arxiv:`cond-mat/0508709` :doi:`10.1103/PhysRevB.72.180403`
+.. Tensor network decompositions in the presence of a global symmetry
+.. [Singh2009] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. A 82, 050301(R), :arxiv:`0907.2994` :doi:`10.1103/PhysRevA.82.050301`
+.. Tensor network states and algorithms in the presence of a global U(1) symmetry
+.. [Singh2010] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. B 83, 115125, :arxiv:`1008.4774` :doi:`10.1103/PhysRevB.83.115125`
+.. Strictly single-site DMRG algorithm with subspace expansion
 .. [Hubig2015] C. Hubig, I. P. McCulloch, U. Schollwoeck, F. A. Wolf, Phys. Rev. B 91, 155115 (2015), :arxiv:`1501.05504` :doi:`10.1103/PhysRevB.91.155115`
-.. [Haegeman2016] J. Haegeman, C. Lubich, I. Oseledets, B. Vandereycken, F. Verstraete, Phys. Rev. B 94, 165116 (2016), :arxiv:`1408.5056` :doi:`10.1103/PhysRevB.94.165116`
+.. Finding purifications with minimal entanglement
 .. [Hauschild2018] J. Hauschild, E. Leviatan, J. H. Bardarson, E. Altman, M. P. Zaletel, F. Pollmann, Phys. Rev. B 98, 235163 (2018), :arxiv:`1711.01288` :doi:`10.1103/PhysRevB.98.235163`
+
+**Time evolution**
+
+.. Time-Dependent Variational Principle for Quantum Lattices
+.. [Haegeman2011] J. Haegeman, J. I. Cirac, T. J. Osborne, I. Pizorn, H. Verschelde, F. Verstraete, Phys. Rev. Lett. 107, 070601 (2011), :arxiv:`1103.0936` :doi:`10.1103/PhysRevLett.107.070601`
+.. Unifying time evolution and optimization with matrix product states
+.. [Haegeman2016] J. Haegeman, C. Lubich, I. Oseledets, B. Vandereycken, F. Verstraete, Phys. Rev. B 94, 165116 (2016), :arxiv:`1408.5056` :doi:`10.1103/PhysRevB.94.165116`
+.. Time-evolution methods for matrix-product states
 .. [Hubig2019] S. Paeckel, T. Köhler, A. Swoboda, S. R. Manmana, U. Schollwöck, C. Hubig, :arxiv:`1901.05824`
+
+**Finite temperature**
+
+.. Reducing the numerical effort of finite-temperature density matrix renormalization group calculations
+.. [Karrasch2013] C. Karrasch, J. H. Bardarson, J. E. Moore, New J. Phys. 15, 083031 (2013), :arxiv:`1303.3942` :doi:`10.1088/1367-2630/15/8/083031`
+
+**One-dimensional systems**
+
+.. Efficient Simulation of One-Dimensional Quantum Many-Body Systems
+.. [Vidal2004] G. Vidal, Phys. Rev. Lett. 93, 040502 (2004), :arxiv:`quant-ph/0310089` :doi:`10.1103/PhysRevLett.93.040502`
+.. Detection of symmetry-protected topological phases in one dimension
+.. [PollmannTurner2012] F. Pollmann, A. Turner, Phys. Rev. B 86, 125441 (2012), :arxiv:`1204.0704` :doi:`10.1103/PhysRevB.86.125441`
+
+**Two-dimensional systems**
+
+.. Fractional quantum Hall states at zero magnetic field
+.. [Neupert2011] Titus Neupert, Luiz Santos, Claudio Chamon, and Christopher Mudry, Phys. Rev. Lett. 106, 236804 (2011), :arxiv:`1012.4723` :doi:`10.1103/PhysRevLett.106.236804`
+.. Topological flat band models with arbitrary Chern numbers
+.. [Yang2012] Shuo Yang, Zheng-Cheng Gu, Kai Sun, and S. Das Sarma, Phys. Rev. B 86, 241112(R) (2012), :arxiv:`1205.5792`, :doi:`10.1103/PhysRevB.86.241112`
+.. Characterization and stability of a fermionic ν=1/3 fractional Chern insulator
+.. [Grushin2015] Adolfo G. Grushin, Johannes Motruk, Michael P. Zaletel, and Frank Pollmann, Phys. Rev. B 91, 035136 (2015), :arxiv:`1407.6985` :doi:`10.1103/PhysRevB.91.035136`

--- a/doc/literature.rst
+++ b/doc/literature.rst
@@ -7,19 +7,19 @@ If you're looking for introductory notes, don't forget the 'official' [TeNPyNote
 also a classic introduction.
 
 
-.. [White1992] S. White, Phys. Rev. Lett. 69, 2863 (1992),
-               S. White, Phys. Rev. B 84, 10345 (1992)
-.. [Resta1997] R. Rest, Phys. Rev. Lett. 80, 1800 (1997)
-.. [Vidal2004] G. Vidal, Phys. Rev. Lett. 93, 040502 (2004), :arxiv:`quant-ph/0310089`
-.. [White2005] S. White, Phys. Rev. B 72, 180403(R) (2005), :arxiv:`cond-mat/0508709`
-.. [Singh2009] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. A 82, 050301(R), :arxiv:`0907.2994`
-.. [Singh2010] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. B 83, 115125, :arxiv:`1008.4774`
-.. [Haegeman2011] J. Haegeman, J. I. Cirac, T. J. Osborne, I. Pizorn, H. Verschelde, F. Verstraete, Phys. Rev. Lett. 107, 070601 (2011), :arxiv:`1103.0936`
-.. [Schollwoeck2011] U. Schollwoeck, Annals of Physics 326, 96 (2011), :arxiv:`1008.3477`
-.. [PollmannTurner2012] F. Pollmann, A. Turner, Phys. Rev. B 86, 125441 (2012), :arxiv:`1204.0704`
-.. [CincioVidal2013] L. Cincio, G. Vidal, Phys. Rev. Lett. 110, 067208 (2013), :arxiv:`1208.2623`
-.. [Karrasch2013] C. Karrasch, J. H. Bardarson, J. E. Moore, New J. Phys. 15, 083031 (2013), :arxiv:`1303.3942`
-.. [Hubig2015] C. Hubig, I. P. McCulloch, U. Schollwoeck, F. A. Wolf, Phys. Rev. B 91, 155115 (2015), :arxiv:`1501.05504`
-.. [Haegeman2016] J. Haegeman, C. Lubich, I. Oseledets, B. Vandereycken, F. Verstraete, Phys. Rev. B 94, 165116 (2016), :arxiv:`1408.5056`
-.. [Hauschild2018] J. Hauschild, E. Leviatan, J. H. Bardarson, E. Altman, M. P. Zaletel, F. Pollmann, Phys. Rev. B 98, 235163 (2018), :arxiv:`1711.01288`
+.. [White1992] S. White, Phys. Rev. Lett. 69, 2863 (1992) :doi:`10.1103/PhysRevLett.69.2863`,
+               S. White, Phys. Rev. B 84, 10345 (1992) :doi:`10.1103/PhysRevB.48.10345`
+.. [Resta1997] R. Rest, Phys. Rev. Lett. 80, 1800 (1997) :doi:`10.1103/PhysRevLett.80.1800`
+.. [Vidal2004] G. Vidal, Phys. Rev. Lett. 93, 040502 (2004), :arxiv:`quant-ph/0310089` :doi:`10.1103/PhysRevLett.93.040502`
+.. [White2005] S. White, Phys. Rev. B 72, 180403(R) (2005), :arxiv:`cond-mat/0508709` :doi:`10.1103/PhysRevB.72.180403`
+.. [Singh2009] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. A 82, 050301(R), :arxiv:`0907.2994` :doi:`10.1103/PhysRevA.82.050301`
+.. [Singh2010] S. Singh, R. Pfeifer, G. Vidal, Phys. Rev. B 83, 115125, :arxiv:`1008.4774` :doi:`10.1103/PhysRevB.83.115125`
+.. [Haegeman2011] J. Haegeman, J. I. Cirac, T. J. Osborne, I. Pizorn, H. Verschelde, F. Verstraete, Phys. Rev. Lett. 107, 070601 (2011), :arxiv:`1103.0936` :doi:`10.1103/PhysRevLett.107.070601`
+.. [Schollwoeck2011] U. Schollwoeck, Annals of Physics 326, 96 (2011), :arxiv:`1008.3477` :doi:`10.1016/j.aop.2010.09.012`
+.. [PollmannTurner2012] F. Pollmann, A. Turner, Phys. Rev. B 86, 125441 (2012), :arxiv:`1204.0704` :doi:`10.1103/PhysRevB.86.125441`
+.. [CincioVidal2013] L. Cincio, G. Vidal, Phys. Rev. Lett. 110, 067208 (2013), :arxiv:`1208.2623` :doi:`10.1103/PhysRevLett.110.067208`
+.. [Karrasch2013] C. Karrasch, J. H. Bardarson, J. E. Moore, New J. Phys. 15, 083031 (2013), :arxiv:`1303.3942` :doi:`10.1088/1367-2630/15/8/083031`
+.. [Hubig2015] C. Hubig, I. P. McCulloch, U. Schollwoeck, F. A. Wolf, Phys. Rev. B 91, 155115 (2015), :arxiv:`1501.05504` :doi:`10.1103/PhysRevB.91.155115`
+.. [Haegeman2016] J. Haegeman, C. Lubich, I. Oseledets, B. Vandereycken, F. Verstraete, Phys. Rev. B 94, 165116 (2016), :arxiv:`1408.5056` :doi:`10.1103/PhysRevB.94.165116`
+.. [Hauschild2018] J. Hauschild, E. Leviatan, J. H. Bardarson, E. Altman, M. P. Zaletel, F. Pollmann, Phys. Rev. B 98, 235163 (2018), :arxiv:`1711.01288` :doi:`10.1103/PhysRevB.98.235163`
 .. [Hubig2019] S. Paeckel, T. Köhler, A. Swoboda, S. R. Manmana, U. Schollwöck, C. Hubig, :arxiv:`1901.05824`

--- a/doc/literature.rst
+++ b/doc/literature.rst
@@ -30,6 +30,8 @@ also a classic introduction.
 
 .. Quantum-Mechanical Position Operator in Extended Systems
 .. [Resta1997] R. Resta, Phys. Rev. Lett. 80, 1800 (1997) :doi:`10.1103/PhysRevLett.80.1800`
+.. Condensed Matter Applications of Entanglement Theory
+.. [Schuch2013] N. Schuch, Quantum Information Processing. Lecture Notes of the 44th IFF Spring School (2013) :arxiv:`1306.5551`
 
 **Algorithm developments**
 

--- a/examples/chern_insulators/chiral_pi_flux.py
+++ b/examples/chern_insulators/chiral_pi_flux.py
@@ -1,6 +1,6 @@
 """Chiral pi flux model - Chern insulator example
 
-Based on the model in :arxiv:`1012.4723`
+Based on the model in [Neupert2011]_
 """
 
 # Copyright 2019 TeNPy Developers

--- a/examples/chern_insulators/haldane.py
+++ b/examples/chern_insulators/haldane.py
@@ -1,6 +1,6 @@
 """Spinless fermion Haldane model - Chern insulator example
 
-Reproduces Fig. 2.a,b) in :arxiv:`1407.6985`
+Reproduces Fig. 2.a,b) in [Grushin2015]_
 """
 
 # Copyright 2019 TeNPy Developers

--- a/examples/chern_insulators/haldane.py
+++ b/examples/chern_insulators/haldane.py
@@ -20,12 +20,12 @@ def plot_model(model_params, phi_ext=0.1):
     plt.figure()
     ax = plt.gca()
     M.lat.plot_sites(ax)
-    M.coupling_terms['t Cd_i C_j'].plot_coupling_terms(ax, M.lat)
+    M.coupling_terms['t1 Cd_i C_j'].plot_coupling_terms(ax, M.lat)
     M.coupling_terms['t2 Cd_i C_j'].plot_coupling_terms(ax,
                                                         M.lat,
                                                         text='{op_j!s} {strength_angle:.2f}',
                                                         text_pos=0.9)
-    print(M.coupling_terms['t Cd_i C_j'].to_TermList())
+    print(M.coupling_terms['t1 Cd_i C_j'].to_TermList())
     ax.set_aspect(1.)
     plt.show()
 
@@ -142,6 +142,6 @@ if __name__ == "__main__":
                         bc_y='cylinder',
                         verbose=0)
 
-    # plot_model(model_params)
-    data = run(model_params)
-    plot_results(data)
+    plot_model(model_params)
+    # data = run(model_params)
+    # plot_results(data)

--- a/examples/chern_insulators/haldane_C3.py
+++ b/examples/chern_insulators/haldane_C3.py
@@ -1,6 +1,6 @@
 """Generalized (C=3) Haldane model - Chern insulator example
 
-Based on the model in :arxiv:`1205.5792`
+Based on the model in [Yang2012]_
 """
 
 # Copyright 2019 TeNPy Developers

--- a/examples/chern_insulators/haldane_FCI.py
+++ b/examples/chern_insulators/haldane_FCI.py
@@ -31,7 +31,7 @@ def plot_model(model_params, phi_ext=0.1):
     plt.show()
 
 
-def run(model_params, phi_ext=np.linspace(0, 2.0, 9)):
+def run(model_params, phi_ext=np.linspace(0, 2.0, 7)):
 
     data = dict(phi_ext=phi_ext, QL=[], ent_spectrum=[])
 
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     t2_value = (np.sqrt(129)/36) * t1_value * np.exp(1j * phi)  # optimal band flatness
 
     model_params = dict(conserve='N', t1=t1_value, t2=t2_value, mu=0, V=0, bc_MPS='infinite',
-                        order='default', Lx=1, Ly=6, bc_y='cylinder', verbose=0)
+                        order='default', Lx=1, Ly=4, bc_y='cylinder', verbose=0)
 
     # plot_model(model_params)
     data = run(model_params)

--- a/examples/chern_insulators/haldane_FCI.py
+++ b/examples/chern_insulators/haldane_FCI.py
@@ -1,6 +1,9 @@
-"""Spinless fermion Haldane model - Chern insulator example
+"""Hardcore boson Haldane model - minimal FCI example
 
-Reproduces Fig. 2.a,b) in :arxiv:`1407.6985`
+Based on Eq.1 of :arxiv:`1407.6985` with:
+- bosons instead of fermions
+- mu=0, V=0 (only infinite onsite repulsion, via hardcore constraint)
+- 1/2 filling of the lowest band (i.e. 1/4 total filling with hardcoded minimal unit cell)
 """
 
 # Copyright 2019 TeNPy Developers
@@ -9,28 +12,25 @@ import numpy as np
 
 from tenpy.algorithms import dmrg
 from tenpy.networks.mps import MPS
-from tenpy.models.haldane import FermionicHaldaneModel
+from tenpy.models.haldane import BosonicHaldaneModel
 
 
 def plot_model(model_params, phi_ext=0.1):
 
     model_params['phi_ext'] = phi_ext
-    M = FermionicHaldaneModel(model_params)
+    M = BosonicHaldaneModel(model_params)
     import matplotlib.pyplot as plt
     plt.figure()
     ax = plt.gca()
     M.lat.plot_sites(ax)
-    M.coupling_terms['t1 Cd_i C_j'].plot_coupling_terms(ax, M.lat)
-    M.coupling_terms['t2 Cd_i C_j'].plot_coupling_terms(ax,
-                                                        M.lat,
-                                                        text='{op_j!s} {strength_angle:.2f}',
-                                                        text_pos=0.9)
-    print(M.coupling_terms['t1 Cd_i C_j'].to_TermList())
+    M.coupling_terms['t1 Bd_i B_j'].plot_coupling_terms(ax, M.lat)
+    M.coupling_terms['t2 Bd_i B_j'].plot_coupling_terms(ax, M.lat, text='{op_j!s} {strength_angle:.2f}', text_pos=0.9)
+    print(M.coupling_terms['t1 Bd_i B_j'].to_TermList())
     ax.set_aspect(1.)
     plt.show()
 
 
-def run(model_params, phi_ext=np.linspace(0, 1.0, 7)):
+def run(model_params, phi_ext=np.linspace(0, 2.0, 9)):
 
     data = dict(phi_ext=phi_ext, QL=[], ent_spectrum=[])
 
@@ -48,18 +48,14 @@ def run(model_params, phi_ext=np.linspace(0, 1.0, 7)):
             'N_min': 5,
             'N_max': 20
         },
-        'chi_list': {
-            0: 9,
-            10: 49,
-            20: 100
-        },
+        'chi_list': {0: 9, 10: 49, 20: 100},
         'max_E_err': 1.e-10,
         'max_S_err': 1.e-6,
         'max_sweeps': 150,
         'verbose': 1.,
     }
 
-    prod_state = ['empty', 'full'] * (model_params['Lx'] * model_params['Ly'])
+    prod_state = [1, 0, 0, 0, 1, 0, 0, 0]
 
     eng = None
 
@@ -71,12 +67,12 @@ def run(model_params, phi_ext=np.linspace(0, 1.0, 7)):
         model_params['phi_ext'] = phi
 
         if eng is None:  # first time in the loop
-            M = FermionicHaldaneModel(model_params)
+            M = BosonicHaldaneModel(model_params)
             psi = MPS.from_product_state(M.lat.mps_sites(), prod_state, bc=M.lat.bc_MPS)
             eng = dmrg.EngineCombine(psi, M, dmrg_params)
         else:
             del eng.DMRG_params['chi_list']
-            M = FermionicHaldaneModel(model_params)
+            M = BosonicHaldaneModel(model_params)
             eng.init_env(model=M)
 
         E, psi = eng.run()
@@ -96,7 +92,7 @@ def plot_results(data):
     ax.plot(data['phi_ext'], data['QL'], marker='o')
     ax.set_xlabel(r"$\Phi_y / 2 \pi$")
     ax.set_ylabel(r"$ \langle Q^L(\Phi_y) \rangle$")
-    plt.savefig("haldane_charge_pump.pdf")
+    plt.savefig("haldane_FCI_charge_pump.pdf")
 
     plt.figure()
     ax = plt.gca()
@@ -110,17 +106,12 @@ def plot_results(data):
                 label = "{q:d}".format(q=q)
                 color_by_charge[q] = colors[len(color_by_charge) % len(colors)]
             color = color_by_charge[q]
-            ax.plot(phi_ext * np.ones(s.shape),
-                    s,
-                    linestyle='',
-                    marker='_',
-                    color=color,
-                    label=label)
+            ax.plot(phi_ext * np.ones(s.shape), s, linestyle='', marker='_', color=color, label=label)
     ax.set_xlabel(r"$\Phi_y / 2 \pi$")
     ax.set_ylabel(r"$ \epsilon_\alpha $")
     ax.set_ylim(0., 8.)
     ax.legend(loc='upper right')
-    plt.savefig("haldane_ent_spec_flow.pdf")
+    plt.savefig("haldane_FCI_ent_spec_flow.pdf")
 
 
 if __name__ == "__main__":
@@ -128,20 +119,11 @@ if __name__ == "__main__":
     t1_value = -1
 
     phi = np.arccos(3 * np.sqrt(3 / 43))
-    t2_value = (np.sqrt(129) / 36) * t1_value * np.exp(1j * phi)  # optimal band flatness
+    t2_value = (np.sqrt(129)/36) * t1_value * np.exp(1j * phi)  # optimal band flatness
 
-    model_params = dict(conserve='N',
-                        t1=t1_value,
-                        t2=t2_value,
-                        mu=0,
-                        V=0,
-                        bc_MPS='infinite',
-                        order='default',
-                        Lx=1,
-                        Ly=3,
-                        bc_y='cylinder',
-                        verbose=0)
+    model_params = dict(conserve='N', t1=t1_value, t2=t2_value, mu=0, V=0, bc_MPS='infinite',
+                        order='default', bc_y='cylinder', verbose=0)
 
-    plot_model(model_params)
-    # data = run(model_params)
-    # plot_results(data)
+    # plot_model(model_params)
+    data = run(model_params)
+    plot_results(data)

--- a/examples/chern_insulators/haldane_FCI.py
+++ b/examples/chern_insulators/haldane_FCI.py
@@ -1,14 +1,15 @@
 """Hardcore boson Haldane model - minimal FCI example
 
-Based on Eq.1 of :arxiv:`1407.6985` with:
+Based on Eq.1 of [Grushin2015]_ with:
 - bosons instead of fermions
 - mu=0, V=0 (only infinite onsite repulsion, via hardcore constraint)
-- 1/2 filling of the lowest band (i.e. 1/4 total filling with hardcoded minimal unit cell)
+- 1/2 filling of the lowest band (i.e. 1/4 total filling)
 """
 
 # Copyright 2019 TeNPy Developers
 
 import numpy as np
+import warnings
 
 from tenpy.algorithms import dmrg
 from tenpy.networks.mps import MPS
@@ -55,7 +56,16 @@ def run(model_params, phi_ext=np.linspace(0, 2.0, 9)):
         'verbose': 1.,
     }
 
-    prod_state = [1, 0, 0, 0, 1, 0, 0, 0]
+    prod_state = [1]
+    if 2 * model_params['Lx'] * model_params['Ly'] % 4 != 0:
+        warnings.warn("Total filling factor = 1/4 cannot be achieved with this unit cell geometry.")
+    for i in range(1, 2 * model_params['Lx'] * model_params['Ly']):
+        if i % 4 == 0:
+            prod_state.append(1)
+        else:
+            prod_state.append(0)
+
+    print(prod_state)
 
     eng = None
 
@@ -122,7 +132,7 @@ if __name__ == "__main__":
     t2_value = (np.sqrt(129)/36) * t1_value * np.exp(1j * phi)  # optimal band flatness
 
     model_params = dict(conserve='N', t1=t1_value, t2=t2_value, mu=0, V=0, bc_MPS='infinite',
-                        order='default', bc_y='cylinder', verbose=0)
+                        order='default', Lx=1, Ly=6, bc_y='cylinder', verbose=0)
 
     # plot_model(model_params)
     data = run(model_params)

--- a/tenpy/algorithms/exact_diag.py
+++ b/tenpy/algorithms/exact_diag.py
@@ -21,6 +21,10 @@ import warnings
 from ..linalg import np_conserved as npc
 from ..networks.mps import MPS
 
+__all__ = [
+    'ExactDiag'
+]
+
 
 class ExactDiag:
     """(Full) exact diagonalization of the Hamiltonian.

--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -26,6 +26,10 @@ from tenpy.tools.params import get_parameter
 from tenpy.linalg.lanczos import LanczosEvolution
 from tenpy.algorithms.truncation import svd_theta
 
+__all__ = [
+    'Engine', 'H0_mixed', 'H1_mixed', 'H2_mixed'
+]
+
 
 class Engine:
     """Time dependant variational principle 'Engine'

--- a/tenpy/linalg/sparse.py
+++ b/tenpy/linalg/sparse.py
@@ -13,6 +13,10 @@ import numpy as np
 from . import np_conserved as npc
 from scipy.sparse.linalg import LinearOperator as ScipyLinearOperator
 
+__all__ = [
+    'NpcLinearOperator', 'FlatLinearOperator', 'FlatHermitianOperator'
+]
+
 
 class NpcLinearOperator:
     """Prototype for a Linear Operator acting on :class:`~tenpy.linalg.np_conserved.Array`.

--- a/tenpy/linalg/svd_robust.py
+++ b/tenpy/linalg/svd_robust.py
@@ -73,6 +73,10 @@ except TypeError:
 #: will be the the CLAPACK library loaded with _load_lapack()
 _lapack_lib = None
 
+__all__ = [
+    'svd', 'svd_gesvd'
+]
+
 
 def svd(a,
         full_matrices=True,

--- a/tenpy/models/haldane.py
+++ b/tenpy/models/haldane.py
@@ -27,8 +27,7 @@ class BosonicHaldaneModel(CouplingMPOModel):
     :math:`t_{\langle ij \rangle}=t_1 \in \mathbb{R}` and
     :math:`t_{\langle\langle ij \rangle\rangle}=t_2 e^{\pm\mathrm{i}\phi} \in \mathbb{C}` respectively, where
     :math:`\pm\phi` is the phase acquired by a boson hopping between atoms in the same sublattice with a sign
-    given by the direction of the hopping. This Hamiltonian is translated from "Characterization and stability
-    of a fermionic :math:`\nu=1/3` fractional Chern insulator", :arxiv:`1407.6985`.
+    given by the direction of the hopping. This Hamiltonian is translated from [Grushin2015]_.
     All parameters are collected in a single dictionary `model_params` and read out with
     :func:`~tenpy.tools.params.get_parameter`.
 
@@ -123,8 +122,7 @@ class FermionicHaldaneModel(CouplingMPOModel):
     :math:`t_{\langle ij \rangle}=t_1 \in \mathbb{R}` and
     :math:`t_{\langle\langle ij \rangle\rangle}=t_2 e^{\pm\mathrm{i}\phi} \in \mathbb{C}` respectively, where
     :math:`\pm\phi` is the phase acquired by an electron hopping between atoms in the same sublattice with a sign
-    given by the direction of the hopping. This Hamiltonian is described in "Characterization and stability
-    of a fermionic :math:`\nu=1/3` fractional Chern insulator", :arxiv:`1407.6985`.
+    given by the direction of the hopping. This Hamiltonian is described in [Grushin2015]_.
     All parameters are collected in a single dictionary `model_params` and read out with
     :func:`~tenpy.tools.params.get_parameter`.
 

--- a/tenpy/models/haldane.py
+++ b/tenpy/models/haldane.py
@@ -1,15 +1,111 @@
-"""Spinless fermionic Haldane model.
+"""Bosonic and fermionic Haldane models.
 
-Hamiltonian based on: "Characterization and stability of a fermionic nu=1/3 fractional Chern insulator",
-:arxiv:`1407.6985`."""
-
+"""
 # Copyright 2019 TeNPy Developers
 
 import numpy as np
 
 from tenpy.models.model import CouplingMPOModel
 from tenpy.tools.params import get_parameter
-from tenpy.networks.site import FermionSite
+from tenpy.networks.site import BosonSite, FermionSite
+
+__all__ = ['BosonicHaldaneModel', 'FermionicHaldaneModel']
+
+
+class BosonicHaldaneModel(CouplingMPOModel):
+    r"""Hardcore bosonic Haldane model.
+
+    The Hamiltonian reads:
+
+    .. math ::
+        H = \sum_{ij} t_{ij} b_i^\dagger b_j + \sum_i \mu (n_{A, i} - n_{B, i})
+        + V \sum_{\langle ij \rangle, i<j} n_{A, i} n_{B, j}
+
+
+    Here, :math:`\langle i,j \rangle, i< j` denotes nearest neighbor pairs and :math:`n_A, n_B` are the number operators
+    on the A and B sites. Hopping is allowed to nearest and next-nearest neighbor sites with amplitudes
+    :math:`t_{\langle ij \rangle}=t_1 \in \mathbb{R}` and
+    :math:`t_{\langle\langle ij \rangle\rangle}=t_2 e^{\pm\mathrm{i}\phi} \in \mathbb{C}` respectively, where
+    :math:`\pm\phi` is the phase acquired by a boson hopping between atoms in the same sublattice with a sign
+    given by the direction of the hopping. This Hamiltonian is translated from "Characterization and stability
+    of a fermionic :math:`\nu=1/3` fractional Chern insulator", :arxiv:`1407.6985`.
+    All parameters are collected in a single dictionary `model_params` and read out with
+    :func:`~tenpy.tools.params.get_parameter`.
+
+    Parameters
+    ----------
+    conserve : 'best' | 'N' | 'parity' | None
+        What should be conserved. See :class:`~tenpy.networks.Site.BosonSite`.
+        For ``'best'``, we check the parameters that can be preserved.
+    t1, t2, V, mu : float | array
+        Hopping, interaction and chemical potential as defined for the Hamiltonian above.
+        The default value for t2 is chosen to achieve the optimal band flatness ratio.
+    bc_MPS : {'finite' | 'infinte'}
+        MPS boundary conditions along the x-direction.
+        For 'infinite' boundary conditions, repeat the unit cell in x-direction.
+        Coupling boundary conditions in x-direction are chosen accordingly.
+        Only used if `lattice` is a string.
+    order : string
+        Ordering of the sites in the MPS, e.g. 'default', 'snake';
+        see :meth:`~tenpy.models.lattice.Lattice.ordering`.
+        Only used if `lattice` is a string.
+    L : int
+        Lenght of the lattice.
+        Only used if `lattice` is the name of a 1D Lattice.
+    Lx, Ly : int
+        Length of the lattice in x- and y-direction.
+        Only used if `lattice` is the name of a 2D Lattice.
+    bc_y : 'ladder' | 'cylinder'
+        Boundary conditions in y-direction.
+        Only used if `lattice` is the name of a 2D Lattice.
+    """
+
+    def __init__(self, model_params):
+        model_params.setdefault('lattice', 'Honeycomb')
+        CouplingMPOModel.__init__(self, model_params)
+
+    def init_sites(self, model_params):
+        conserve = get_parameter(model_params, 'conserve', 'N', self.name)
+        site = BosonSite(conserve=conserve)
+        return site
+
+    def init_terms(self, model_params):
+        t1 = get_parameter(model_params, 't1', -1., self.name, True)
+        t2 = get_parameter(model_params, 't2',
+                           (np.sqrt(129) / 36) * t1 * np.exp(1j * np.arccos(3 * np.sqrt(3 / 43))),
+                           self.name, True)
+        V = get_parameter(model_params, 'V', 0, self.name, True)
+        mu = get_parameter(model_params, 'mu', 0., self.name, True)
+        phi_ext = 2 * np.pi * get_parameter(model_params, 'phi_ext', 0., self.name)
+
+        for u in range(len(self.lat.unit_cell)):
+            self.add_onsite(mu, 0, 'N', category='mu N')
+            self.add_onsite(-mu, 1, 'N', category='mu N')
+
+        for u1, u2, dx in self.lat.nearest_neighbors:
+            t1_phi = self.coupling_strength_add_ext_flux(t1, dx, [0, phi_ext])
+            self.add_coupling(t1_phi, u1, 'Bd', u2, 'B', dx, category='t1 Bd_i B_j')
+            self.add_coupling(np.conj(t1_phi),
+                              u2,
+                              'Bd',
+                              u1,
+                              'B',
+                              -dx,
+                              category='t1 Bd_i B_j h.c.')  # h.c.
+            self.add_coupling(V, u1, 'N', u2, 'N', dx, category='V N_i N_j')
+
+        for u1, u2, dx in [(0, 0, np.array([-1, 1])), (0, 0, np.array([1, 0])),
+                           (0, 0, np.array([0, -1])), (1, 1, np.array([0, 1])),
+                           (1, 1, np.array([1, -1])), (1, 1, np.array([-1, 0]))]:
+            t2_phi = self.coupling_strength_add_ext_flux(t2, dx, [0, phi_ext])
+            self.add_coupling(t2_phi, u1, 'Bd', u2, 'B', dx, category='t2 Bd_i B_j')
+            self.add_coupling(np.conj(t2_phi),
+                              u2,
+                              'Bd',
+                              u1,
+                              'B',
+                              -dx,
+                              category='t2 Bd_i B_j h.c.')  # h.c.
 
 
 class FermionicHaldaneModel(CouplingMPOModel):
@@ -65,18 +161,15 @@ class FermionicHaldaneModel(CouplingMPOModel):
     """
 
     def __init__(self, model_params):
-
         model_params.setdefault('lattice', 'Honeycomb')
         CouplingMPOModel.__init__(self, model_params)
 
     def init_sites(self, model_params):
-
         conserve = get_parameter(model_params, 'conserve', 'N', self.name)
         site = FermionSite(conserve=conserve)
         return site
 
     def init_terms(self, model_params):
-
         t1 = get_parameter(model_params, 't1', -1., self.name, True)
         t2 = get_parameter(model_params, 't2',
                            (np.sqrt(129) / 36) * t1 * np.exp(1j * np.arccos(3 * np.sqrt(3 / 43))),

--- a/tenpy/models/lattice.py
+++ b/tenpy/models/lattice.py
@@ -19,8 +19,8 @@ from ..tools.misc import to_iterable, inverse_permutation
 from ..networks.mps import MPS  # only to check boundary conditions
 
 __all__ = [
-    'Lattice', 'SimpleLattice', 'Chain', 'Ladder', 'Square', 'Triangular', 'Honeycomb', 'Kagome',
-    'get_lattice', 'get_order', 'get_order_grouped', 'bc_choices'
+    'Lattice', 'TrivialLattice', 'IrregularLattice', 'SimpleLattice', 'Chain', 'Ladder', 'Square', 'Triangular',
+    'Honeycomb', 'Kagome', 'get_lattice', 'get_order', 'get_order_grouped'
 ]
 
 # (update module doc string if you add further lattices)

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -87,7 +87,7 @@ from ..tools.misc import to_iterable, argsort
 from ..tools.math import lcm, speigs, entropy
 from ..algorithms.truncation import TruncationError, svd_theta
 
-__all__ = ['MPS', 'MPSEnvironment', 'TransferMatrix']
+__all__ = ['MPS', 'MPSEnvironment', 'TransferMatrix', 'build_initial_state']
 
 
 class MPS:

--- a/tenpy/tools/math.py
+++ b/tenpy/tools/math.py
@@ -11,6 +11,10 @@ from scipy.sparse.linalg import eigs as sparse_eigen
 int_I3 = np.eye(3, dtype=int)
 LeviCivita3 = np.array([[np.cross(b, a) for a in int_I3] for b in int_I3])
 
+__all__ = [
+    'matvec_to_array', 'entropy', 'gcd', 'gcd_array', 'lcm', 'speigs', 'perm_sign', 'qr_li', 'rq_li'
+]
+
 
 def matvec_to_array(H):
     """transform an linear operator with a `matvec` method into a dense numpy array.

--- a/tenpy/tools/misc.py
+++ b/tenpy/tools/misc.py
@@ -9,7 +9,7 @@ import itertools
 import argparse
 import warnings
 
-all = [
+__all__ = [
     'to_iterable', 'to_array', 'anynan', 'argsort', 'inverse_permutation', 'list_to_dict_list',
     'atleast_2d_pad', 'transpose_list_list', 'zero_if_close', 'pad', 'any_nonzero'
 ]

--- a/tenpy/tools/optimization.py
+++ b/tenpy/tools/optimization.py
@@ -69,7 +69,7 @@ from enum import IntEnum
 import warnings
 import os
 
-all = [
+__all__ = [
     'bottleneck', 'OptimizationFlag', 'temporary_level', 'set_level', 'get_level', 'optimize',
     'use_cython', 'have_cython_functions'
 ]

--- a/tenpy/tools/string.py
+++ b/tenpy/tools/string.py
@@ -2,6 +2,10 @@
 
 # Copyright 2018 TeNPy Developers
 
+__all__ = [
+    'is_non_string_iterable', 'vert_join', 'to_mathematica_lists'
+]
+
 
 def is_non_string_iterable(x):
     """Check if x is a non-string iterable, (e.g., list, tuple, dictionary, np.ndarray)"""


### PR DESCRIPTION
Hi Johannes,

I have made the following changes that may be helpful:

- fixed typo from my previous pull request (to make the plot couplings work for the haldane CI example)
- added bosonic Haldane model to haldane.py
- added bosonic Haldane FCI benchmark example. This coincidentally gives the correct FCI charge pumping with the current parameters (you can try it to see that one charge quantum is pumped after 4*pi flux insertion, which characterizes a 1/2 filled bosonic FCI), however it is not working at higher chi for example, or larger MPS unit cells... I think it is nevertheless useful as a benchmark because it is one of the simplest/cheapest FCI examples that should definitely work, and this example does show some signs of working. It could be useful in debugging the convergence issue with the DMRG engine.
- Literature list #65 (I am not sure if my rst comments are good practice - we can remove them if not)
- add missing __all__ #44 (checked recursively in the tenpy directory only)

All the best

Bart