### PR TITLE
Union operators for Config

### DIFF
--- a/tenpy/tools/params.py
+++ b/tenpy/tools/params.py
@@ -210,6 +210,10 @@ class Config(MutableMapping):
     def __del__(self):
         self.warn_unused()
 
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
     def warn_unused(self, recursive=False):
         """Warn about (so far) unused options.
 


### PR DESCRIPTION
The library now supports Python 3.9, which includes [PEP 584](https://www.python.org/dev/peps/pep-0584/). Therefore, I see no compelling reason for `Config` not to support the `|=` operator (see below for a comment on `|`). This is not defined by `collections.abc.MutableMapping`, hence the manual implementation which is simply a `self.update` call.

As discussed below, the proposed implementation is meant to be used for updating a `Config` with another mapping, but not another `Config`. This is also the reason why `|` is not implemented in this PR. 

Currently, by doing `configA |= configB`, configB's `unused` options are lost and its `name` is ignored. One could merge names and keep track of the (un)used options of the RHS, but I wonder whether this use case should actually be discouraged. Indeed, I would expect a program to have a unique `Config` instance for a given set of options; when that is not the case, the information on unused parameters will no longer be unique, regardless of the implementation.