### PR TITLE
Purification for canonical ensemble: fix and extra charge conservation

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -1,0 +1,27 @@
+[latest]
+========
+
+Release Notes
+-------------
+TODO: Summarize the most important changes
+
+Changelog
+---------
+
+Backwards incompatible changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- nothing yet
+
+Added
+^^^^^
+- nothing yet
+
+Changed
+^^^^^^^
+- nothing yet
+
+Fixed
+^^^^^
+- :meth:`~tenpy.networks.purification_mps.PurificationMPS.from_infiniteT_canonical` should now work with arbitrary
+  charges of the original model, and has the option to double the number of charges to separately conserve the charges
+  on each the physical and ancialla legs.

--- a/tenpy/networks/purification_mps.py
+++ b/tenpy/networks/purification_mps.py
@@ -127,7 +127,7 @@ from ..linalg import np_conserved as npc
 from ..tools.math import entropy
 from ..tools.misc import lexsort
 
-__all__ = ['PurificationMPS']
+__all__ = ['PurificationMPS', 'convert_model_purification_canonical_conserve_ancilla_charge']
 
 
 class PurificationMPS(MPS):


### PR DESCRIPTION
This is a fix for PurificationMPS.from_infiniteT_canonical().
Also, it now allows to use separate charge conservation on the ancilla legs.
For the latter, you have to enable 'conserve_ancilla_charge', and convert the model charges with the new function
`convert_model_purification_canonical_conserve_ancilla_charge`.
