### PR TITLE
Correctly suppress warning message if norm_err < norm_tol

### DIFF
--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -948,7 +948,7 @@ class DMRGEngine(Sweep):
             norm_tol_iter = self.options.get('norm_tol_iter', 5)
         if norm_tol is None or (norm_err < norm_tol and norm_err < norm_tol_final):
             return
-        if warn:
+        if warn and norm_err > norm_tol:
             logger.warning(
                 "final DMRG state not in canonical form up to "
                 "norm_tol=%.2e: norm_err=%.2e", norm_tol, norm_err)


### PR DESCRIPTION
Fixes a minor error in PR #159 in which the wrong warning message was given if norm_err < norm_tol but norm_err > norm_tol_final.