### PR TITLE
Cover edge case in call signature of MPS.entanglement_entropy()

### DIFF
--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -1668,6 +1668,8 @@ class MPS:
         if bonds is None:
             nt = self.nontrivial_bonds
             bonds = range(nt.start, nt.stop)
+        if isinstance(bonds, int):
+            bonds = [bonds]
         res = []
         for ib in bonds:
             s = self._S[ib]


### PR DESCRIPTION
`bonds` argument of [MPS.entanglement_entropy()](https://github.com/tenpy/tenpy/blob/e857fbb67f32e99b5639585a60c7d23d121edd14/tenpy/networks/mps.py#L1625) is documented as accepting an `int`, but it does not.

