### PR TITLE
Measurement function fixes 

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -5,6 +5,9 @@ Release Notes
 -------------
 Backwards-incompatible rewrite of TDVP!
 
+Note that measurment functions for simulations need to be updated to accept another `model` parameter
+
+
 Changelog
 ---------
 
@@ -12,6 +15,8 @@ Backwards incompatible changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Replace the :class:`~tenpy.algorithms.tdvp.TDVPEngine` with a new version. 
   The previous one is for now still available as :class:`~tenpy.algorithms.tdvp.OldTDVPEngine`.
+- Measurement functions now have to take another argument `model` as well, which matches the indexing/sites of `psi`.
+  This helps to avoid special cases for grouped sites and `OrthogonalExciations`.
 - Add more fine grained sweep convergence checks for the :class:`~tenpy.algorithms.mps_common.VariationalCompression` (used when applying an MPO to an MPS!).
   In this context, we renamed the parameter `N_sweeps` to :cfg:option:`VariationalCompression.max_sweeps`.
   Further, we added the parameter :cfg:option:`VariationalCompression.min_sweeps` and :cfg:option:`VariationalCompression.tol_theta_diff`
@@ -29,7 +34,7 @@ Added
 - Allow non-trivial :attr:`~tenpy.models.lattice.Lattice.position_disorder` for lattices.
 - Option `fix_u` for :func:`~tenpy.simulations.measurement.onsite_expectation_value`.
 - Lattice :attr:`~tenpy.models.lattice.Lattice.cylinder_axis`.
-- Random number generator :attr:`~tenpy.models.model.Model.rng` for models.
+- Random number generator :attr:`~tenpy.models.model.Model.rng` for models. Any randomness of model (parameters) should use this!
 - :meth:`~tenpy.models.aklt.AKLTChain.psi_AKLT` for the exact MPS ground state of (spin-1/2) AKLT chain.
 - :func:`~tenpy.simulations.simulation.init_simulation` and :func:`~tenpy.simulations.simulation.init_simulation_from_checkpoint` for debugging or post-simulation measurement.
 - :func:`~tenpy.linalg.np_conserved.orthogonal_columns` constructing orthogonal columns to a given (rectangular) matrix.

--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -5,7 +5,7 @@ Release Notes
 -------------
 Backwards-incompatible rewrite of TDVP!
 
-Note that measurment functions for simulations need to be updated to accept another `model` parameter
+Note that measurement functions for simulations need to be updated to accept a `model` keyword argument.
 
 
 Changelog
@@ -17,6 +17,7 @@ Backwards incompatible changes
   The previous one is for now still available as :class:`~tenpy.algorithms.tdvp.OldTDVPEngine`.
 - Measurement functions now have to take another argument `model` as well, which matches the indexing/sites of `psi`.
   This helps to avoid special cases for grouped sites and `OrthogonalExciations`.
+  Moreover, we renamed all measurement functions to start with ``m_`` to clarify their usage, and renamed the (optional) argument `key` to `results_key`.
 - Add more fine grained sweep convergence checks for the :class:`~tenpy.algorithms.mps_common.VariationalCompression` (used when applying an MPO to an MPS!).
   In this context, we renamed the parameter `N_sweeps` to :cfg:option:`VariationalCompression.max_sweeps`.
   Further, we added the parameter :cfg:option:`VariationalCompression.min_sweeps` and :cfg:option:`VariationalCompression.tol_theta_diff`

--- a/doc/intro/measurements.rst
+++ b/doc/intro/measurements.rst
@@ -1,0 +1,154 @@
+Measurements for Simulations
+============================
+
+Rationale
+---------
+
+When we run a simulation performing a time evolution, we are interested in measurements
+after every (n-th) time step, but it would be too costly (in terms of disk space) to save the
+full psi at each time step; we only have the ``|psi(t)>`` *during* the simulation, not afterwards.
+Hence, we need to define what measurements we want to perform for a given simulation **before**
+running it.
+
+.. note ::
+    For variational ground state searches, e.g. DMRG, the situation is better: we're not
+    interested in how we got to the ground state, but only properties of the ground state itselft.
+    In this case, we can first run DMRG, save the state, and then perform additional
+    measurements and analysis *after* finishing the simulation, so it is not crucial to
+    define all the measurements before the simulation.
+
+The setup for simulations in TeNPy is as follows.
+
+1) For each measurement that is to be done, we need a measurement function that evaluates
+   whatever we want to measure, e.g., the expectation value or correlation function of some operators.
+   If needed, you can define your own, custom functions.
+2) For a given simulation, we specify the list of measurement functions in the simulation parameter
+   :cfg:option:`Simulation.connect_measurements`.
+3) When the simulation runs, it calls the :meth:`~tenpy.simulations.Simulation.make_measurements` method
+   each time a set of measurements should be performed, e.g. on the initial state, during the time 
+   evolution, and on the final state.
+   This causes a call to each of the measurement functions specified in
+   the :cfg:option:`Simulation.connect_measurements` parameter, passing the current state
+   ``psi, model, simulation`` as arguments (possibly amongst other keyword arguments 
+   also specified in :cfg:option:`Simulation.connect_measurements`).
+   Moreover, it passes a dictionary ``results``, in which measurement results should be saved.
+   At the end of `make_measurements`, the simulation class merges the obtained results 
+   into the collection :attr:`~tenpy.simulations.Simulation.results` of all previous measurements
+4) At the end of simulation, the `results` are saved and returned for further analysis (e.g. plotting).
+
+
+Measurement functions
+---------------------
+
+In the simplest case, a measurement function is just a function, which can take the keyword arguments
+``results, psi, model, simulation`` and saves the measurement results in the dictionary `results`.
+The other arguments `psi` and `model` are the current MPS and model that can be used for measurements, 
+and `simulation` gives access to the full simulation class, in case other addiontal data is needed.
+
+Within TeNPy, we use the convention that measurement functions (taking these arguments and saving to `results` instead
+of simply returning values) start with an ``m_`` in their name.
+A few generic measurement functions are defined in :mod:`~tenpy.simulations.measurement`.
+
+As a first, somewhat trivial example, let us look at the source code of
+:func:`tenpy.simulations.measurement.m_entropy`::
+
+    def m_entropy(results, psi, model, simulation, results_key='entropy'):
+        results[results_key] = psi.entanglement_entropy()
+
+As you can see, it's a simple wrapper around the MPS method :meth:`~tenpy.networks.mps.MPS.entanglement_entropy`.
+Note that usually the `psi` and `model` arguments are the same as the simulation attributes 
+``simulation.psi`` and ``simulation.model``, but they can be different in certain cases, e.g. when grouping sites.
+In most cases, you should directly use the passed `psi` and `model`.
+
+Of course, you can also do some actual calculations in the measurement functions.
+A good example of this is the :func:`tenpy.simulations.measurement.m_onsite_expectation_value` - take a look at it's
+source code. Another example could be the `m_pollmann_turner_inversion` measurement function defined in the
+:doc:`/examples/model_custom` example from the :doc:`/intro/simulations` guide.
+
+
+The connect_measurements parameter
+----------------------------------
+
+The :cfg:option:`Simulation.connect_measurements` parameter is a list with one entry for each measurment function to be
+used. Each function is specified by a tuple ``module, func_name, extra_kwargs, priority``.
+Here, `module` and `func` specfiy the module and name of the function, `extra_kwargs` are (optional) additional keyword
+arguments to be given to the function, and `priority` allows to control the order in which the measurement functions get
+called. The latter is usefull if you want to "post-process" results of another measurement function.
+
+For example, say you want to measure local expectation values of both `Sz` and `Sx` with
+:func:`tenpy.simulations.measurment.m_onsite_expectation_value`, then you could use
+
+.. code :: yaml
+
+    connect_measurement
+        - - tenpy.simulations.measurement
+          - m_onsite_expectation_value
+          - opname: Sx
+        - - tenpy.simulations.measurement
+          - m_onsite_expectation_value
+          - opname: Sz
+
+These measurement functions have default `results_key` under which they save values in the `results`, so you can then
+read out ``results['<Sx>']`` and ``results['<Sz>']`` in the simulation results.
+If you want other keys, you can explicitly specify them with the `results_key` argument of the function, e.g.,
+
+.. code :: yaml
+
+    connect_measurement:
+        - - tenpy.simulations.measurement
+          - m_onsite_expectation_value
+          - opname: Sx
+            results_key: X_i     # save as results['X_i']
+        - - tenpy.simulations.measurement
+          - m_onsite_expectation_value
+          - opname: Sz
+            results_key: Z_i     # save as results['Z_i']
+
+
+Some measurements are actually that common that they get added by default to the simulations (unless you explicitly
+disable them with :cfg:option:`Simulation.use_default_measurements`); for example the :func:`tenpy.simulations.measurement.m_entropy`
+is measured for any simulation, as it appears in :attr:`~tenpy.simulations.simulation.Simulation.default_measurements`.
+
+Often, what you want to measure is just calling a method of the state `psi`, so there is a special syntax in the
+`connect_measurement` parameter:
+if you **specify the first entry for  to be `psi_method`, `model_method` or `simulation_method`**, you can call a method of the
+corresponding classes. 
+As for global measurement functions, we pass the corresponding ``results, psi, model, simulation`` keyword arguments,
+e.g. `psi_method` measurement functions need to accept ``results, model, simulation`` as arguments, and
+`simulation_method` measurement functions should accept ``results, psi, model``.
+
+This is already very usefull to call measurement functions defined inside (custom) models or simulation classes, 
+yet methods of `psi` don't follow the measurement function call structure, but simply return values.
+For those cases, you can use another special syntax, namely to **simply add `wrap` before the function name**.
+In this case, we don't pass ``results, psi, model, simulation``, but simply save the return values of the function
+in the results, under the `results_key` that gets passed as extra keyword argument,
+see :func:`~tenpy.simulations.measurment.measurment_wrapper`.
+The `results_key` defaults to the function name.
+
+To make this clearer, let's extend the example above with more measurements:
+
+.. code :: yaml
+
+    connect_measurement:
+        - - tenpy.simulations.measurement
+          - m_onsite_expectation_value
+          - opname: Sx
+        - - tenpy.simulations.measurement
+          - m_onsite_expectation_value
+          - opname: Sz
+        - - psi_method
+          - wrap correlation_function   # call psi.correlation_function()
+          - results_key: '<Sz Sz>'      # save returned value as results["<Sz Sz>"]
+            ops1: Sz                    # other (necessary) arguments to psi.correlation_function
+            ops2: Sz
+        - - simulation_method
+          - wrap walltime               # "measure" wall clock time it took to run so far
+        - - tenpy.tools.process
+          - wrap memory_usage           # "measure" the current RAM usage in MB
+
+
+.. note ::
+
+   The `*_method` and `wrap` syntax are (currently) special to the :cfg:option:`Simulation.connect_measurements`
+   parameter, and do not apply to e.g. :cfg:option:`Simulation.connect_algorithm_checkpoint`, which uses an analogous
+   setup to allow calling functions at each algorithm checkpoint.

--- a/doc/intro/simulations.rst
+++ b/doc/intro/simulations.rst
@@ -171,8 +171,10 @@ such that we can read out the final half-chain entanglement entropy like this::
     (2, 31)
     >>> print(results['measurements']['entropy'][-1, (L-1)//2])
 
-Here, the shape of the entropy array is ``(2, 31)`` since 2 is the number of measurements, and 31=L-1 the number of bonds.
-Note that you can easily read out the simulation parameters, even default ones.
+Here, the shape of the entropy array is ``(2, 31)`` since 2 is the number of measurements 
+(one on the initial state, one on the final ground state), and 31=L-1 the number of bonds.
+Note that you can easily read out the simulation parameters, even default ones that are only implicitly defined
+somewhere in the code!
 
 
 Adding more measurements

--- a/doc/intro/simulations.rst
+++ b/doc/intro/simulations.rst
@@ -180,7 +180,7 @@ somewhere in the code!
 Adding more measurements
 ------------------------
 Most simulation classes have only a few :attr:`~tenpy.simulations.Simulation.default_measurements`, but you can easily
-add more under :cfg:option:`Simulation.connect_measurements`. Each measurement is simply a function that is
+add more with the :cfg:option:`Simulation.connect_measurements` parameters. Each measurement is simply a function that is
 called whenever the simulation wants to measure, e.g. with the initial state, at the end of the simulation, and for time
 evolutions also during the evolution. The default measurement functions are defined in
 the module :mod:`tenpy.simulations.measurement`; :func:`~tenpy.simulations.measurement.measurement_index` documents what
@@ -195,7 +195,7 @@ following example shows.
         - onsite_expectation_value
         - opname: Sz
       - - psi_method
-        - correlation_function
+        - wrap correlation_function
         - key: '<Sp_i Sm_j>'
           ops1: Sp
           ops2: Sm
@@ -208,7 +208,7 @@ Note the indentation and minus signs here: this yaml syntax is equivalent to the
                                'onsite_expectation_value',
                                {'opname': 'Sz'}],
                               ['psi_method',
-                               'correlation_function',
+                               'wrap correlation_function',
                                {'key': '<Sp_i Sm_j>',
                                 'ops1': 'Sp',
                                 'ops2': 'Sm'}]]}
@@ -216,6 +216,7 @@ Note the indentation and minus signs here: this yaml syntax is equivalent to the
 The measurement functions add the values under the specified `key` to the `results` returned and saved by the
 simulation, e.g. for the above measurements you can now read out ``results['measurements']['<Sz>']`` (default key) and ``results['measurements']['<Sp_i Sm_j>']``.
 
+For more details, see the extra guide :doc:`/intro/measurements`.
 
 A full example with custom python code
 --------------------------------------
@@ -266,7 +267,7 @@ e.g., in DMRG at the end of a sweep.
 The checkpoints are saved to the same filename as the desired final output file, and get overwritten by each following save at a checkpoint.
 You can check ``results['finished']`` in the output file to see whether it finished.
 
-You can then resume the simulation using the function :func:`~tenpy.resume_from_checkpoint`.
+You can then resume the simulation using the function :func:`tenpy.resume_from_checkpoint`.
 
 Note that you can also adjust parameters for the resume. 
 For example, if you find that a DMRG result (even a finished one) is not yet fully converged in bond dimension, you can "resume" the simulation

--- a/doc/intro/simulations.rst
+++ b/doc/intro/simulations.rst
@@ -184,18 +184,17 @@ evolutions also during the evolution. The default measurement functions are defi
 the module :mod:`tenpy.simulations.measurement`; :func:`~tenpy.simulations.measurement.measurement_index` documents what
 arguments a measurement function should have. 
 In the simplest case, you just specify the module and function name, but you can also add more arguments, as the
-following example shows:
+following example shows.
 
 .. code-block :: yaml
 
-    connect_measurements: 
+    connect_measurements:
       - - tenpy.simulations.measurement
         - onsite_expectation_value
         - opname: Sz
-      - - tenpy.simulations.measurement
-        - psi_method
-        - method: correlation_function
-          key: '<Sp_i Sm_j>'
+      - - psi_method
+        - correlation_function
+        - key: '<Sp_i Sm_j>'
           ops1: Sp
           ops2: Sm
 
@@ -206,10 +205,9 @@ Note the indentation and minus signs here: this yaml syntax is equivalent to the
     {'connect_measurements': [['tenpy.simulations.measurement',
                                'onsite_expectation_value',
                                {'opname': 'Sz'}],
-                              ['tenpy.simulations.measurement',
-                               'psi_method',
+                              ['psi_method',
+                               'correlation_function',
                                {'key': '<Sp_i Sm_j>',
-                                'method': 'correlation_function',
                                 'ops1': 'Sp',
                                 'ops2': 'Sm'}]]}
 

--- a/doc/introductions.rst
+++ b/doc/introductions.rst
@@ -15,6 +15,7 @@ If you are new to TeNPy, read the :doc:`intro/overview`.
     intro/input_output
     intro/logging
     intro/options
+    intro/measurements
     intro/npc
     intro/JordanWigner
     intro/dmrg-protocol

--- a/examples/model_custom.py
+++ b/examples/model_custom.py
@@ -47,7 +47,7 @@ class AnisotropicSpin1Chain(CouplingMPOModel, NearestNeighborModel):
             self.add_onsite(D, u, 'Sz Sz')
 
 
-def pollmann_turner_inversion(results, psi, simulation, tol=0.01):
+def pollmann_turner_inversion(results, psi, model, simulation, tol=0.01):
     """Measurement function for equation 15 of :arxiv:`1204.0704`.
 
     See :func:`~tenpy.simulations.measurement.measurement_index` for the call structure.

--- a/examples/model_custom.py
+++ b/examples/model_custom.py
@@ -47,7 +47,7 @@ class AnisotropicSpin1Chain(CouplingMPOModel, NearestNeighborModel):
             self.add_onsite(D, u, 'Sz Sz')
 
 
-def pollmann_turner_inversion(results, psi, model, simulation, tol=0.01):
+def m_pollmann_turner_inversion(results, psi, model, simulation, tol=0.01):
     """Measurement function for equation 15 of :arxiv:`1204.0704`.
 
     See :func:`~tenpy.simulations.measurement.measurement_index` for the call structure.

--- a/examples/simulation_custom.yml
+++ b/examples/simulation_custom.yml
@@ -44,10 +44,10 @@ connect_measurements:
     - onsite_expectation_value
     - opname: Sz
   - - psi_method
-    - correlation_function
+    - wrap correlation_function
     - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
   - - model_custom               # module where function is defined
     - pollmann_turner_inversion  # function defined in the module to be measured
-    # - extra: keyword_arguments # any additional keyword arguments to be given to the function.
+    # - extra: argument          # any additional keyword argument(s) to be given to the function.

--- a/examples/simulation_custom.yml
+++ b/examples/simulation_custom.yml
@@ -41,13 +41,13 @@ algorithm_params:
 
 connect_measurements: 
   - - tenpy.simulations.measurement
-    - onsite_expectation_value
+    - m_onsite_expectation_value
     - opname: Sz
   - - psi_method
     - wrap correlation_function
-    - key: '<Sp_i Sm_j>'
+    - results_key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
-  - - model_custom               # module where function is defined
-    - pollmann_turner_inversion  # function defined in the module to be measured
-    # - extra: argument          # any additional keyword argument(s) to be given to the function.
+  - - model_custom                 # module where function is defined
+    - m_pollmann_turner_inversion  # function defined in the module to be measured
+    # - extra: argument            # any additional keyword argument(s) to be given to the function.

--- a/examples/simulation_custom.yml
+++ b/examples/simulation_custom.yml
@@ -43,11 +43,11 @@ connect_measurements:
   - - tenpy.simulations.measurement
     - onsite_expectation_value
     - opname: Sz
-  - - tenpy.simulations.measurement
-    - psi_method
-    - method: correlation_function
-      key: '<Sp_i Sm_j>'
+  - - psi_method
+    - correlation_function
+    - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
-  - - model_custom  # module where function is defined
-    - pollmann_turner_inversion
+  - - model_custom               # module where function is defined
+    - pollmann_turner_inversion  # function defined in the module to be measured
+    # - extra: keyword_arguments # any additional keyword arguments to be given to the function.

--- a/examples/yaml/details_simulation.yml
+++ b/examples/yaml/details_simulation.yml
@@ -39,9 +39,11 @@ connect_measurements:
   - - tenpy.simulations.measurement
     - onsite_expectation_value
     - opname: Sz
-  - - tenpy.simulations.measurement
-    - psi_method
-    - method: correlation_function
-      key: '<Sp_i Sm_j>'
+  - - psi_method
+    - correlation_function
+    - key: '<Sp_i Sm_jasdf>'
       ops1: Sp
       ops2: Sm
+  - - simulation_method
+    - m_walltime
+    - key: walltime

--- a/examples/yaml/details_simulation.yml
+++ b/examples/yaml/details_simulation.yml
@@ -40,10 +40,9 @@ connect_measurements:
     - onsite_expectation_value
     - opname: Sz
   - - psi_method
-    - correlation_function
-    - key: '<Sp_i Sm_jasdf>'
+    - wrap correlation_function
+    - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
   - - simulation_method
-    - m_walltime
-    - key: walltime
+    - wrap walltime

--- a/examples/yaml/details_simulation.yml
+++ b/examples/yaml/details_simulation.yml
@@ -37,11 +37,11 @@ algorithm_params:
 
 connect_measurements: 
   - - tenpy.simulations.measurement
-    - onsite_expectation_value
+    - m_onsite_expectation_value
     - opname: Sz
   - - psi_method
     - wrap correlation_function
-    - key: '<Sp_i Sm_j>'
+    - results_key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
   - - simulation_method

--- a/examples/yaml/minimal_ExpMPOEvolution.yml
+++ b/examples/yaml/minimal_ExpMPOEvolution.yml
@@ -32,10 +32,8 @@ connect_measurements:
   - - tenpy.simulations.measurement
     - onsite_expectation_value
     - opname: Sz
-  - - tenpy.simulations.measurement
-    - psi_method
-    - method: correlation_function
-      key: '<Sp_i Sm_j>'
+  - - psi_method
+    - correlation_function
+    - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
-

--- a/examples/yaml/minimal_ExpMPOEvolution.yml
+++ b/examples/yaml/minimal_ExpMPOEvolution.yml
@@ -34,6 +34,6 @@ connect_measurements:
     - opname: Sz
   - - psi_method
     - wrap correlation_function
-    - key: '<Sp_i Sm_j>'
+    - results_key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm

--- a/examples/yaml/minimal_ExpMPOEvolution.yml
+++ b/examples/yaml/minimal_ExpMPOEvolution.yml
@@ -33,7 +33,7 @@ connect_measurements:
     - onsite_expectation_value
     - opname: Sz
   - - psi_method
-    - correlation_function
+    - wrap correlation_function
     - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm

--- a/examples/yaml/minimal_TDVP.yml
+++ b/examples/yaml/minimal_TDVP.yml
@@ -30,7 +30,7 @@ connect_measurements:
     - onsite_expectation_value
     - opname: Sz
   - - psi_method
-    - correlation_function
+    - wrap correlation_function
     - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm

--- a/examples/yaml/minimal_TDVP.yml
+++ b/examples/yaml/minimal_TDVP.yml
@@ -29,10 +29,8 @@ connect_measurements:
   - - tenpy.simulations.measurement
     - onsite_expectation_value
     - opname: Sz
-  - - tenpy.simulations.measurement
-    - psi_method
-    - method: correlation_function
-      key: '<Sp_i Sm_j>'
+  - - psi_method
+    - correlation_function
+    - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
-

--- a/examples/yaml/minimal_TDVP.yml
+++ b/examples/yaml/minimal_TDVP.yml
@@ -31,6 +31,6 @@ connect_measurements:
     - opname: Sz
   - - psi_method
     - wrap correlation_function
-    - key: '<Sp_i Sm_j>'
+    - results_key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm

--- a/examples/yaml/minimal_TEBD.yml
+++ b/examples/yaml/minimal_TEBD.yml
@@ -30,7 +30,7 @@ connect_measurements:
     - onsite_expectation_value
     - opname: Sz
   - - psi_method
-    - correlation_function
+    - wrap correlation_function
     - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm

--- a/examples/yaml/minimal_TEBD.yml
+++ b/examples/yaml/minimal_TEBD.yml
@@ -29,10 +29,8 @@ connect_measurements:
   - - tenpy.simulations.measurement
     - onsite_expectation_value
     - opname: Sz
-  - - tenpy.simulations.measurement
-    - psi_method
-    - method: correlation_function
-      key: '<Sp_i Sm_j>'
+  - - psi_method
+    - correlation_function
+    - key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm
-

--- a/examples/yaml/minimal_TEBD.yml
+++ b/examples/yaml/minimal_TEBD.yml
@@ -31,6 +31,6 @@ connect_measurements:
     - opname: Sz
   - - psi_method
     - wrap correlation_function
-    - key: '<Sp_i Sm_j>'
+    - results_key: '<Sp_i Sm_j>'
       ops1: Sp
       ops2: Sm

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -936,7 +936,7 @@ def multi_sites_combine_charges(sites, same_charges=[]):
     This function adjusts the charges of these sites such that they can be used together.
 
     .. deprecated :: 0.7.3
-        Deprecated in favore of the new, more powerful
+        Deprecated in favor of the new, more powerful
         :func:`~tenpy.networks.site.set_common_charges`.
         Be aware of the slightly different argument structure though, namely that
         this function keeps charges not included in `same_charges`, whereas you need

--- a/tenpy/simulations/__init__.py
+++ b/tenpy/simulations/__init__.py
@@ -17,8 +17,8 @@ The classes provided here provide a structure for the whole setup of simulations
 from . import measurement, simulation, ground_state_search, time_evolution
 
 __all__ = [
-    "simulation",
     "measurement",
+    "simulation",
     "ground_state_search",
     "time_evolution",
 ]

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -19,12 +19,31 @@ import functools
 import warnings
 
 __all__ = [
+    'measurement_wrapper', 'm_measurement_index', 'm_bond_dimension', 'm_bond_energies',
+    'm_simulation_parameter', 'm_energy_MPO', 'm_entropy', 'm_onsite_expectation_value',
+    'm_correlation_length', 'm_evolved_time',
     'measurement_index', 'bond_dimension', 'bond_energies', 'simulation_parameter', 'energy_MPO',
-    'entropy', 'onsite_expectation_value', 'correlation_length', 'psi_method', 'evolved_time'
+    'entropy', 'onsite_expectation_value', 'correlation_length',  'evolved_time', 'psi_method',
 ]
 
 
-def measurement_index(results, psi, model, simulation, key='measurement_index'):
+def measurement_wrapper(function, results_key, **kwargs):
+    if results_key is None:
+        results_key = function.__name__
+
+    #  @functools.wraps(function)
+    def measurement_call(results, psi, model, simulation, **kwargs):
+        if results_key in results:
+            raise ValueError(f"key {results_key!r} already exists in `results`, "
+                             "measurement would overwrite data. "
+                             "Probably a measurement function used multiple times!")
+        res = function(**kwargs)
+        results[results_key] = res
+
+    return measurement_call
+
+
+def m_measurement_index(results, psi, model, simulation, results_key='measurement_index'):
     """'Measure' the index of how many mearuements have been performed so far.
 
     The parameter description below documents the common interface of all measurement
@@ -51,87 +70,88 @@ def measurement_index(results, psi, model, simulation, key='measurement_index'):
         See :meth:`~tenpy.simulations.simulation.Simulation.get_measurement_psi_model`.
     simulation : :class:`~tenpy.simulations.simulation.Simulation`
         The simulation class. This gives also access to the `model`, algorithm `engine`, etc.
-    key : str
+    results_key : str
         The key under which to save data in `results`.
         For some measurement functions optional, e.g in this case.
+        Note that a single measurement function can add results under multiple keys, if desired.
     **kwargs :
         Other optional keyword arguments for individual measurement functions.
         Those are documented inside each measurement function.
     """
-    index = len(simulation.results.get('measurements', {}).get(key, []))
-    results[key] = index
+    index = len(simulation.results.get('measurements', {}).get(results_key, []))
+    results[results_key] = index
 
 
-def bond_dimension(results, psi, model, simulation, key='bond_dimension'):
+def m_bond_dimension(results, psi, model, simulation, results_key='bond_dimension'):
     """'Measure' the bond dimension of an MPS.
 
     Parameters
     ----------
-    results, psi, model, simulation, key :
+    results, psi, model, simulation, results_key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    results[key] = psi.chi
+    results[results_key] = psi.chi
 
 
-def bond_energies(results, psi, model, simulation, key='bond_energies'):
+def m_bond_energies(results, psi, model, simulation, results_key='bond_energies'):
     """Measure the energy of an MPS.
 
     Parameters
     ----------
-    results, psi, model, simulation, key :
+    results, psi, model, simulation, results_key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    results[key] = model.bond_energies(psi)
+    results[results_key] = model.bond_energies(psi)
 
 
-def simulation_parameter(results, psi, model, simulation, recursive_key, key=None, **kwargs):
+def m_simulation_parameter(results, psi, model, simulation, recursive_key, results_key=None, **kwargs):
     """Dummy meausurement of a simulation parameter.
 
     This can be useful e.g. if you have a time-dependent hamiltonian parameter.
 
     Parameters
     ----------
-    results, psi, simulation, key :
+    results, psi, simulation, results_key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     recursive_key : str
         Recursive key of the simulation parameter to be read out.
     default, separators :
         Remaining arguments of :func:`~tenpy.tools.misc.get_recursive`.
     """
-    if key is None:
-        key = recursive_key
-    results[key] = get_recursive(simulation.options, recursive_key, **kwargs)
+    if results_key is None:
+        results_key = recursive_key
+    results[results_key] = get_recursive(simulation.options, recursive_key, **kwargs)
 
 
-def energy_MPO(results, psi, model, simulation, key='energy_MPO'):
+def m_energy_MPO(results, psi, model, simulation, results_key='energy_MPO'):
     """Measure the energy of an MPS by evaluating the MPS expectation value.
 
     Parameters
     ----------
-    results, psi, model, simulation, key :
+    results, psi, model, simulation, results_key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
     psi = simulation.psi  # take original psi, possibly grouped, but compatible with simulation.model
     if psi.bc == 'segment':
         init_env_data = simulation.init_env_data
         E = MPOEnvironment(psi, simulation.model.H_MPO, psi, **init_env_data).full_contraction(0)
-        results[key] = E - simulation.results['ground_state_energy']
+        results[results_key] = E - simulation.results['ground_state_energy']
     else:
-        results[key] = simulation.model.H_MPO.expectation_value(psi)
+        results[results_key] = simulation.model.H_MPO.expectation_value(psi)
 
 
-def entropy(results, psi, model, simulation, key='entropy'):
+def m_entropy(results, psi, model, simulation, results_key='entropy'):
     """Measure the entropy at all bonds of an MPS.
 
     Parameters
     ----------
-    results, psi, simulation, key :
+    results, psi, simulation, results_key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    results[key] = psi.entanglement_entropy()
+    results[results_key] = psi.entanglement_entropy()
 
 
-def onsite_expectation_value(results, psi, model, simulation, opname, key=None, fix_u=None,
+def m_onsite_expectation_value(results, psi, model, simulation, opname, results_key=None, fix_u=None,
                              **kwargs):
     """Measure expectation values of an onsite operator.
 
@@ -139,11 +159,11 @@ def onsite_expectation_value(results, psi, model, simulation, opname, key=None, 
     (possibly dropping y and/or u if they are trivial), not by the MPS index.
     Note that this makes the result independent of the way the MPS winds through the lattice.
 
-    The key defaults to ``f"<{opname}>"``.
+    The results_key defaults to ``f"<{opname}>"``.
 
     Parameters
     ----------
-    results, psi, model, simulation, key:
+    results, psi, model, simulation, results_key:
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     opname : str
         The operator to be measured.
@@ -151,31 +171,33 @@ def onsite_expectation_value(results, psi, model, simulation, opname, key=None, 
     fix_u : None | int
         Select a (lattice) unit cell index to restrict measurements to.
     """
-    if key is None:
+    if results_key is None:
         if not isinstance(opname, str):
             raise ValueError("can't auto-determine key for operator " + repr(opname))
-        key = f"<{opname}>"
-    if key in results:
-        raise ValueError(f"key {key!r} already exists in results")
-    lattice = model.lat
+        results_key = f"<{opname}>"
+    if results_key in results:
+        raise ValueError(f"key {results_key!r} already exists in results")
     if fix_u is not None:
-        kwargs['sites'] = lattice.mps_idx_fix_u(fix_u)
+        kwargs['sites'] = model.lat.mps_idx_fix_u(fix_u)
+
+    # the actual "measurement"
     exp_vals = psi.expectation_value(opname, **kwargs)
+
     assert exp_vals.ndim == 1  # here exp_vals is given in MPS indices i
     # now reshape/reorder to index (x, y, u)
     if fix_u is None and 'sites' in kwargs:
-        exp_vals = lattice.mps2lat_values_masked(exp_vals, mps_inds=kwargs['sites'])
+        exp_vals = model.lat.mps2lat_values_masked(exp_vals, mps_inds=kwargs['sites'])
     else:
-        exp_vals = lattice.mps2lat_values(exp_vals, u=fix_u)
-    results[key] = exp_vals
+        exp_vals = model.lat.mps2lat_values(exp_vals, u=fix_u)
+    results[results_key] = exp_vals
 
 
-def correlation_length(results, psi, model, simulation, key='correlation_length', unit=None, **kwargs):
+def m_correlation_length(results, psi, model, simulation, results_key='correlation_length', unit=None, **kwargs):
     """Measure the correlaiton of an infinite MPS.
 
     Parameters
     ----------
-    results, psi, model, simulation, key:
+    results, psi, model, simulation, results_key:
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     unit : ``'MPS_sites' | 'MPS_sites_ungrouped' | 'lattice_rings'``
         The unit in which the correlation length is returned, see the warning in
@@ -219,23 +241,19 @@ def correlation_length(results, psi, model, simulation, key='correlation_length'
         corr = corr * psi.grouped / lat.N_sites_per_ring / np.inner(lat.basis[0], lat.cylinder_axis)
     else:
         raise ValueError("can't understand unit=" + repr(unit))
-    results[key] = corr
+    results[results_key] = corr
 
+def m_evolved_time(results, psi, model, simulation, results_key='evolved_time'):
+    """Measure the time evolved by the engine, ``engine.evolved_time``.
 
-def measurement_wrapper(function, key, **kwargs):
-    if key is None:
-        key = function.__name__
+    "Measures" :attr:`tenpy.algorithms.algorithm.TimeEvolutionAlgorithm.evolved_time`.
 
-    #  @functools.wraps(function)
-    def measurement_call(results, psi, model, simulation, **kwargs):
-        if key in results:
-            raise ValueError(f"key {key!r} already exists in `results`, "
-                             "measurement would overwrite data. "
-                             "Probably a measurement function used multiple times!")
-        res = function(**kwargs)
-        results[key] = res
-
-    return measurement_call
+    Parameters
+    ----------
+    results, psi, model, simulation, results_key:
+        See :func:`~tenpy.simulation.measurement.measurement_index`.
+    """
+    results[results_key] = simulation.engine.evolved_time
 
 
 def psi_method(results, psi, model, simulation, method, key=None, **kwargs):
@@ -250,28 +268,28 @@ def psi_method(results, psi, model, simulation, method, key=None, **kwargs):
 
             An old python entry for connect_measurements
                 ['tenpy.simulations.measurement',
-                'psi_method',
-                'correlation_function',
-                {'key': '<Sp_i Sm_j>',
-                'ops1': 'Sp',
-                'ops2': 'Sm'}]
+                 'psi_method',
+                 'correlation_function',
+                 {'key': '<Sp_i Sm_j>',
+                  'ops1': 'Sp',
+                  'ops2': 'Sm'}]
             can get replaced with new entry:
                 ['psi_method',
-                'wrap correlation_function',
-                {'key': '<Sp_i Sm_j>',
-                'ops1': 'Sp',
-                'ops2': 'Sm'}]
+                 'wrap correlation_function',
+                 {'results_key': '<Sp_i Sm_j>',
+                  'ops1': 'Sp',
+                  'ops2': 'Sm'}]
             Similarly, an old yaml entry for connect_measurements
                 - - tenpy.simulations.measurement
-                - psi_method
-                - method: correlation_function
+                  - psi_method
+                  - method: correlation_function
                     key: '<Sp_i Sm_j>'
                     ops1: Sp
                     ops2: Sm
             can get replaced with new yaml:
                 - - psi_method
-                - wrap correlation_function
-                - key: '<Sp_i Sm_j>'
+                  - wrap correlation_function
+                  - results_key: '<Sp_i Sm_j>'
                     ops1: Sp
                     ops2: Sm
 
@@ -279,6 +297,7 @@ def psi_method(results, psi, model, simulation, method, key=None, **kwargs):
         Note the additional "wrap " in the function name, which indicates that the specified
         function just returns the results and does not take ``results, model, simulation`` as
         arguments, hence we need a wrapper function for the measurement.
+        Also note the renaming of `key` to `results_key`.
 
     Parameters
     ----------
@@ -291,9 +310,9 @@ def psi_method(results, psi, model, simulation, method, key=None, **kwargs):
     """
     # extract the deprecation comment from the doc string
     _psi_method_deprecated_msg = '\n'.join([line[8:] for line in
-                                            psi_method.__doc__.splitlines()[4:40]])
+                                            psi_method.__doc__.splitlines()[4:42]])
     warnings.warn(_psi_method_deprecated_msg, FutureWarning)
-    _m_psi_method_wrapped(results, psi, model, simulation, method, key=key, **kwargs)
+    _m_psi_method_wrapped(results, psi, model, simulation, method, results_key=key, **kwargs)
 
 
 # the following wrapper functions _m_{psi,model}_method_[wrapped] are used
@@ -305,14 +324,14 @@ def _m_psi_method(results, psi, model, simulation, func_name, **kwargs):
     psi_method(results, model, simulation, **kwargs)
 
 
-def _m_psi_method_wrapped(results, psi, model, simulation, func_name, key, **kwargs):
-    if key in results:
-        raise ValueError(f"key {key!r} already exists in `results`, "
+def _m_psi_method_wrapped(results, psi, model, simulation, func_name, results_key, **kwargs):
+    if results_key in results:
+        raise ValueError(f"key {results_key!r} already exists in `results`, "
                          "measurement would overwrite data. "
                          "Probably a measurement function used multiple times!")
     psi_method = getattr(psi, func_name)
     res = psi_method(**kwargs)
-    results[key] = res
+    results[results_key] = res
 
 
 def _m_model_method(results, psi, model, simulation, func_name, **kwargs):
@@ -320,24 +339,72 @@ def _m_model_method(results, psi, model, simulation, func_name, **kwargs):
     model_method(results, psi, simulation, **kwargs)
 
 
-def _m_model_method_wrapped(results, psi, model, simulation, func_name, key, **kwargs):
-    if key in results:
-        raise ValueError(f"key {key!r} already exists in `results`, "
+def _m_model_method_wrapped(results, psi, model, simulation, func_name, results_key, **kwargs):
+    if results_key in results:
+        raise ValueError(f"key {results_key!r} already exists in `results`, "
                          "measurement would overwrite data. "
                          "Probably a measurement function used multiple times!")
     model_method = getattr(model, func_name)
     res = model_method(**kwargs)
-    results[key] = res
+    results[results_key] = res
+
+
+# Deprecated functions
+_deprecated_msg = ("renamed function and argument {0:s}(..., key) to m_{0:s}(..., results_key), "
+                   "update corresponding entry in simulation parameter `connect_measurements`!")
+
+
+def measurement_index(results, psi, model, simulation, key='measurement_index'):
+    """Deprecated version of :func:`m_measurement_index`."""
+    warnings.warn(_deprecated_msg.format("measurement_index"), FutureWarning)
+    m_measurement_index(results, psi, model, simulation, key)
+
+
+def bond_dimension(results, psi, model, simulation, key='bond_dimension'):
+    """Deprecated version of :func:`m_bond_dimension`."""
+    warnings.warn(_deprecated_msg.format("bond_dimension"), FutureWarning)
+    m_bond_dimension(results, psi, model, simulation, key)
+
+
+def bond_energies(results, psi, model, simulation, key='bond_energies'):
+    """Deprecated version of :func:`m_bond_energies`."""
+    warnings.warn(_deprecated_msg.format("bond_energies"), FutureWarning)
+    m_bond_dimension(results, psi, model, simulation, key)
+
+
+def simulation_parameter(results, psi, model, simulation, recursive_key, key=None, **kwargs):
+    """Deprecated version of :func:`m_simulation_parameter`."""
+    warnings.warn(_deprecated_msg.format("simulation_parameter"), FutureWarning)
+    m_simulation_parameter(results, psi, model, simulation, recursive_key, key, **kwargs)
+
+
+def energy_MPO(results, psi, model, simulation, key='energy_MPO'):
+    """Deprecated version of :func:`m_energy_MPO`."""
+    warnings.warn(_deprecated_msg.format("energy_MPO"), FutureWarning)
+    m_energy_MPO(results, psi, model, simulation, key)
+
+
+def entropy(results, psi, model, simulation, key='entropy'):
+    """Deprecated version of :func:`m_entroy`."""
+    warnings.warn(_deprecated_msg.format("entropy"), FutureWarning)
+    m_entropy(results, psi, model, simulation, key)
+
+
+def onsite_expectation_value(results, psi, model, simulation, opname, key=None, fix_u=None,
+                             **kwargs):
+    """Deprecated version of :func:`m_onsite_expectation_value`."""
+    warnings.warn(_deprecated_msg.format("onsite_expectation_value"), FutureWarning)
+    m_onsite_expectation_value(results, psi, model, simulation, opname, key, fix_u, **kwargs)
+
+
+def correlation_length(results, psi, model, simulation, key='correlation_length', unit=None,
+                       **kwargs):
+    """Deprecated version of :func:`m_correlation_length`."""
+    warnings.warn(_deprecated_msg.format("correlation_length"), FutureWarning)
+    m_correlation_length(results, psi, model, simulation, key, unit, **kwargs)
 
 
 def evolved_time(results, psi, model, simulation, key='evolved_time'):
-    """Measure the time evolved by the engine, ``engine.evolved_time``.
-
-    "Measures" :attr:`tenpy.algorithms.algorithm.TimeEvolutionAlgorithm.evolved_time`.
-
-    Parameters
-    ----------
-    results, psi, model, simulation, key:
-        See :func:`~tenpy.simulation.measurement.measurement_index`.
-    """
-    results[key] = simulation.engine.evolved_time
+    """Deprecated version of :func:`m_evolved_time`."""
+    warnings.warn(_deprecated_msg.format("evolved_time"), FutureWarning)
+    m_evolved_time(results, psi, model, simulation, key)

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -1,10 +1,14 @@
 """Functions to perform measurments during simulations.
 
 All measurement functions provided in this module support the interface used by the simulation
-class, i.e. they take the parameters documented in :func:`measurement_index` and write
+class, i.e. they take the parameters ``results, psi, model, simulation`` as keyword arguments,
+as documented in :func:`measurement_index` and write
 the measurement results into the `results` dictionary taken as argument.
+It can take extra keyword arguments that can be specified in
 
-As explained in :doc:`/intro/simulations`, you can easily add custom measurement functions.
+As briefly explained in :doc:`/intro/simulations`, you can easily add custom measurement functions.
+
+Full description and details in :doc:`/intro/measurements`.
 """
 # Copyright 2020-2021 TeNPy Developers, GNU GPLv3
 
@@ -77,7 +81,7 @@ def bond_energies(results, psi, model, simulation, key='bond_energies'):
     results, psi, model, simulation, key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    results[key] = simulation.model.bond_energies(psi)
+    results[key] = model.bond_energies(psi)
 
 
 def simulation_parameter(results, psi, model, simulation, recursive_key, key=None, **kwargs):
@@ -107,7 +111,7 @@ def energy_MPO(results, psi, model, simulation, key='energy_MPO'):
     results, psi, model, simulation, key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    psi = simulation.psi  # take original psi, possibly grouped, but compatible with model
+    psi = simulation.psi  # take original psi, possibly grouped, but compatible with simulation.model
     if psi.bc == 'segment':
         init_env_data = simulation.init_env_data
         E = MPOEnvironment(psi, simulation.model.H_MPO, psi, **init_env_data).full_contraction(0)
@@ -124,7 +128,7 @@ def entropy(results, psi, model, simulation, key='entropy'):
     results, psi, simulation, key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    results['entropy'] = psi.entanglement_entropy()
+    results[key] = psi.entanglement_entropy()
 
 
 def onsite_expectation_value(results, psi, model, simulation, opname, key=None, fix_u=None,

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -269,8 +269,8 @@ def psi_method(results, psi, model, simulation, method, key=None, **kwargs):
             An old python entry for connect_measurements
                 ['tenpy.simulations.measurement',
                  'psi_method',
-                 'correlation_function',
-                 {'key': '<Sp_i Sm_j>',
+                 {'method': 'correlation_function',
+                  'key': '<Sp_i Sm_j>',
                   'ops1': 'Sp',
                   'ops2': 'Sm'}]
             can get replaced with new entry:

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -230,12 +230,12 @@ def m_correlation_length(results, psi, model, simulation, results_key='correlati
     elif unit == 'MPS_sites_ungrouped':
         corr = corr * psi.grouped
     elif unit == 'lattice_rings':
-        lat = model.lattice
+        lat = model.lat
         if lat.N_sites_per_ring is None:
             raise ValueError("lattice doesn't define N_sites_per_ring")
         corr = corr * psi.grouped / lat.N_sites_per_ring
     elif unit == 'lattice_spacing':
-        lat = model.lattice
+        lat = model.lat
         if lat.N_sites_per_ring is None:
             raise ValueError("lattice doesn't define N_sites_per_ring")
         corr = corr * psi.grouped / lat.N_sites_per_ring / np.inner(lat.basis[0], lat.cylinder_axis)

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -10,11 +10,13 @@ As explained in :doc:`/intro/simulations`, you can easily add custom measurement
 
 from ..networks.mpo import MPOEnvironment
 from ..tools.misc import get_recursive
+from ..tools import process
 import warnings
 
 __all__ = [
     'measurement_index', 'bond_dimension', 'bond_energies', 'simulation_parameter', 'energy_MPO',
-    'entropy', 'onsite_expectation_value', 'correlation_length', 'psi_method', 'evolved_time'
+    'entropy', 'onsite_expectation_value', 'correlation_length', 'psi_method',
+    'simulation_method', 'evolved_time'
 ]
 
 
@@ -205,7 +207,7 @@ def correlation_length(results, psi, simulation, key='correlation_length', unit=
 
 
 def psi_method(results, psi, simulation, method, key=None, **kwargs):
-    """General method to measure arbitrary method of psi with given additional kwargs.
+    """Generic method to measure arbitrary method of psi with given additional kwargs.
 
     Parameters
     ----------
@@ -221,6 +223,30 @@ def psi_method(results, psi, simulation, method, key=None, **kwargs):
     if key in results:
         raise ValueError(f"key {key!r} already exists in results")
     method = getattr(psi, method)
+    results[key] = method(**kwargs)
+
+
+def simulation_method(results, psi, simulation, method, key=None, **kwargs):
+    """Generic method to measure arbitrary method of simulation class with given additional kwargs.
+
+    This can be convenient if you define measurement functions in a
+    custom :class:`~tenpy.simulations.simulation.Simulation` subclass or for utility measurement
+    functions like :meth:`~tenpy.simulaitons.simulation.Simulation.walltime`
+
+    Parameters
+    ----------
+    results, psi, simulation, key:
+        See :func:`~tenpy.simulation.measurement.measurement_index`.
+    method : str
+        Name of the method of `psi` to call. `key` defaults to this if not specified.
+    **kwargs :
+        further keyword arguments given to the method
+    """
+    if key is None:
+        key = method
+    if key in results:
+        raise ValueError(f"key {key!r} already exists in results")
+    method = getattr(simulation, method)
     results[key] = method(**kwargs)
 
 

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -19,13 +19,18 @@ __all__ = [
 ]
 
 
-def measurement_index(results, psi, simulation, key='measurement_index'):
+def measurement_index(results, psi, model, simulation, key='measurement_index'):
     """'Measure' the index of how many mearuements have been performed so far.
 
     The parameter description below documents the common interface of all measurement
     functions that can be registered to simulations.
 
     See :doc:`/intro/simulations` for the general setup using measurements.
+
+    .. versionadded:: 0.10.0
+
+        The `model` parameter is new! Any measurement function for simulations now has to accept
+        this as keyword argument!
 
     Parameters
     ----------
@@ -34,7 +39,11 @@ def measurement_index(results, psi, simulation, key='measurement_index'):
         Instead of returning the result, the output should be written into this dictionary
         under an appropriate key (or multiple keys, if applicable).
     psi :
-        Tensor network state to be measured. Shorthand for ``simulation.psi``.
+    model :
+        Tensor network state and matching model (with same sites/indexing) to be measured.
+        Usually shorthand for ``simulation.psi`` and ``simulation.model``, respectively,
+        but can be different, e.g., when grouping sites.
+        See :meth:`~tenpy.simulations.simulation.Simulation.get_measurement_psi_model`.
     simulation : :class:`~tenpy.simulations.simulation.Simulation`
         The simulation class. This gives also access to the `model`, algorithm `engine`, etc.
     key : str
@@ -47,29 +56,29 @@ def measurement_index(results, psi, simulation, key='measurement_index'):
     results[key] = index
 
 
-def bond_dimension(results, psi, simulation, key='bond_dimension'):
+def bond_dimension(results, psi, model, simulation, key='bond_dimension'):
     """'Measure' the bond dimension of an MPS.
 
     Parameters
     ----------
-    results, psi, simulation, key :
+    results, psi, model, simulation, key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
     results[key] = psi.chi
 
 
-def bond_energies(results, psi, simulation, key='bond_energies'):
+def bond_energies(results, psi, model, simulation, key='bond_energies'):
     """Measure the energy of an MPS.
 
     Parameters
     ----------
-    results, psi, simulation, key :
+    results, psi, model, simulation, key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
     results[key] = simulation.model.bond_energies(psi)
 
 
-def simulation_parameter(results, psi, simulation, recursive_key, key=None, **kwargs):
+def simulation_parameter(results, psi, model, simulation, recursive_key, key=None, **kwargs):
     """Dummy meausurement of a simulation parameter.
 
     This can be useful e.g. if you have a time-dependent hamiltonian parameter.
@@ -88,14 +97,15 @@ def simulation_parameter(results, psi, simulation, recursive_key, key=None, **kw
     results[key] = get_recursive(simulation.options, recursive_key, **kwargs)
 
 
-def energy_MPO(results, psi, simulation, key='energy_MPO'):
+def energy_MPO(results, psi, model, simulation, key='energy_MPO'):
     """Measure the energy of an MPS by evaluating the MPS expectation value.
 
     Parameters
     ----------
-    results, psi, simulation, key :
+    results, psi, model, simulation, key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
+    psi = simulation.psi  # take original psi, possibly grouped, but compatible with model
     if psi.bc == 'segment':
         init_env_data = simulation.init_env_data
         E = MPOEnvironment(psi, simulation.model.H_MPO, psi, **init_env_data).full_contraction(0)
@@ -104,7 +114,7 @@ def energy_MPO(results, psi, simulation, key='energy_MPO'):
         results[key] = simulation.model.H_MPO.expectation_value(psi)
 
 
-def entropy(results, psi, simulation, key='entropy'):
+def entropy(results, psi, model, simulation, key='entropy'):
     """Measure the entropy at all bonds of an MPS.
 
     Parameters
@@ -115,7 +125,8 @@ def entropy(results, psi, simulation, key='entropy'):
     results['entropy'] = psi.entanglement_entropy()
 
 
-def onsite_expectation_value(results, psi, simulation, opname, key=None, fix_u=None, **kwargs):
+def onsite_expectation_value(results, psi, model, simulation, opname, key=None, fix_u=None,
+                             **kwargs):
     """Measure expectation values of an onsite operator.
 
     The resulting array of measurements is indexed by *lattice* indices ``(x, y, u)``
@@ -126,7 +137,7 @@ def onsite_expectation_value(results, psi, simulation, opname, key=None, fix_u=N
 
     Parameters
     ----------
-    results, psi, simulation, key:
+    results, psi, model, simulation, key:
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     opname : str
         The operator to be measured.
@@ -140,7 +151,7 @@ def onsite_expectation_value(results, psi, simulation, opname, key=None, fix_u=N
         key = f"<{opname}>"
     if key in results:
         raise ValueError(f"key {key!r} already exists in results")
-    lattice = simulation.model.lat
+    lattice = model.lat
     if fix_u is not None:
         kwargs['sites'] = lattice.mps_idx_fix_u(fix_u)
     exp_vals = psi.expectation_value(opname, **kwargs)
@@ -153,12 +164,12 @@ def onsite_expectation_value(results, psi, simulation, opname, key=None, fix_u=N
     results[key] = exp_vals
 
 
-def correlation_length(results, psi, simulation, key='correlation_length', unit=None, **kwargs):
+def correlation_length(results, psi, model, simulation, key='correlation_length', unit=None, **kwargs):
     """Measure the correlaiton of an infinite MPS.
 
     Parameters
     ----------
-    results, psi, simulation, key:
+    results, psi, model, simulation, key:
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     unit : ``'MPS_sites' | 'MPS_sites_ungrouped' | 'lattice_rings'``
         The unit in which the correlation length is returned, see the warning in
@@ -191,12 +202,12 @@ def correlation_length(results, psi, simulation, key='correlation_length', unit=
     elif unit == 'MPS_sites_ungrouped':
         corr = corr * psi.grouped
     elif unit == 'lattice_rings':
-        lat = simulation.model.lattice
+        lat = model.lattice
         if lat.N_sites_per_ring is None:
             raise ValueError("lattice doesn't define N_sites_per_ring")
         corr = corr * psi.grouped / lat.N_sites_per_ring
     elif unit == 'lattice_spacing':
-        lat = simulation.model.lattice
+        lat = model.lattice
         if lat.N_sites_per_ring is None:
             raise ValueError("lattice doesn't define N_sites_per_ring")
         corr = corr * psi.grouped / lat.N_sites_per_ring / np.inner(lat.basis[0], lat.cylinder_axis)
@@ -205,7 +216,7 @@ def correlation_length(results, psi, simulation, key='correlation_length', unit=
     results[key] = corr
 
 
-def psi_method(results, psi, simulation, method, key=None, **kwargs):
+def psi_method(results, psi, model, simulation, method, key=None, **kwargs):
     """Generic function to measure arbitrary method of psi with given additional kwargs.
 
     Instead of using `tenpy.simulations.measurement.psi_method` as a measurement function,
@@ -243,7 +254,7 @@ def psi_method(results, psi, simulation, method, key=None, **kwargs):
 
     Parameters
     ----------
-    results, psi, simulation, key:
+    results, psi, model, simulation, key:
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     method : str
         Name of the method of `psi` to call. `key` defaults to this if not specified.
@@ -254,10 +265,10 @@ def psi_method(results, psi, simulation, method, key=None, **kwargs):
     _psi_method_deprecated_msg = '\n'.join([line[4:] for line in
                                             psi_method.__doc__.splitlines()[2:32]])
     warnings.warn(_psi_method_deprecated_msg, FutureWarning)
-    _psi_method_wrapper(results, psi, simulation, method, key=key, **kwargs)
+    _psi_method_wrapper(results, psi, model, simulation, method, key=key, **kwargs)
 
 
-def _psi_method_wrapper(results, psi, simulation, method, key=None, **kwargs):
+def _psi_method_wrapper(results, psi, model, simulation, method, key=None, **kwargs):
     """Wrapper function to allow measuring psi methods.
 
     This function is used in :meth:`tenpy.simulations.Simulation._connect_measurements_method`
@@ -272,7 +283,7 @@ def _psi_method_wrapper(results, psi, simulation, method, key=None, **kwargs):
     results[key] = method(**kwargs)
 
 
-def _simulation_method_wrapper(results, psi, simulation, method, key, **kwargs):
+def _simulation_method_wrapper(results, psi, model, simulation, method, key, **kwargs):
     """Wrapper function to allow measuring psi methods.
 
     This function is used in :meth:`tenpy.simulations.Simulation._connect_measurements_method`
@@ -284,14 +295,14 @@ def _simulation_method_wrapper(results, psi, simulation, method, key, **kwargs):
     results[key] = method(psi=psi, **kwargs)
 
 
-def evolved_time(results, psi, simulation, key='evolved_time'):
+def evolved_time(results, psi, model, simulation, key='evolved_time'):
     """Measure the time evolved by the engine, ``engine.evolved_time``.
 
     "Measures" :attr:`tenpy.algorithms.algorithm.TimeEvolutionAlgorithm.evolved_time`.
 
     Parameters
     ----------
-    results, psi, simulation, key:
+    results, psi, model, simulation, key:
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
     results[key] = simulation.engine.evolved_time

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -214,7 +214,7 @@ class Simulation:
             'finished_run': False,
         }
         self._last_save = self._init_walltime = time.time()
-        self.measurement_event = EventHandler("psi, simulation, results")
+        self.measurement_event = EventHandler("psi, simulation, model, results")
         if resume_data is not None:
             if 'psi' in resume_data:
                 self.psi = resume_data['psi']

--- a/tenpy/simulations/time_evolution.py
+++ b/tenpy/simulations/time_evolution.py
@@ -30,7 +30,7 @@ class RealTimeEvolution(Simulation):
     """
     default_algorithm = 'TEBDEngine'
     default_measurements = Simulation.default_measurements + [
-        ('tenpy.simulations.measurement', 'evolved_time'),
+        ('tenpy.simulations.measurement', 'm_evolved_time'),
     ]
 
     def __init__(self, options, **kwargs):
@@ -46,13 +46,13 @@ class RealTimeEvolution(Simulation):
         while True:
             if np.real(self.engine.evolved_time) >= self.final_time:
                 break
+            self.logger.info("evolve to time %.2f, max chi=%d", self.engine.evolved_time.real,
+                             max(self.psi.chi))
             self.engine.run()
             # for time-dependent H (TimeDependentExpMPOEvolution) the engine can re-init the model;
             # use it for the measurements....
             self.model = self.engine.model
 
-            self.logger.info("reached time %.2f, max chi=%d", self.engine.evolved_time.real,
-                             max(self.psi.chi))
             self.make_measurements()
             self.engine.checkpoint.emit(self.engine)  # TODO: is this a good idea?
 

--- a/tenpy/tools/events.py
+++ b/tenpy/tools/events.py
@@ -219,6 +219,5 @@ class EventHandler:
         return None
 
     def _prepare_emit(self):
-        # TODO: logging?
         # sort listeners: highest priority first
         self.listeners = sorted(self.listeners, key=lambda listener: -listener.priority)

--- a/tenpy/tools/events.py
+++ b/tenpy/tools/events.py
@@ -14,7 +14,7 @@ from .hdf5_io import find_global
 
 __all__ = ['Listener', 'EventHandler']
 
-Listener = namedtuple('Listener', "listener_id, callback, priority")
+Listener = namedtuple('Listener', "listener_id, callback, priority, extra_kwargs")
 
 
 class EventHandler:
@@ -122,7 +122,7 @@ class EventHandler:
             raise ValueError("connect() hasn't been called yet!'")
         return self._id_counter - 1
 
-    def connect(self, callback=None, priority=0):
+    def connect(self, callback=None, priority=0, extra_kwargs=None):
         """Register a `callback` function as a listener to the event.
 
         You can either call this function directly or use it as a function decorator,
@@ -138,6 +138,9 @@ class EventHandler:
         priority : int
             Higher priority indicates that the callback function should be called before other
             possibly registered callback functions.
+        extra_kwargs : None | dict
+            Optional extra keyword arguments given directly to the function.
+            ``None`` is equivalent to ``{}``.
 
         Returns
         -------
@@ -156,10 +159,12 @@ class EventHandler:
             return property
         listener_id = self._id_counter
         self._id_counter += 1
-        self.listeners.append(Listener(listener_id, callback, priority))
+        if extra_kwargs is None:
+            extra_kwargs = {}
+        self.listeners.append(Listener(listener_id, callback, priority, extra_kwargs))
         return callback
 
-    def connect_by_name(self, module_name, func_name, kwargs=None, priority=0):
+    def connect_by_name(self, module_name, func_name, extra_kwargs=None, priority=0):
         """Connect to a function given by the name in a module, optionally inserting arguments.
 
         Parameters
@@ -168,16 +173,15 @@ class EventHandler:
             The name of the module containing the function to be used. Gets imported.
         func_name : str
             The (qualified) name of the function inside the module.
-        kwargs : dict
+        extra_kwargs : dict
             Optional extra keyword-arguments to be given to the function.
+            ``None`` is equivalent to ``{}``.
         priority : int
             Higher priority indicates that the callback function should be called before other
             possibly registered callback functions.
         """
         func = find_global(module_name, func_name)
-        if kwargs is not None:
-            func = functools.partial(func, **kwargs)
-        self.connect(func, priority)
+        self.connect(func, priority, extra_kwargs)
 
     def disconnect(self, listener_id):
         """De-register a listener.
@@ -197,6 +201,12 @@ class EventHandler:
     def emit(self, *args, **kwargs):
         """Call the `callback` functions of all listeners.
 
+        Parameters
+        ----------
+        *args, **kwargs:
+            (Keyword) arguments to give to the callback functions.
+            Recall that there can also be addiontal `extra_kwargs` for each callback function.
+
         Returns
         -------
         results : list
@@ -204,16 +214,16 @@ class EventHandler:
         """
         self._prepare_emit()
         results = []
-        for _, callback, _ in self.listeners:
-            res = callback(*args, **kwargs)
+        for _, callback, _, extra_kwargs in self.listeners:
+            res = callback(*args, **kwargs, **extra_kwargs)
             results.append(res)
         return results
 
     def emit_until_result(self, *args, **kwargs):
         """Call the listeners `callback` until one returns not `None`."""
         self._prepare_emit()
-        for _, callback, _ in self.listeners:
-            res = callback(*args, **kwargs)
+        for _, callback, _, extra_kwargs in self.listeners:
+            res = callback(*args, **kwargs, **extra_kwargs)
             if res is not None:
                 return res
         return None

--- a/tests/export_import_test/test_pickle.py
+++ b/tests/export_import_test/test_pickle.py
@@ -83,7 +83,7 @@ def test_simulation_export_import(tmp_path):
             'product_state': [['up'], ['down']]
         },
         'connect_measurements': [
-            ('tenpy.simulations.measurement', 'onsite_expectation_value', {
+            ('tenpy.simulations.measurement', 'm_onsite_expectation_value', {
                 'opname': 'Sz'
             }),
         ],

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -89,7 +89,7 @@ simulation_params = {
     },
     'save_every_x_seconds':
     0.,  # save at each checkpoint
-    'connect_measurements': [('tenpy.simulations.measurement', 'onsite_expectation_value', {
+    'connect_measurements': [('tenpy.simulations.measurement', 'm_onsite_expectation_value', {
         'opname': 'Sz'
     }), (__name__, 'dummy_measurement')],
 }

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -66,7 +66,7 @@ class DummyEnv:
         return {"Env data": "Could be big"}
 
 
-def dummy_measurement(results, psi, simulation):
+def dummy_measurement(results, psi, model, simulation):
     results['dummy_value'] = simulation.engine.dummy_value
 
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -3,6 +3,7 @@
 
 import copy
 import numpy as np
+import warnings
 import sys
 
 import tenpy
@@ -19,7 +20,7 @@ tenpy.tools.misc.skip_logging_setup = True  # skip logging setup
 class DummyAlgorithm(Algorithm):
     def __init__(self, psi, model, options, *, resume_data=None, cache=None):
         super().__init__(psi, model, options, resume_data=resume_data)
-        self.dummy_value = None
+        self.dummy_value = -1
         self.evolved_time = self.options.get('start_time', 0.)
         init_env_data = {} if resume_data is None else resume_data['init_env_data']
         self.env = DummyEnv(**init_env_data)
@@ -69,6 +70,13 @@ class DummyEnv:
 def dummy_measurement(results, psi, model, simulation):
     results['dummy_value'] = simulation.engine.dummy_value
 
+def bad_dummy_measurement(results, psi, model, simulation):
+    """Check using different keys - it should still work."""
+    i = results['measurement_index']
+    results[f"changing_key_{i:d}"] = simulation.engine.dummy_value
+    #  if i == 3:
+    #      raise ValueError("something went wrong")
+
 
 simulation_params = {
     'model_class':
@@ -93,6 +101,7 @@ simulation_params = {
         'opname': 'Sz'
     }), (__name__, 'dummy_measurement')],
 }
+expected_dummy_value = simulation_params['algorithm_params']['N_steps']**2
 
 
 def test_Simulation(tmp_path):
@@ -106,8 +115,30 @@ def test_Simulation(tmp_path):
     meas = results['measurements']
     # expect two measurements: once in `init_measurements` and in `final_measurement`.
     assert np.all(meas['measurement_index'] == np.arange(2))
-    assert meas['dummy_value'] == [None, sim_params['algorithm_params']['N_steps']**2]
+    assert np.all(meas['dummy_value'] == [-1, expected_dummy_value])
     assert (tmp_path / sim_params['output_filename']).exists()
+
+
+def test_bad_measurements():
+    sim_params = copy.deepcopy(simulation_params)
+    sim_params['connect_measurements'].append((__name__, 'bad_dummy_measurement', {}, -1))
+    sim = Simulation(sim_params)
+
+    with warnings.catch_warnings(record=True) as caught:
+        results = sim.run()
+    for w in caught:
+        msg = str(w.message)
+        expected = any((part in msg) for part in ["measurement gave new keys {'changing_key",
+                                                  "measurement didn't give keys {'changing_key"])
+        if not expected:
+            warnings.showwarning(w.message, w.category, w.filename, w.lineno, w.file, w.line)
+    assert len(caught) >= 2, "expected to get warnings about changing keys"
+
+    meas = results['measurements']
+    assert np.all(meas['measurement_index'] == np.arange(2))
+    assert np.all(meas['dummy_value'] == [-1, expected_dummy_value])
+    assert meas['changing_key_0'] == [-1, None]
+    assert meas['changing_key_1'] == [None, expected_dummy_value]
 
 
 def test_Simulation_resume(tmp_path):
@@ -170,7 +201,7 @@ def test_GroundStateSearch():
     meas = results['measurements']
     # expect two measurements: once in `init_measurements` and in `final_measurement`.
     assert np.all(meas['measurement_index'] == np.arange(2))
-    assert meas['dummy_value'] == [None, sim_params['algorithm_params']['N_steps']**2]
+    assert np.all(meas['dummy_value'] == [-1, expected_dummy_value])
     del sim
 
 
@@ -192,7 +223,7 @@ def test_RealTimeEvolution():
     N = len(expected_times)
     assert np.allclose(meas['evolved_time'], expected_times)
     assert np.all(meas['measurement_index'] == np.arange(N))
-    assert meas['dummy_value'] == [None] + [sim_params['algorithm_params']['N_steps']**2] * (N - 1)
+    assert np.all(meas['dummy_value'] == [-1] + [expected_dummy_value] * (N - 1))
 
 
 def test_output_filename_from_dict():


### PR DESCRIPTION
Again, this change is backwards incompatible, so I'm creating a pull request to make the change more visible and track it better.

The relevant incompatibility is in f58050620ddd9282c4e99a820517d49935363462 (cherry-picked from 2a5052ac2abc672b0f2e83d8f74fb3ca3be2229b), namely that measurement functions need to accept models as additional arguments. This is necessary to ensure compatiblity of the `psi` to be measured with the model, e.g. when grouping sites.

While you're changing those measurement functions, you might also want to follow the new TeNPy convention that they start with an `m_`, e.g. we renamed `tenpy.simulations.measurement.bond_dimension` to `tenpy.simulations.measurement.m_bond_dimension`.  For now, the old names still work in the config/yaml files, but they give a FutureWarning. 
You should update the config yaml files in projects where you want to update to a new TeNPy version:
- update the `connect_measurements` simulation parameter: all direct measurement functions (taking `results, psi, model, simulation` as arguments and saving to `results`) defined in TeNPy have been renamed to start with `m_`.
  At this point, all those functions are defined in `tenpy.simulations.measurement.py`.
- If you're using `psi_method` to measure e.g. correlation functions, you need to update the entry as follows:
An old python entry for connect_measurements
```python
{...,
 'connect_measurements': [['tenpy.simulations.measurement',
                           'psi_method',
                           'correlation_function',
                           {'key': '<Sp_i Sm_j>', 'ops1': 'Sp', 'ops2': 'Sm'},
                          ],
                          ...
                          ]
```
can get replaced with new entry:
```python
{...,
 'connect_measurements': [['psi_method',
                           'wrap correlation_function',
                           {'key': '<Sp_i Sm_j>', 'ops1': 'Sp', 'ops2': 'Sm'},
                          ],
                          ...
                          ]
```

Similarly, an old yaml entry for connect_measurements
```yaml
connect_measurements:
    - - tenpy.simulations.measurement
      - psi_method
      - method: correlation_function
        key: '<Sp_i Sm_j>'
        ops1: Sp
        ops2: Sm
    - ...
```
can get replaced with new yaml:
```yaml
connect_measurements:
    - - psi_method
      - wrap correlation_function
      - results_key: '<Sp_i Sm_j>'
        ops1: Sp
        ops2: Sm
    - ...
```






