### PR TITLE
bugfix MPS.gauge_total_charge

### DIFF
--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -1529,7 +1529,7 @@ class MPS:
             if np.any(vL_chdiff != 0):
                 # adjust left leg
                 self._B[0] = B.gauge_total_charge('vL', B.qtotal + vL_chdiff, vL_leg.qconj)
-            B.get_leg('vL').test_equal(vL_leg)
+            self._B[0].get_leg('vL').test_equal(vL_leg)
         for i in range(self.L):
             B = self._B[i]
             desired_qtotal = qtotal[i]
@@ -4236,8 +4236,7 @@ class MPS:
         """If necessary, gauge total charge of `other` to match the vL, vR legs of self."""
         if self.chinfo.qnumber == 0:
             return
-        from tenpy.tools import optimization
-        need_gauge = any(self.get_total_charge() != other.get_total_charge())
+        need_gauge = self._outer_virtual_legs() != other._outer_virtual_legs()
         if need_gauge:
             vL, vR = self._outer_virtual_legs()
             other.gauge_total_charge(None, vL, vR)


### PR DESCRIPTION
This is a short bugfix for gauging the total charge of a MPS.

The addressed bug mainly introduced errors when trying to calculate overlaps of two MPS with different _outer_virtual_legs (e.g. after applying a spatial inversion to one MPS with total charge != 0).

The following code is a minimal example to reproduce the bug.
```
from tenpy.networks.mps import MPS
from tenpy.networks.site import SpinSite

p_state = 1*['up'] + 10*[1] + 1*['up']
sites = [SpinSite(S=1, conserve='Sz')]*len(p_state)
psi = MPS.from_product_state(sites, p_state)

other = psi.copy()
psi.spatial_inversion()
# print(f"Before overlap: {psi._outer_virtual_legs()=}")
overlap = psi.overlap(other)
# print(f"After overlap: {psi._outer_virtual_legs()=}")
print(f"Successfully calculated the overlap: {overlap}")

# Note that with the bugfix the virtual legs of psi are getting changed when psi.overlap is called.
```

Additional question: Should the docstring in MPS.overlap mention, that the function might change the input MPS (or rather its virtual legs)? Or should it make a copy instead of silently changing the virtual leg charges?