### PR TITLE
TDVP rewrite

### DIFF
--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -31,8 +31,8 @@ import time
 import warnings
 import copy
 import logging
-logger = logging.getLogger(__name__)
 
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'Sweep',
@@ -117,7 +117,6 @@ class Sweep(Algorithm):
         A dictionary to gradually increase the `chi_max` parameter of `trunc_params`.
         See :cfg:option:`Sweep.chi_list`
     """
-
     def __init__(self, psi, model, options, *, orthogonal_to=None, **kwargs):
         if not hasattr(self, "EffectiveH"):
             raise NotImplementedError("Subclass needs to set EffectiveH")
@@ -138,8 +137,7 @@ class Sweep(Algorithm):
 
     @property
     def engine_params(self):
-        warnings.warn("renamed self.engine_params -> self.options",
-                      FutureWarning, stacklevel=2)
+        warnings.warn("renamed self.engine_params -> self.options", FutureWarning, stacklevel=2)
         return self.options
 
     @property
@@ -229,8 +227,7 @@ class Sweep(Algorithm):
         if resume_data is None:
             resume_data = {}
         if 'init_env_data' in self.options:
-            warnings.warn(
-                "put init_env_data in resume_data instead of options!", FutureWarning)
+            warnings.warn("put init_env_data in resume_data instead of options!", FutureWarning)
             resume_data.setdefault('init_env_data', self.options['init_env_data'])
         init_env_data = {}
         if self.env is not None and self.psi.bc != 'finite':
@@ -275,8 +272,7 @@ class Sweep(Algorithm):
 
         if orthogonal_to:
             if not self.finite:
-                raise ValueError(
-                    "Can't orthogonalize for infinite MPS: overlap not well defined.")
+                raise ValueError("Can't orthogonalize for infinite MPS: overlap not well defined.")
             logger.info("got %d states to orthogonalize against", len(orthogonal_to))
             self.ortho_to_envs = []
             for i, ortho in enumerate(orthogonal_to):
@@ -667,8 +663,7 @@ class EffectiveH(NpcLinearOperator):
     acts_on = None
 
     def __init__(self, env, i0, combine=False, move_right=True):
-        raise NotImplementedError(
-            "This function should be implemented in derived classes")
+        raise NotImplementedError("This function should be implemented in derived classes")
 
     def combine_theta(self, theta):
         """Combine the legs of `theta`, such that it fits to how we combined the legs of `self`.
@@ -683,8 +678,7 @@ class EffectiveH(NpcLinearOperator):
         theta : :class:`~tenpy.linalg.np_conserved.Array`
             Wave function with labels as given by `self.acts_on`.
         """
-        raise NotImplementedError(
-            "This function should be implemented in derived classes")
+        raise NotImplementedError("This function should be implemented in derived classes")
 
     def update_LP(self, env, i, U=None):
         """Equivalent to ``env.get_LP(i, store=True)``; optimized for `combine`.
@@ -870,8 +864,7 @@ class OneSiteH(EffectiveH):
         else:
             contr = npc.tensordot(self.LP, self.W0, axes=['wR', 'wL'])
             contr = npc.tensordot(contr, self.RP, axes=['wR', 'wL'])
-            contr = contr.combine_legs(
-                [['vR*', 'p0', 'vL*'], ['vR', 'p0*', 'vL']], qconj=[+1, -1])
+            contr = contr.combine_legs([['vR*', 'p0', 'vL*'], ['vR', 'p0*', 'vL']], qconj=[+1, -1])
         return contr
 
     def adjoint(self):
@@ -995,8 +988,7 @@ class TwoSiteH(EffectiveH):
         labels = theta.get_leg_labels()
         if self.combine:
             theta = npc.tensordot(self.LHeff, theta, axes=['(vR.p0*)', '(vL.p0)'])
-            theta = npc.tensordot(theta, self.RHeff, axes=[
-                                  ['wR', '(p1.vR)'], ['wL', '(p1*.vL)']])
+            theta = npc.tensordot(theta, self.RHeff, axes=[['wR', '(p1.vR)'], ['wL', '(p1*.vL)']])
             theta.ireplace_labels(['(vR*.p0)', '(p1.vL*)'], ['(vL.p0)', '(p1.vR)'])
         else:
             theta = npc.tensordot(self.LP, theta, axes=['vR', 'vL'])
@@ -1142,7 +1134,7 @@ class ZeroSiteH(EffectiveH):
     def __init__(self, env, i0):
         self.i0 = i0
         self.LP = env.get_LP(i0)
-        self.RP = env.get_RP(i0-1)
+        self.RP = env.get_RP(i0 - 1)
         self.dtype = env.H.dtype
         self.N = self.LP.get_leg('vR').ind_len * self.RP.get_leg('vL').ind_len
 

--- a/tests/test_tdvp.py
+++ b/tests/test_tdvp.py
@@ -1,45 +1,17 @@
 #!/usr/bin/python2
 # Copyright 2019-2021 TeNPy Developers, GNU GPLv3
 import numpy as np
-import copy
-import pickle
-import tenpy.linalg.np_conserved as npc
-import tenpy.models.spins
-import tenpy.networks.mps as mps
-import tenpy.networks.site as site
+import pytest
+from tenpy.models.spins import SpinChain
 from tenpy.algorithms import tdvp
 from tenpy.algorithms import tebd
-import sys
-import tdvp_numpy
-import tenpy.networks.mpo
-import tenpy.models.model as model
-import tenpy.models.lattice
 from tenpy.networks.mps import MPS
-from tenpy.tools.misc import inverse_permutation
-import pytest
-
-
-# TODO: no need to convert everything to numpy...
-# just compare the np_conserved TEBD with np_conserved TDVP, using mps.overlap()
-# or even better: directly compare to ED for small system
-def overlap(mps1, mps2):
-    """Calculate overlap <self|mps2>.
-
-    Performs conjugation of self!
-    """
-    X = np.ones((1, 1))
-    L = len(mps1)
-    for i in range(0, L):
-        tmp = np.tensordot(X, np.conj(mps1[i]), axes=[[0], [1]])
-        X = np.tensordot(tmp, mps2[i], axes=[[0, 1], [1, 0]])
-    overlap = X.reshape(())
-    return overlap
 
 
 @pytest.mark.slow
 def test_tdvp():
-    L = 10
-    J = 1
+    """compare overlap from TDVP with TEBD """
+    L = 8
     chi = 20
     delta_t = 0.01
     parameters = {
@@ -49,56 +21,21 @@ def test_tdvp():
         'Jz': 1.0,
         'Jy': 1.0,
         'Jx': 1.0,
-        'hx': 0.0,
-        'hy': 0.0,
-        'hz': 0.0,
-        'muJ': 0.0,
         'bc_MPS': 'finite',
     }
 
-    heisenberg = tenpy.models.spins.SpinChain(parameters)
-    H_MPO = heisenberg.H_MPO
-    h_test = []
-    for i_sites in range(H_MPO.L):
-        h_test.append(H_MPO.get_W(i_sites).transpose(['wL', 'wR', 'p*', 'p']).to_ndarray())
+    M = SpinChain(parameters)
+    # prepare system in product state
+    product_state = ["up", "down"] * (L // 2)
+    psi = MPS.from_product_state(M.lat.mps_sites(), product_state, bc=M.lat.bc_MPS)
 
-    def random_prod_state_tenpy(L, a_model):
-        product_state = []
-        #the numpy mps used to compare
-        psi_compare = []
-        sz = 2. * np.random.randint(0, 2, size=L) - 1.0
-        for i in range(L):
-            psi_compare.append(np.zeros((2, 1, 1)))
-            if sz[i] > 0:
-                product_state += ["up"]
-                psi_compare[-1][0, 0, 0] = 1
-            else:
-                product_state += ["down"]
-                psi_compare[-1][1, 0, 0] = 1
-
-        psi = MPS.from_product_state(a_model.lat.mps_sites(),
-                                     product_state,
-                                     bc=a_model.lat.bc_MPS,
-                                     form='B')
-        psi_converted = []
-        for i in range(L):
-            site = psi.sites[i]
-            perm = site.perm
-            B_tmp = psi.get_B(i).transpose(['p', 'vL', 'vR']).to_ndarray()
-            B = B_tmp[inverse_permutation(perm), :, :]
-            B = B[::-1, :, :]
-            psi_converted.append(B)
-
-        return psi
-
-    psi = random_prod_state_tenpy(heisenberg.lat.N_sites, heisenberg)
-    N_steps = 50
+    N_steps = 2
     tebd_params = {
         'order': 2,
         'dt': delta_t,
         'N_steps': N_steps,
         'trunc_params': {
-            'chi_max': 50,
+            'chi_max': chi,
             'svd_min': 1.e-10,
             'trunc_cut': None
         }
@@ -109,51 +46,27 @@ def test_tdvp():
         'dt': delta_t,
         'N_steps': N_steps,
         'trunc_params': {
-            'chi_max': 50,
+            'chi_max': chi,
             'svd_min': 1.e-10,
             'trunc_cut': None
         }
     }
 
-    psi_tdvp2 = copy.deepcopy(psi)
-    engine = tebd.TEBDEngine(psi, heisenberg, tebd_params)
-    tdvp_engine = tdvp.TDVPEngine(psi_tdvp2, heisenberg, tdvp_params)
-    engine.run()
-    tdvp_engine.run_two_sites(N_steps)
-    ov = psi.overlap(psi_tdvp2)
-    print("overlap TDVP and TEBD")
-    psi = engine.psi
-    print("difference")
-    print(np.abs(1 - np.abs(ov)))
-    assert np.abs(1 - np.abs(ov)) < 1e-10
-    print("two sites tdvp works")
+    # start by comparing TEBD and 2-site TDVP (increasing bond dimension)
+    psi_tdvp = psi.copy()
+    tebd_engine = tebd.TEBDEngine(psi, M, tebd_params)
+    tdvp2_engine = tdvp.TwoSiteTDVPEngine(psi_tdvp, M, tdvp_params)
+    for _ in range(10):
+        tebd_engine.run()
+        tdvp2_engine.run()
+        ov = psi.overlap(psi_tdvp)
+        assert np.abs(1 - np.abs(ov)) < 1e-10
 
-    # test that the initial conditions are the same
-
-    tdvp_engine = tdvp.TDVPEngine(psi, heisenberg, tdvp_params)
-    psit_compare = []
-    for i in range(L):
-        B_tmp = psi.get_B(i).transpose(['p', 'vL', 'vR']).to_ndarray()
-        B = B_tmp[::-1, :, :]
-        psit_compare.append(B)
-    #**********************************************************************************************************
-    #Initialize TDVP
-    tdvp_params = {
-        'start_time': 0,
-        'dt': delta_t,
-        'N_steps': 1,
-    }
-    tdvp_engine = tdvp.TDVPEngine(psi, heisenberg, tdvp_params)
-    for t in range(10):
-        tdvp_engine.run_one_site(N_steps=1)
-        psit_compare, Rp_list, spectrum = tdvp_numpy.tdvp(psit_compare,
-                                                          h_test,
-                                                          0.5 * 1j * delta_t,
-                                                          Rp_list=None)
-        psit_ = []
-    for i in range(L):
-        B = psi.get_B(i).transpose(['p', 'vL', 'vR']).to_ndarray()
-        B = B[::-1, :, :]
-        psit_.append(B)
-    assert np.abs(np.abs(overlap(psit_, psit_compare)) - 1.0) < 1e-13
-    print("one site TDVP works")
+    # now compare TEBD and 1-site TDVP (constant bond dimension)
+    tdvp_params['start_time'] = tdvp2_engine.evolved_time
+    tdvp1_engine = tdvp.SingleSiteTDVPEngine(psi_tdvp, M, tdvp_params)
+    for _ in range(10):
+        tebd_engine.run()
+        tdvp1_engine.run()
+        ov = psi.overlap(psi_tdvp)
+        assert np.abs(1 - np.abs(ov)) < 1e-10

--- a/tests/test_time_evolution.py
+++ b/tests/test_time_evolution.py
@@ -75,7 +75,7 @@ def test_ExpMPOEvolution(bc_MPS, approximation, compression, g=1.5):
             psi = eng.run()
             print(psi.norm)
             print(np.abs(psi.overlap(psiTEBD) - 1))
-            #This test fails
+            # This test fails
             assert (abs(abs(psi.overlap(psiTEBD)) - 1) < 1e-2)
 
 
@@ -93,7 +93,7 @@ def fermion_TFI_H(L, g=1.5, J=1.):
         A[i, i + 1] += -J
         A[i + 1, i] += -np.conj(J)
         B[i, i + 1] += -J
-        B[i + 1, i] += J  #no minus due to anti-commutation
+        B[i + 1, i] += J  # no minus due to anti-commutation
     A[L - 1, L - 1] += 2 * g
     return np.concatenate((np.concatenate(
         (A, B), axis=1), np.concatenate((B.conj().T, -A.T), axis=1)),
@@ -111,9 +111,9 @@ def exact_expectation(L, g, t=1., dt=0.01):
 
     H0 = fermion_TFI_H(L, g=g, J=0.)
     vp, U0p = LA.eigh(H0)
-    assert np.all(vp.round(10) != 0.)  #so far no handling of zero eigenvalues
+    assert np.all(vp.round(10) != 0.)  # so far no handling of zero eigenvalues
 
-    #reshape eigenvalues und -vectors to the form (v1, ..., vN, -v1, ..., -vN)
+    # reshape eigenvalues und -vectors to the form (v1, ..., vN, -v1, ..., -vN)
     U0 = np.zeros(U0p.shape)
     U0[:, :L] = U0p[:, L::][:, ::-1]
     for i in range(L):
@@ -130,12 +130,12 @@ def exact_expectation(L, g, t=1., dt=0.01):
     for i in range(L):
         U[:, L + i] = gamma @ U[:, i]
 
-    mag = []  #avarage magnetization
-    szsz = []  #correlation functions
+    mag = []  # avarage magnetization
+    szsz = []  # correlation functions
     spsm = []  # nearest neighbor <S+S- + S-S+> correlation
     for t in np.arange(0, t, dt):
         Ub = U @ np.diag(np.exp(
-            -1j * t * v)) @ U.conj().T @ U0  #the total (unitary) Boguliobov transformation
+            -1j * t * v)) @ U.conj().T @ U0  # the total (unitary) Boguliobov transformation
         X = Ub[L::, L::]
         Y = Ub[L::, :L]
         npt.assert_almost_equal((X @ X.conj().T + Y @ Y.conj().T), np.identity(L), 7)
@@ -155,7 +155,7 @@ def exact_expectation(L, g, t=1., dt=0.01):
         Delta = LA.inv(S)
         npt.assert_almost_equal(np.abs(LA.det(X)) * np.sqrt(LA.det(S)), 1, 7)
 
-        #measure z-magnetization
+        # measure z-magnetization
         mz = []
         for i in range(L):
             ni = Delta[i + L, i]
@@ -163,13 +163,14 @@ def exact_expectation(L, g, t=1., dt=0.01):
             mz.append(1 - 2 * ni.real)
         mag.append(mz)
 
-        #measure sigmaz-sigmaz correlations
+        # measure sigmaz-sigmaz correlations
         s = np.zeros((L, L))
         for i in range(L):
             for j in range(L):
-                ninj =  -0.25*(-Delta[j+L, i+3*L] + Delta[i+L, j+3*L])*(-Delta[j+2*L, i] + Delta[i+2*L, j]) \
-                        +0.25*(-Delta[j+L, j] + Delta[j+2*L, j+3*L])*(-Delta[i+L, i] + Delta[i+2*L, i+3*L]) \
-                        -0.25*(-Delta[j+L, i] + Delta[i+2*L, j+3*L])*(-Delta[i+L, j] + Delta[j+2*L, i+3*L])
+                ninj = -0.25*(-Delta[j+L, i+3*L] + Delta[i+L, j+3*L])*(-Delta[j+2*L, i] + Delta[i+2*L, j]) \
+                    + 0.25*(-Delta[j+L, j] + Delta[j+2*L, j+3*L])*(-Delta[i+L, i] + Delta[i+2*L, i+3*L]) \
+                    - 0.25*(-Delta[j+L, i] + Delta[i+2*L, j+3*L]) * \
+                    (-Delta[i+L, j] + Delta[j+2*L, i+3*L])
                 ni = Delta[i + L, i]
                 nj = Delta[j + L, j]
                 sij = 1 - 2 * ni - 2 * nj + 4 * ninj
@@ -177,7 +178,7 @@ def exact_expectation(L, g, t=1., dt=0.01):
                 s[i, j] = sij.real if i != j else 1.
         szsz.append(s)
 
-        #measure sigma+sigma- correlatios
+        # measure sigma+sigma- correlatios
         s = []
         for i in range(L - 1):
             j = i + 1
@@ -197,12 +198,12 @@ def test_time_methods(algorithm):
 
     model_params = dict(L=L, J=1., g=g, bc_MPS='finite', conserve=None)
     M = TFIChain(model_params)
-    product_state = ["up"] * L  #prepare system in spin polarized state
+    product_state = ["up"] * L  # prepare system in spin polarized state
     psi = MPS.from_product_state(M.lat.mps_sites(), product_state, bc=M.lat.bc_MPS)
 
     dt = 0.01
     N_steps = 2
-    t = 0.5  #total time evolution
+    t = 0.3  # total time evolution
     params = {
         'order': 2,
         'dt': dt,
@@ -216,9 +217,8 @@ def test_time_methods(algorithm):
     if algorithm == 'TEBD':
         eng = tebd.TEBDEngine(psi, M, params)
     elif algorithm == 'TDVP':
-        params['active_sites'] = 2
         del params['order']
-        eng = tdvp.TDVPEngine(psi, M, params)
+        eng = tdvp.TwoSiteTDVPEngine(psi, M, params)
     elif algorithm == 'ExpMPO':
         params['compression_method'] = 'SVD'
         del params['order']


### PR DESCRIPTION
@wilhelmkadow rewrote the TDVP by now a couple month ago.
I thought I had merged this already, but apparently I didn't - I'm sorry!

I think there were some subtleties left to fix, but I forgot what exactly. What comes up looking at it now:
-[ ] does the `combine_legs` option make sense, implement the possiblity to use it?
-[ ] Make it easy to switch between single-site and two-site TDVP, without recreating all the different environments.
-[ ] Ensure backwards compatiblity: the old engine had the `run_two_site` and `run_one_site` methods, that were part of the interface and probably used downstream. 
-[ ] it might be handy to keep the original TDVP engine around for reference, at least until we finally get a TeNPy version 1.0
-[ ] update the `examples/e_tdvp.py` accordingly
-[ ] create an example `examples/yaml/a_minimal_tdvp.yml`.


