### PR TITLE
Sites sort charges

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -17,6 +17,13 @@ Backwards incompatible changes
   Further, we added the parameter :cfg:option:`VariationalCompression.min_sweeps` and :cfg:option:`VariationalCompression.tol_theta_diff`
 - Adjusted default paramters of :meth:`tenpy.networks.mps.InitialStateBuilder.randomized` to be as documented with better ``chi_max``.
 - No longer return `ov` from :func:`tenpy.linalg.lanczos.gram_schmidt`.
+- Add option `sort_charge` to the :class:`~tenpy.networks.site.Site` (calling the new :meth:`~tenpy.networks.site.Site.sort_charge` method).
+  Using `True` sorts the charges of the physical leg and thus helps to reduce overhead when using charge conservation.
+  However, doing this can lead to inconsistencies between saved data and newly generated data (after updating TeNPy). 
+  Hence, for now we keep the current default `False` behaviour, but raise a warning that you should set this option explicitly for cases where it changes things.
+  Set it to `False`, if you already have data (for your particular model), that you want to be able to load/compare to.
+  If you start a new project and don't have data yet, set it to `True`.
+  We will change the default behaviour from `False` to `True` in version 1.0.
 
 Added
 ^^^^^

--- a/doc/intro/JordanWigner.rst
+++ b/doc/intro/JordanWigner.rst
@@ -143,7 +143,7 @@ If you look at the definitions very closely, you can see that in terms like ``["
 Jordan-Wigner sign :math:`(-1)^{n_\uparrow,2}` appears twice (namely once in the definition of ``"Cd"`` and once in the ``"JW"`` on site
 2) and could in principle be canceled, however in favor of a simplified handling in the code we do not recommend you to cancel it.
 Similar, within a spinless :class:`~tenpy.networks.site.FermionSite`, one can simplify ``"Cd JW" == "Cd"`` and ``"JW C" == "C"``, 
-but these relations do *not* hold in the :class:`~tenpy.networks.site.SpinHalfSite`, 
+but these relations do *not* hold in the :class:`~tenpy.networks.site.SpinHalfFermionSite`, 
 and for consistency we recommend to explicitly keep the ``"JW"`` operator string even in nearest-neighbor models where it is not strictly necessary.
 
 

--- a/examples/advanced/mpo_exponential_decay.py
+++ b/examples/advanced/mpo_exponential_decay.py
@@ -48,6 +48,9 @@ class ExponentiallyDecayingHeisenberg(MPOModel):
         MPS boundary conditions.
     conserve : 'Sz' | 'parity' | None
         What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
+    sort_charge : bool | None
+        Whether to sort by charges of physical legs.
+        See change comment in :class:`~tenpy.networks.site.Site`.
     """
     def __init__(self, model_params):
         # model parameters
@@ -58,6 +61,7 @@ class ExponentiallyDecayingHeisenberg(MPOModel):
         Jz = model_params.get('Jz', 1.5)
         hz = model_params.get('hz', 0.)
         conserve = model_params.get('conserve', 'Sz')
+        sort_charge = model_params.get('sort_charge', None)
         if xi == 0.:
             g = 0.
         elif xi == np.inf:
@@ -67,7 +71,7 @@ class ExponentiallyDecayingHeisenberg(MPOModel):
 
         # Define the sites and the lattice, which in this case is a simple uniform chain
         # of spin 1/2 sites
-        site = SpinHalfSite(conserve=conserve)
+        site = SpinHalfSite(conserve=conserve, sort_charge=sort_charge)
         lat = Chain(L, site, bc_MPS='infinite', bc='periodic')
 
         # The operators that appear in the Hamiltonian. Standard spin operators are

--- a/examples/model_custom.py
+++ b/examples/model_custom.py
@@ -31,7 +31,8 @@ class AnisotropicSpin1Chain(CouplingMPOModel, NearestNeighborModel):
         if conserve == 'best':
             conserve = 'Sz' if not model_params.any_nonzero(['B']) else None
             self.logger.info("%s: set conserve to %s", self.name, conserve)
-        return SpinSite(S=1., conserve=None)
+        sort_charge = model_params.get('sort_charge', True)
+        return SpinSite(S=1., conserve=None, sort_charge=sort_charge)
 
     def init_terms(self, model_params):
         J = model_params.get('J', 1.)

--- a/examples/userguide/c_mps_mpo.py
+++ b/examples/userguide/c_mps_mpo.py
@@ -5,9 +5,6 @@ from tenpy.networks.mps import MPS
 from tenpy.networks.mpo import MPO
 
 spin = SpinHalfSite(conserve="Sz")
-print(spin.Sz.to_ndarray())
-# [[ 0.5  0. ]
-#  [ 0.  -0.5]]
 
 N = 6  # number of sites
 sites = [spin] * N  # repeat entry of list N times

--- a/examples/z_exact_diag.py
+++ b/examples/z_exact_diag.py
@@ -13,7 +13,7 @@ from tenpy.algorithms import dmrg
 
 
 def example_exact_diagonalization(L, Jz):
-    xxz_pars = dict(L=L, Jxx=1., Jz=Jz, hz=0.0, bc_MPS='finite')
+    xxz_pars = dict(L=L, Jxx=1., Jz=Jz, hz=0.0, bc_MPS='finite', sort_charge=True)
     M = XXZChain(xxz_pars)
 
     product_state = ["up", "down"] * (xxz_pars['L'] // 2)  # this selects a charge sector!

--- a/tenpy/models/aklt.py
+++ b/tenpy/models/aklt.py
@@ -2,9 +2,7 @@
 
 The AKLT model is famous for having a very simple ground state MPS of bond dimension 2.
 Writing down the Hamiltonian is easiest done in terms of bond couplings.
-This class thus serves as an example how this can be done in more gen
-The XXZ chain is contained in the more general :class:`~tenpy.models.spins.SpinChain`; the idea of
-this module is more to serve as a pedagogical example for a model.
+This class thus serves as an example how this can be done.
 """
 # Copyright 2021 TeNPy Developers, GNU GPLv3
 

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -295,7 +295,7 @@ class NearestNeighborModel(Model):
         .. doctest :: from_MPOModel
 
             >>> from tenpy.models.spins_nnn import SpinChainNNN2
-            >>> nnn_chain = SpinChainNNN2({'L': 20})
+            >>> nnn_chain = SpinChainNNN2({'L': 20, 'sort_charge': True})
             >>> print(isinstance(nnn_chain, NearestNeighborModel))
             False
             >>> print("range before grouping:", nnn_chain.H_MPO.max_range)

--- a/tenpy/models/spins.py
+++ b/tenpy/models/spins.py
@@ -45,6 +45,9 @@ class SpinModel(CouplingMPOModel):
         conserve : 'best' | 'Sz' | 'parity' | None
             What should be conserved. See :class:`~tenpy.networks.Site.SpinSite`.
             For ``'best'``, we check the parameters what can be preserved.
+        sort_charge : bool | None
+            Whether to sort by charges of physical legs.
+            See change comment in :class:`~tenpy.networks.site.Site`.
         Jx, Jy, Jz, hx, hy, hz, muJ, D, E  : float | array
             Coupling as defined for the Hamiltonian above.
 
@@ -62,7 +65,8 @@ class SpinModel(CouplingMPOModel):
             else:
                 conserve = None
             self.logger.info("%s: set conserve to %s", self.name, conserve)
-        site = SpinSite(S, conserve)
+        sort_charge = model_params.get('sort_charge', None)
+        site = SpinSite(S, conserve, sort_charge)
         return site
 
     def init_terms(self, model_params):

--- a/tenpy/models/spins_nnn.py
+++ b/tenpy/models/spins_nnn.py
@@ -83,7 +83,7 @@ class SpinChainNNN(CouplingMPOModel, NearestNeighborModel):
             else:
                 conserve = None
             self.logger.info("%s: set conserve to %s", self.name, conserve)
-        spinsite = SpinSite(S, conserve)
+        spinsite = SpinSite(S, conserve, sort_charge=False)  # GroupedSite does sort charges
         site = GroupedSite([spinsite, spinsite], charges='same')
         return site
 
@@ -157,6 +157,9 @@ class SpinChainNNN2(CouplingMPOModel):
         conserve : 'best' | 'Sz' | 'parity' | None
             What should be conserved. See :class:`~tenpy.networks.Site.SpinSite`.
             For ``'best'``, we check the parameters what can be preserved.
+        sort_charge : bool | None
+            Whether to sort by charges of physical legs.
+            See change comment in :class:`~tenpy.networks.site.Site`.
         Jx, Jy, Jz, Jxp, Jyp, Jzp, hx, hy, hz : float | array
             Coupling as defined for the Hamiltonian above.
     """
@@ -173,7 +176,8 @@ class SpinChainNNN2(CouplingMPOModel):
             else:
                 conserve = None
             self.logger.info("%s: set conserve to %s", self.name, conserve)
-        site = SpinSite(S, conserve)
+        sort_charge = model_params.get('sort_charge', None)
+        site = SpinSite(S, conserve, sort_charge=sort_charge)
         return site
 
     def init_terms(self, model_params):

--- a/tenpy/models/tf_ising.py
+++ b/tenpy/models/tf_ising.py
@@ -44,6 +44,9 @@ class TFIModel(CouplingMPOModel):
 
         conserve : None | 'parity'
             What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
+        sort_charge : bool | None
+            Whether to sort by charges of physical legs.
+            See change comment in :class:`~tenpy.networks.site.Site`.
         J, g : float | array
             Coupling as defined for the Hamiltonian above.
 
@@ -54,7 +57,8 @@ class TFIModel(CouplingMPOModel):
         if conserve == 'best':
             conserve = 'parity'
             self.logger.info("%s: set conserve to %s", self.name, conserve)
-        site = SpinHalfSite(conserve=conserve)
+        sort_charge = model_params.get('sort_charge', None)
+        site = SpinHalfSite(conserve=conserve, sort_charge=sort_charge)
         return site
 
     def init_terms(self, model_params):

--- a/tenpy/models/toric_code.py
+++ b/tenpy/models/toric_code.py
@@ -119,6 +119,9 @@ class ToricCode(CouplingMPOModel):
             Dimension of the lattice, number of plaquettes around the cylinder.
         conserve : 'parity' | None
             What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
+        sort_charge : bool | None
+            Whether to sort by charges of physical legs.
+            See change comment in :class:`~tenpy.networks.site.Site`.
         Jv, Jp : float | array
             Couplings as defined for the Hamiltonian above.
         order : str
@@ -140,7 +143,8 @@ class ToricCode(CouplingMPOModel):
 
     def init_sites(self, model_params):
         conserve = model_params.get('conserve', 'parity')
-        site = SpinHalfSite(conserve)
+        sort_charge = model_params.get('sort_charge', None)
+        site = SpinHalfSite(conserve, sort_charge=sort_charge)
         return site
 
     def init_terms(self, model_params):

--- a/tenpy/models/xxz_chain.py
+++ b/tenpy/models/xxz_chain.py
@@ -45,6 +45,9 @@ class XXZChain(CouplingModel, NearestNeighborModel, MPOModel):
             Coupling as defined for the Hamiltonian above.
         bc_MPS : {'finite' | 'infinte'}
             MPS boundary conditions. Coupling boundary conditions are chosen appropriately.
+        sort_charge : bool | None
+            Whether to sort by charges of physical legs.
+            See change comment in :class:`~tenpy.networks.site.Site`.
 
     """
     def __init__(self, model_params):
@@ -55,6 +58,7 @@ class XXZChain(CouplingModel, NearestNeighborModel, MPOModel):
         Jz = model_params.get('Jz', 1.)
         hz = model_params.get('hz', 0.)
         bc_MPS = model_params.get('bc_MPS', 'finite')
+        sort_charge = model_params.get('sort_charge', None)
         # 1-3):
         USE_PREDEFINED_SITE = False
         if not USE_PREDEFINED_SITE:
@@ -66,11 +70,11 @@ class XXZChain(CouplingModel, NearestNeighborModel, MPOModel):
             Sz = [[0.5, 0.], [0., -0.5]]
             # (Can't define Sx and Sy as onsite operators: they are incompatible with Sz charges.)
             # 3) local physical site
-            site = Site(leg, ['up', 'down'], Sp=Sp, Sm=Sm, Sz=Sz)
+            site = Site(leg, ['up', 'down'], sort_charge=sort_charge, Sp=Sp, Sm=Sm, Sz=Sz)
         else:
             # there is a site for spin-1/2 defined in TeNPy, so just we can just use it
             # replacing steps 1-3)
-            site = SpinHalfSite(conserve='Sz')
+            site = SpinHalfSite(conserve='Sz', sort_charge=sort_charge)
         # 4) lattice
         bc = 'open' if bc_MPS == 'finite' else 'periodic'
         lat = Chain(L, site, bc=bc, bc_MPS=bc_MPS)
@@ -104,7 +108,8 @@ class XXZChain2(CouplingMPOModel, NearestNeighborModel):
     force_default_lattice = True
 
     def init_sites(self, model_params):
-        return SpinHalfSite(conserve='Sz')  # use predefined Site
+        sort_charge = model_params.get('sort_charge', None)
+        return SpinHalfSite(conserve='Sz', sort_charge=sort_charge)  # use predefined Site
 
     def init_terms(self, model_params):
         # read out parameters

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -513,7 +513,7 @@ class MPS:
 
         .. doctest :: MPS.from_product_state
 
-            >>> spin = tenpy.networks.site.SpinHalfSite(conserve=None)
+            >>> spin = tenpy.networks.site.SpinHalfSite(conserve=None, sort_charge=False)
             >>> p_state = ["up", "down"] * (L//2)  # repeats entries L/2 times
             >>> theta, phi = np.pi/4, np.pi/6
             >>> bloch_sphere_state = np.array([np.cos(theta/2), np.exp(1.j*phi)*np.sin(theta/2)])

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -146,12 +146,15 @@ class Site(Hdf5Exportable):
             self.sort_charge()
         elif sort_charge is None:
             if not (leg.sorted and leg.bunched):
-                warnings.warn(f"LegCharge of physical leg in site {self!s} is not sorted. "
-                              "You should explicitly set `sort_charge`."
-                              "We will switch the default from False to True in version 1.0, "
-                              "which breaks compatibility of existing data with "
-                              "code/models that don't explicitly set sort_legcharge.",
-                              FutureWarning, 2)
+                msg = (f"LegCharge of physical leg in site {self!s} is not sorted. "
+                       "You should explicitly set `sort_charge`. "
+                       "Set it to False, if you already have saved data for your model and want "
+                       "to be able to load it/keep backwards compatibility. "
+                       "For new projects, if you don't have data yet, set it to `True`. "
+                       "We will switch the default from False to True in version 1.0, "
+                       "which breaks compatibility of existing data with "
+                       "code/models that don't explicitly set sort_legcharge.")
+                warnings.warn(msg, FutureWarning, 2)
         self.test_sanity()
 
     def change_charge(self, new_leg_charge=None, permute=None):

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -1,6 +1,7 @@
 """Defines a class describing the local physical Hilbert space.
 
 The :class:`Site` is the prototype, read it's docstring.
+
 """
 # Copyright 2018-2021 TeNPy Developers, GNU GPLv3
 
@@ -34,6 +35,19 @@ class Site(Hdf5Exportable):
         The order of the local basis can change depending on the charge conservation!
         This is a *necessary* feature since we need to sort the basis by charges for efficiency.
         We use the :attr:`state_labels` and :attr:`perm` to keep track of these permutations.
+
+    .. versionchanged :: 0.10
+
+        Add the option `sort_charge`. Right now the default behavriou is ``False`` for
+        backwards compatibility, but we will change it for Version 1.0 to ``True``.
+        For now, we raise a warning in cases where it can lead to changes.
+        If you see this warning, just set the value explicitly to avoid breaking compatibility of
+        existing data with future releases.
+        Set it to `False`, if you already have data (for your particular model),
+        that you want to be able to load/compare to.
+        If you start a new project and don't have data yet, set it to `True`.
+        See also the `breaking changes` section in the release notes.
+
 
     Parameters
     ----------

--- a/tests/export_import_test/io_test.py
+++ b/tests/export_import_test/io_test.py
@@ -57,7 +57,7 @@ def dummy_function(obj):
 def gen_example_data(version=tenpy.version.full_version):
     if '+' in version:
         version = version.split('+')[0]  # discard '+GITHASH' from version
-    s = tenpy.networks.site.SpinHalfSite()
+    s = tenpy.networks.site.SpinHalfSite(sort_charge=False)
     data = {
         'SpinHalfSite': s,
         'trivial_array': npc.Array.from_ndarray_trivial(np.arange(20).reshape([4, 5])),
@@ -66,7 +66,7 @@ def gen_example_data(version=tenpy.version.full_version):
     if parse_version(version) >= parse_version('0.5.0.dev25'):
         psi = tenpy.networks.mps.MPS.from_singlets(s, 6, [(0, 3), (1, 2), (4, 5)])
         psi.test_sanity()
-        M = tenpy.models.tf_ising.TFIChain({'L': 3, 'bc_MPS': 'infinite'})
+        M = tenpy.models.tf_ising.TFIChain({'L': 3, 'bc_MPS': 'infinite', 'sort_charge': False})
         data.update({
             'version':
             version,

--- a/tests/export_import_test/test_pickle.py
+++ b/tests/export_import_test/test_pickle.py
@@ -70,7 +70,8 @@ def test_simulation_export_import(tmp_path):
         'XXZChain',
         'model_params': {
             'bc_MPS': 'infinite',
-            'L': 2
+            'L': 2,
+            'sort_charge': False,
         },
         'algorithm_class':
         'DummyAlgorithmSleep',

--- a/tests/test_dmrg.py
+++ b/tests/test_dmrg.py
@@ -173,7 +173,7 @@ def test_dmrg_excited(eps=1.e-12):
     # (without truncation)
     L, g = 8, 1.3
     bc = 'finite'
-    model_params = dict(L=L, J=1., g=g, bc_MPS=bc, conserve='parity')
+    model_params = dict(L=L, J=1., g=g, bc_MPS=bc, conserve='parity', sort_charge=True)
     M = TFIChain(model_params)
     # compare to exact solution
     ED = ExactDiag(M)

--- a/tests/test_exact_diag.py
+++ b/tests/test_exact_diag.py
@@ -10,7 +10,7 @@ from tenpy.linalg.lanczos import lanczos
 
 def test_ED():
     # just quickly check that it runs without errors for a small system
-    xxz_pars = dict(L=4, Jxx=1., Jz=1., hz=0.0, bc_MPS='finite')
+    xxz_pars = dict(L=4, Jxx=1., Jz=1., hz=0.0, bc_MPS='finite', sort_charge=True)
     M = XXZChain(xxz_pars)
     ED = ExactDiag(M)
     ED.build_full_H_from_mpo()

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -76,15 +76,15 @@ def test_lattice():
 
 
 def test_TrivialLattice():
-    s1 = site.SpinHalfSite('Sz')
-    s2 = site.SpinSite(0.5, 'Sz')
-    s3 = site.SpinSite(1.0, 'Sz')
+    s1 = site.SpinHalfSite('Sz', sort_charge=True)
+    s2 = site.SpinSite(0.5, 'Sz', sort_charge=True)
+    s3 = site.SpinSite(1.0, 'Sz', sort_charge=True)
     lat = lattice.TrivialLattice([s1, s2, s3, s2, s1])
     lat.test_sanity()
 
 
 def test_MultiSpeciesLattice():
-    s1 = site.SpinHalfSite('Sz')
+    s1 = site.SpinHalfSite('Sz', sort_charge=True)
     f1 = site.FermionSite('N')
     site.set_common_charges([s1, f1], 'independent')
     simple_lat = lattice.Honeycomb(3, 4, None)
@@ -93,7 +93,7 @@ def test_MultiSpeciesLattice():
 
 
 def test_IrregularLattice():
-    s1 = site.SpinHalfSite('Sz')
+    s1 = site.SpinHalfSite('Sz', sort_charge=False)
     s2 = site.SpinSite(0.5, 'Sz')
     reg = lattice.Honeycomb(3, 3, [s1, s2], bc=['open', 'periodic'])
     ir = lattice.IrregularLattice(reg, [[1, 1, 0], [1, 1, 1], [0, 0, 0]],
@@ -121,7 +121,7 @@ def test_IrregularLattice():
 
 
 def test_HelicalLattice():
-    s = site.SpinHalfSite()
+    s = site.SpinHalfSite('Sz', sort_charge=False)
     honey = lattice.Honeycomb(2, 3, s, bc=['periodic', -1], bc_MPS='infinite', order='Cstyle')
     hel = lattice.HelicalLattice(honey, 2)
     strength = np.array([[1.5, 2.5, 1.5], [2.5, 1.5, 2.5]])
@@ -228,7 +228,7 @@ def test_pairs():
 
 
 def test_lattice_order():
-    s = site.SpinHalfSite('Sz')
+    s = site.SpinHalfSite('Sz', sort_charge=True)
     # yapf: disable
     chain = lattice.Chain(4, s)
     order_default = np.array([[0, 0], [1, 0], [2, 0], [3, 0]])
@@ -305,7 +305,7 @@ def test_possible_couplings():
 
 def test_index_conversion():
     from tenpy.networks.mps import MPS
-    s = site.SpinHalfSite(conserve=None)
+    s = site.SpinHalfSite(conserve=None, sort_charge=True)
     state1 = [[[0, 1]]]  # 0=up, 1=down
     for order in ["snake", "default"]:
         lat = lattice.Honeycomb(2, 3, [s, s], order=order, bc_MPS="finite")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,7 +14,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-spin_half_site = tenpy.networks.site.SpinHalfSite('Sz')
+spin_half_site = tenpy.networks.site.SpinHalfSite('Sz', sort_charge=False)
 
 fermion_site = tenpy.networks.site.FermionSite('N')
 
@@ -307,7 +307,7 @@ def test_CouplingModel_multi_couplings_explicit(use_plus_hc, JW):
 class MyMod(model.CouplingMPOModel, model.NearestNeighborModel):
     def init_sites(self, model_params):
         conserve = model_params.get('conserve', 'parity')
-        return tenpy.networks.site.SpinHalfSite(conserve)
+        return tenpy.networks.site.SpinHalfSite(conserve, True)
 
     def init_terms(self, model_params):
         x = model_params.get('x', 1.)
@@ -321,7 +321,7 @@ class MyMod(model.CouplingMPOModel, model.NearestNeighborModel):
 
 def test_CouplingMPOModel_group():
     m1 = MyMod(dict(x=0.5, L=5, bc_MPS='finite'))
-    model_params = {'L': 6, 'hz': np.random.random([6]), 'bc_MPS': 'finite'}
+    model_params = {'L': 6, 'hz': np.random.random([6]), 'bc_MPS': 'finite', 'sort_charge': True}
     m2 = XXZChain(model_params)
     for m in [m1, m2]:
         print("model = ", m)
@@ -349,7 +349,7 @@ def test_CouplingMPOModel_group():
 
 def test_model_H_conversion(L=6):
     bc = 'finite'
-    model_params = {'L': L, 'hz': np.random.random([L]), 'bc_MPS': bc}
+    model_params = {'L': L, 'hz': np.random.random([L]), 'bc_MPS': bc, 'sort_charge': True}
     m = XXZChain(model_params)
 
     # can we run the conversion?
@@ -469,7 +469,7 @@ def test_model_plus_hc(L=6):
 class DisorderedLatticeModel(model.CouplingMPOModel):
     def init_sites(self, model_params):
         conserve = model_params.get('conserve', 'parity')
-        return tenpy.networks.site.SpinHalfSite(conserve)
+        return tenpy.networks.site.SpinHalfSite(conserve, sort_charge=True)
 
     def init_lattice(self, model_params):
         lat = super().init_lattice(model_params)

--- a/tests/test_model_spins.py
+++ b/tests/test_model_spins.py
@@ -4,11 +4,13 @@ from test_model import check_general_model
 
 
 def test_SpinModel():
-    check_general_model(spins.SpinModel, {'lattice': "Square", 'Lx': 2, 'Ly': 3}, {})
+    check_general_model(spins.SpinModel,
+                        {'lattice': "Square", 'Lx': 2, 'Ly': 3, 'sort_charge': True},
+                        {})
 
 
 def test_SpinChain():
-    check_general_model(spins.SpinChain, {}, {
+    check_general_model(spins.SpinChain, {'sort_charge': True}, {
         'conserve': [None, 'parity', 'Sz'],
         'S': [0.5, 1, 2]
     })
@@ -16,7 +18,8 @@ def test_SpinChain():
         'hz': 2.,
         'Jx': -4.,
         'Jz': -0.4,
-        'L': 4
+        'L': 4,
+        'sort_charge': True,
     }, {
         'conserve': [None, 'parity'],
         'bc_MPS': ['finite', 'infinite']

--- a/tests/test_model_tf_ising.py
+++ b/tests/test_model_tf_ising.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def test_TFIChain_general():
-    check_general_model(TFIChain, dict(L=4, J=1., bc_MPS='finite'), {
+    check_general_model(TFIChain, dict(L=4, J=1., bc_MPS='finite', sort_charge=True), {
         'conserve': [None, 'parity'],
         'g': [0., 0.2]
     })
@@ -15,7 +15,7 @@ def test_TFIChain_general():
 @pytest.mark.slow
 def test_TFIModel2D_general():
     check_general_model(
-        TFIModel, dict(Lx=2, J=1., g=0.1), {
+        TFIModel, dict(Lx=2, J=1., g=0.1, sort_charge=True), {
             'Ly': [2, 3],
             'bc_MPS': ['finite', 'infinite'],
             'bc_y': ['ladder', 'cylinder'],

--- a/tests/test_model_toric_code.py
+++ b/tests/test_model_toric_code.py
@@ -11,14 +11,14 @@ import warnings
 
 @pytest.mark.slow
 def test_ToricCode_general():
-    check_general_model(ToricCode, dict(Lx=2, Ly=3, bc_MPS='infinite'), {
+    check_general_model(ToricCode, dict(Lx=2, Ly=3, bc_MPS='infinite', sort_charge=True), {
         'conserve': [None, 'parity'],
     })
 
 
 @pytest.mark.slow
 def test_ToricCode(Lx=1, Ly=2):
-    model_params = {'Lx': Lx, 'Ly': Ly, 'bc_MPS': 'infinite'}
+    model_params = {'Lx': Lx, 'Ly': Ly, 'bc_MPS': 'infinite', 'sort_charge': True}
     M = ToricCode(model_params)
     psi = MPS.from_product_state(M.lat.mps_sites(), [0] * M.lat.N_sites, bc='infinite')
     dmrg_params = {

--- a/tests/test_model_xxz_chain.py
+++ b/tests/test_model_xxz_chain.py
@@ -11,7 +11,7 @@ from test_model import check_general_model
 
 
 def test_XXZChain():
-    pars = dict(L=4, Jxx=1., Jz=1., hz=0., bc_MPS='finite')
+    pars = dict(L=4, Jxx=1., Jz=1., hz=0., bc_MPS='finite', sort_charge=True)
     chain = XXZChain(pars)
     chain.test_sanity()
     for Hb in chain.H_bond[1:]:  # check bond eigenvalues
@@ -51,15 +51,15 @@ def test_XXZChain():
 
 
 def test_XXZChain_general(tol=1.e-14):
-    check_general_model(XXZChain, dict(L=4, Jxx=1., hz=0., bc_MPS='finite'), {
+    check_general_model(XXZChain, dict(L=4, Jxx=1., hz=0., bc_MPS='finite', sort_charge=True), {
         'Jz': [0., 1., 2.],
         'hz': [0., 0.2]
     })
-    check_general_model(XXZChain2, dict(L=4, Jxx=1., hz=0., bc_MPS='finite'), {
+    check_general_model(XXZChain2, dict(L=4, Jxx=1., hz=0., bc_MPS='finite', sort_charge=True), {
         'Jz': [0., 1., 2.],
         'hz': [0., 0.2]
     })
-    model_param = dict(L=3, Jxx=1., Jz=1.5, hz=0.25, bc_MPS='finite')
+    model_param = dict(L=3, Jxx=1., Jz=1.5, hz=0.25, bc_MPS='finite', sort_charge=True)
     m1 = XXZChain(model_param)
     m2 = XXZChain2(model_param)
     for Hb1, Hb2 in zip(m1.H_bond, m2.H_bond):

--- a/tests/test_mpo.py
+++ b/tests/test_mpo.py
@@ -13,7 +13,7 @@ from tenpy.networks.terms import OnsiteTerms, CouplingTerms, MultiCouplingTerms,
 
 from random_test import random_MPS
 
-spin_half = site.SpinHalfSite(conserve='Sz')
+spin_half = site.SpinHalfSite(conserve='Sz', sort_charge=False)
 
 
 def test_MPO():
@@ -169,7 +169,7 @@ def test_MPO_conversion():
 
 
 def test_MPOEnvironment():
-    xxz_pars = dict(L=4, Jxx=1., Jz=1.1, hz=0.1, bc_MPS='finite')
+    xxz_pars = dict(L=4, Jxx=1., Jz=1.1, hz=0.1, bc_MPS='finite', sort_charge=True)
     L = xxz_pars['L']
     M = XXZChain(xxz_pars)
     state = ([0, 1] * L)[:L]  # Neel

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -14,7 +14,7 @@ import tenpy.linalg.np_conserved as npc
 
 import pytest
 
-spin_half = site.SpinHalfSite(conserve='Sz')
+spin_half = site.SpinHalfSite(conserve='Sz', sort_charge=False)
 
 
 def test_mps():
@@ -53,7 +53,7 @@ def test_mps():
 
 
 def test_mps_add():
-    s = site.SpinHalfSite(conserve='Sz')
+    s = site.SpinHalfSite(conserve='Sz', sort_charge=True)
     u, d = 'up', 'down'
     psi1 = mps.MPS.from_product_state([s] * 4, [u, u, d, u], bc='finite')
     psi2 = mps.MPS.from_product_state([s] * 4, [u, d, u, u], bc='finite')
@@ -77,7 +77,7 @@ def test_mps_add():
 
 
 def test_MPSEnvironment():
-    xxz_pars = dict(L=4, Jxx=1., Jz=1.1, hz=0.1, bc_MPS='finite')
+    xxz_pars = dict(L=4, Jxx=1., Jz=1.1, hz=0.1, bc_MPS='finite', sort_charge=True)
     L = xxz_pars['L']
     M = XXZChain(xxz_pars)
     state = ([0, 1] * L)[:L]  # Neel state
@@ -308,7 +308,7 @@ def test_apply_op(bc, eps=1.e-13):
 
 
 def test_enlarge_mps_unit_cell():
-    s = site.SpinHalfSite(conserve='Sz')
+    s = site.SpinHalfSite(conserve='Sz', sort_charge=True)
     psi = mps.MPS.from_product_state([s] * 3, ['up', 'down', 'up'], bc='infinite')
     psi0 = psi.copy()
     psi1 = psi.copy()
@@ -324,7 +324,7 @@ def test_enlarge_mps_unit_cell():
 
 
 def test_roll_mps_unit_cell():
-    s = site.SpinHalfSite(conserve='Sz')
+    s = site.SpinHalfSite(conserve='Sz', sort_charge=True)
     psi = mps.MPS.from_product_state([s] * 4, ['down', 'up', 'up', 'up'], bc='infinite')
     psi1 = psi.copy()
     psi1.roll_mps_unit_cell(1)
@@ -343,7 +343,7 @@ def test_roll_mps_unit_cell():
 
 
 def test_mps_enlarge_chi(eps=1.e-14):
-    s = site.SpinHalfSite(conserve='Sz')
+    s = site.SpinHalfSite(conserve='Sz', sort_charge=True)
     # infinite
     psi = mps.MPS.from_product_state([s] * 2, ['up', 'down'], bc='infinite')
     psi.perturb({'trunc_params': {'chi_max': 10}, 'N_steps': 10}, close_1=False)
@@ -369,7 +369,7 @@ def test_mps_enlarge_chi(eps=1.e-14):
 
 
 def test_group():
-    s = site.SpinHalfSite(conserve='parity')
+    s = site.SpinHalfSite(conserve='parity', sort_charge=True)
     psi1 = mps.MPS.from_singlets(s, 6, [(1, 3), (2, 5)], lonely=[0, 4], bc='finite')
     psi2 = psi1.copy()
     print("group n=2")
@@ -522,7 +522,7 @@ def test_expectation_value_multisite():
 
 
 def test_sample_measurements(eps=1.e-14, seed=5):
-    spin_half = site.SpinHalfSite()
+    spin_half = site.SpinHalfSite('Sz', sort_charge=True)
     u, d = spin_half.state_indices(['up', 'down'])
     spin_half.add_op('Pup', spin_half.Sz + 0.5 * spin_half.Id)
     psi = mps.MPS.from_singlets(spin_half, 6, [(0, 1), (2, 5)], lonely=[3, 4], bc='finite')
@@ -582,7 +582,7 @@ def test_mps_compress(method, eps=1.e-13):
 
 
 def test_InitialStateBuilder():
-    s0 = site.SpinHalfSite()
+    s0 = site.SpinHalfSite('Sz', sort_charge=True)
     lat = Chain(10, s0, bc_MPS='finite')
     psi1 = mps.InitialStateBuilder(
         lat, {

--- a/tests/test_purification.py
+++ b/tests/test_purification.py
@@ -14,7 +14,7 @@ import tenpy.linalg.random_matrix as rmat
 import tenpy.linalg.np_conserved as npc
 import pytest
 
-spin_half = site.SpinHalfSite(conserve='Sz')
+spin_half = site.SpinHalfSite(conserve='Sz', sort_charge=False)
 ferm = site.FermionSite(conserve='N')
 
 
@@ -68,7 +68,8 @@ def test_canoncial_purification(L=6, charge_sector=0, eps=1.e-14):
             assert abs(entry) < eps
 
     # and one quick test of TEBD
-    xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS='finite')
+    xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS='finite', sort_charge=False)
+    # sort_charge should be same as for global `spin_half`.
     M = XXZChain(xxz_pars)
     TEBD_params = {
         'trunc_params': {
@@ -88,7 +89,7 @@ def test_canoncial_purification(L=6, charge_sector=0, eps=1.e-14):
 
 @pytest.mark.slow
 def test_purification_TEBD(L=3):
-    xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS='finite')
+    xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS='finite', sort_charge=True)
     M = XXZChain(xxz_pars)
     for disent in [
             None, 'backwards', 'min(None,last)-renyi', 'noise-norm', 'renyi-min(None,noise-renyi)'
@@ -116,7 +117,7 @@ def test_purification_TEBD(L=3):
 
 
 def test_purification_MPO(L=6):
-    xxz_pars = dict(L=L, Jxx=1., Jz=2., hz=0., bc_MPS='finite')
+    xxz_pars = dict(L=L, Jxx=1., Jz=2., hz=0., bc_MPS='finite', sort_charge=True)
     M = XXZChain(xxz_pars)
     psi = purification_mps.PurificationMPS.from_infiniteT(M.lat.mps_sites(), bc='finite')
     options = {'trunc_params': {'chi_max': 50, 'svd_min': 1.e-8}}
@@ -127,7 +128,7 @@ def test_purification_MPO(L=6):
 
 
 def test_renyi_disentangler(L=4, eps=1.e-15):
-    xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS='finite')
+    xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS='finite', sort_charge=True)
     M = XXZChain(xxz_pars)
     psi = purification_mps.PurificationMPS.from_infiniteT(M.lat.mps_sites(), bc='finite')
     eng = PurificationTEBD(psi, M, {'disentangle': 'renyi'})
@@ -221,7 +222,7 @@ def gen_disentangler_psi_singlet_test(site_P=spin_half, L=6, max_range=4):
     print("PQ:", np.round(mutinf_pq / np.log(2), 3))
     print("P: ", np.round(psi0.mutinf_two_site(legs='p')[1] / np.log(2), 3))
     print("Q: ", np.round(psi0.mutinf_two_site(legs='q')[1] / np.log(2), 3))
-    M = XXZChain(dict(L=L))
+    M = XXZChain(dict(L=L, sort_charge=True))
     tebd_pars = dict(trunc_params={'trunc_cut': 1.e-10}, disentangle='diag')
     eng = PurificationTEBD(psi0, M, tebd_pars)
     for i in range(L):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -76,6 +76,7 @@ simulation_params = {
     'model_params': {
         'bc_MPS': 'infinite',  # defaults to finite
         'L': 4,
+        'sort_charge': True,
     },
     'algorithm_class':
     'DummyAlgorithm',

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -58,10 +58,8 @@ def test_site():
     leg2 = npc.LegCharge.from_change_charge(leg2, 0, 2, 'changed')
     s2 = copy.deepcopy(s)
     s2.change_charge(leg2)
-    perm_qind, leg2s = leg2.sort()
-    perm_flat = leg2.perm_flat_from_perm_qind(perm_qind)
     s2s = copy.deepcopy(s2)
-    s2s.change_charge(leg2s, perm_flat)
+    s2s.sort_charge()
     for site_check in [s2, s2s]:
         print("site_check.leg = ", site_check.leg)
         for opn in site_check.opnames:
@@ -80,7 +78,8 @@ def test_site():
 
 
 def test_double_site():
-    for site0, site1 in [[site.SpinHalfSite(None)] * 2, [site.SpinHalfSite('Sz')] * 2]:
+    for site0, site1 in [[site.SpinHalfSite(None)] * 2,
+                         [site.SpinHalfSite('Sz', sort_charge=False)] * 2]:
         for charges in ['same', 'drop', 'independent']:
             ds = site.GroupedSite([site0, site1], charges=charges)
             ds.test_sanity()
@@ -141,27 +140,8 @@ def test_spin_half_site():
                Sigmaz='Sigmaz')
     sites = []
     for conserve in [None, 'Sz', 'parity']:
-        S = site.SpinHalfSite(conserve)
-        S.test_sanity()
-        for op in S.onsite_ops:
-            assert S.hc_ops[op] == hcs[op]
-        if conserve != 'Sz':
-            SxSy = ['Sx', 'Sy']
-        else:
-            SxSy = None
-        check_spin_site(S, SxSy=SxSy)
-        sites.append(S)
-    check_same_operators(sites)
-
-
-def test_spin_site():
-    hcs = dict(Id='Id', JW='JW', Sx='Sx', Sy='Sy', Sz='Sz', Sp='Sm', Sm='Sp')
-    for s in [0.5, 1, 1.5, 2, 5]:
-        print('s = ', s)
-        sites = []
-        for conserve in [None, 'Sz', 'parity']:
-            print("conserve = ", conserve)
-            S = site.SpinSite(s, conserve)
+        for sort_charge in [True, False]:
+            S = site.SpinHalfSite(conserve, sort_charge=sort_charge)
             S.test_sanity()
             for op in S.onsite_ops:
                 assert S.hc_ops[op] == hcs[op]
@@ -171,6 +151,27 @@ def test_spin_site():
                 SxSy = None
             check_spin_site(S, SxSy=SxSy)
             sites.append(S)
+    check_same_operators(sites)
+
+
+def test_spin_site():
+    hcs = dict(Id='Id', JW='JW', Sx='Sx', Sy='Sy', Sz='Sz', Sp='Sm', Sm='Sp')
+    for s in [0.5, 1, 1.5, 2, 5]:
+        print('s = ', s)
+        sites = []
+        for sort_charge in [True, False]:
+                for conserve in [None, 'Sz', 'parity']:
+                    print("conserve = ", conserve)
+                    S = site.SpinSite(s, conserve, sort_charge=sort_charge)
+                    S.test_sanity()
+                    for op in S.onsite_ops:
+                        assert S.hc_ops[op] == hcs[op]
+                    if conserve != 'Sz':
+                        SxSy = ['Sx', 'Sy']
+                    else:
+                        SxSy = None
+                    check_spin_site(S, SxSy=SxSy)
+                    sites.append(S)
         check_same_operators(sites)
 
 

--- a/tests/test_tebd.py
+++ b/tests/test_tebd.py
@@ -89,7 +89,7 @@ def test_tebd(bc_MPS, g=0.5):
 
 def test_RandomUnitaryEvolution():
     L = 8
-    spin_half = SpinHalfSite(conserve='Sz')
+    spin_half = SpinHalfSite(conserve='Sz', sort_charge=True)
     psi = MPS.from_product_state([spin_half] * L, [0, 1] * (L // 2), bc='finite')  # Neel state
     assert tuple(psi.chi) == (1, 1, 1, 1, 1, 1, 1)
     TEBD_params = dict(N_steps=2, trunc_params={'chi_max': 10})

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -9,7 +9,7 @@ from tenpy.networks import site
 from tenpy.networks import mpo
 from tenpy.linalg.np_conserved import LegCharge
 
-spin_half = site.SpinHalfSite(conserve='Sz')
+spin_half = site.SpinHalfSite(conserve='Sz', sort_charge=True)
 fermion = site.FermionSite(conserve='N')
 dummy = site.Site(spin_half.leg)
 


### PR DESCRIPTION
This change is backwards incompatible, so I'm creating a pull request to make the change more visible and track it better.

**Motivation**: Sorting charges reduces the overhead in `npc.tensordot` etc. Internally, `tensordot` checks whether the legs are sorted by charge. If they are not sorted, it creates copies where it sorts by charge, does the tensordot with the copies, and finally (if necessary, namely when an uncontracted leg was not sorted) permutes the result back.

**Incompatibility**: Tensors with sorted legs cannot be contracted with unsorted legs. 
When the user starts a whole simulation (initialising the MPS and Model etc), the sorting is consistent throughout, so it does not break working setups.
*However*, when the user has saved some MPS before this change, and then wants to re-run DMRG with the saved initial state, but does recreates the model from the model parameters (which is the default in TeNPy simulations), he will run into an error message of incompatible charges - at least if the sorting affects the sites of the model.

Since the physical leg of the `SpinHalfSite(conserve='Sz')` is not sorted at this point, this will likely affect quite a few users!

At this point, the strategy to allow a smooth transition is the following:
1) I've added an extra option `sort_charge` to the `Site` initialization, which defaults to `None`. 
2) If it is None, the Site raises a FutureWarning if the leg is not sorted, i.e. if the users might be affected.
Explicitly setting a value to True or False disables the warning.
3) All TeNPy models support a new model parameter `sort_charge` that is just carried on to the Site class, so users can just explicitly add the parameter to their setups to avoid the warning. They are advised to set it to False if they already have data, or True if they start a new project.
4) In a future release (likely version 1.0) we will change the default value from None to True.
At that point, we can also add a Warning when loading data from File where the site doesn't have `used_sort_charge` set, with the advice to set `sort_charge=False` if a ValueError occurs.
