### PR TITLE
Qr based tebd

### DIFF
--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -723,7 +723,7 @@ class QRBasedTEBDEngine(TEBDEngine):
                 s_new = min(s_new, sizes_new[j_new])  # don't go beyond block
                 start = vL_new.slices[j_new]
                 piv[start:start+s_new] = True
-            #  Y0.iproject(piv, 'vL')
+            Y0.iproject(piv, 'vL')
             Y0 = Y0.ireplace_label('p1', 'p').iconj()
         else:
             Y0 = self.psi.get_B(i1).conj()

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -658,18 +658,10 @@ class QRBasedTEBDEngine(TEBDEngine):
 
         if self.options.get('use_eig_based_svd', False):
             U, S, Vd, trunc_err, renormalize = _eig_based_svd(
-                Xi, inner_labels=['vR', 'vL'], need_U=False, 
-                trunc_params=self.trunc_params if expand else None
+                Xi, inner_labels=['vR', 'vL'], need_U=False, trunc_params=self.trunc_params
             )
         else:
-            if expand:
-                U, S, Vd, trunc_err, renormalize = svd_theta(Xi, self.trunc_params)
-            else:
-                # direct svd without truncation
-                U, S, Vd = npc.svd(Xi, inner_labels=['vR', 'vL'])
-                renormalize = np.linalg.norm(S)
-                S /= renormalize
-                trunc_err = TruncationError()  # no truncation
+            U, S, Vd, trunc_err, renormalize = svd_theta(Xi, self.trunc_params)
 
         B_R = npc.tensordot(Vd, B_R, axes=['vR', 'vL'])
 
@@ -754,17 +746,10 @@ class QRBasedTEBDEngine(TEBDEngine):
 
         if self.options.get('use_eig_based_svd', False):
             U, S, Vd, trunc_err, renormalize = _eig_based_svd(
-                Xi, inner_labels=['vR', 'vL'], trunc_params=self.trunc_params if expand else None
+                Xi, inner_labels=['vR', 'vL'], trunc_params=self.trunc_params
             )
         else:
-            if expand:
-                U, S, Vd, trunc_err, renormalize = svd_theta(Xi, self.trunc_params)
-            else:
-                # direct svd without truncation
-                U, S, Vd = npc.svd(Xi, inner_labels=['vR', 'vL'])
-                renormalize = np.linalg.norm(S)
-                S /= renormalize
-                trunc_err = TruncationError()  # no truncation
+            U, S, Vd, trunc_err, renormalize = svd_theta(Xi, self.trunc_params)
 
         B_R = npc.tensordot(Vd, B_R, axes=['vR', 'vL'])
         A_L = npc.tensordot(A_L, U, axes=['vR', 'vL'])

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -734,7 +734,6 @@ def _qr_tebd_cbe_Y0(B_L: npc.Array, B_R: npc.Array, theta: npc.Array, expand: fl
     vL_new = Y0.get_leg('vL')  # is blocked, since created from pipe
 
     # vL_old is guaranteed to be a slice of vL_new by charge rule in B_L
-    # TODO (JU): Is this actually true if all charges on the physical leg are non-zero?
     piv = np.zeros(vL_new.ind_len, dtype=bool)  # indices to keep in vL_new
     increase_per_block = max(1, int(vL_old.ind_len * expand // vL_new.block_number))
     sizes_old = vL_old.get_block_sizes()

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -603,6 +603,11 @@ class QRBasedTEBDEngine(TEBDEngine):
         and we need to disregard those eigenvectors of the larger one, that have eigenvalue zero,
         since we dont have corresponding eigenvalues of the smaller one.
 
+    .. todo ::
+        Can we implement some simple diagnostics that issue a warning if the CBE expansion
+        was too small?
+        Could potentially look into the tail of the schmidt spectrum.
+
     Options
     -------
     .. cfg:config :: QRBasedTEBDEngine

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -592,8 +592,8 @@ class Engine(TEBDEngine):
 
 
 class QRBasedTEBDEngine(TEBDEngine):
-    r"""Version of :class:`~tenpy.algorithms.tebd.TEBDEngine` that relies on QR decompositions
-    for the truncation of the evolved local wavefunction.
+    r"""Version of TEBD that relies on QR decompositions rather than SVD.
+    
     As introduced in :arxiv:`2212.09782`.
 
     .. todo ::
@@ -602,11 +602,6 @@ class QRBasedTEBDEngine(TEBDEngine):
         This means that :math:`M^{\dagger} M` and :math:`M M^{\dagger}` dont have the same size,
         and we need to disregard those eigenvectors of the larger one, that have eigenvalue zero,
         since we dont have corresponding eigenvalues of the smaller one.
-
-    .. todo ::
-        Can we implement some simple diagnostics that issue a warning if the CBE expansion
-        was too small?
-        Could potentially look into the tail of the schmidt spectrum.
 
     Options
     -------
@@ -628,7 +623,7 @@ class QRBasedTEBDEngine(TEBDEngine):
             Default is `False`.
         compute_err : bool
             Whether the truncation error should be computed exactly.
-            Unlike for SVD-based TEBD, computing the truncation error is significantly more expensive.
+            Compared to SVD-based TEBD, computing the truncation error is significantly more expensive.
             If `True` (default), the full error is computed.
             Otherwise, the truncation error is set to NaN.
     """         
@@ -783,8 +778,10 @@ class QRBasedTEBDEngine(TEBDEngine):
 
 def _eig_based_svd(A, need_U: bool = True, need_Vd: bool = True, inner_labels=[None, None],
                    trunc_params=None):
-    """Computes the singular value decomposition of a matrix A, but via diagonalization of
-    its "square" A.hc @ A and/or A @ A.hc, i.e. two eigh calls instead of an svd call.
+    """Computes the singular value decomposition of a matrix A via eigh
+
+    Singular values and vectors are obtained by diagonalizing the "square" A.hc @ A and/or A @ A.hc, 
+    i.e. with two eigh calls instead of an svd call.
 
     Truncation if performed if and only if trunc_params are given.
     This performs better on GPU, but is not really useful on CPU.

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -592,14 +592,14 @@ class Engine(TEBDEngine):
 
 
 class QRBasedTEBDEngine(TEBDEngine):
-    """Version of :class:`~tenpy.algorithms.tebd.TEBDEngine` that relies on QR decompositions
+    r"""Version of :class:`~tenpy.algorithms.tebd.TEBDEngine` that relies on QR decompositions
     for the truncation of the evolved local wavefunction.
     As introduced in :arxiv:`2212.09782`.
 
     .. todo ::
         To use `use_eig_based_svd == True`, which makes sense on GPU only, we need to implement
         the `_eig_based_svd` for "non-square" matrices.
-        This means that :math:`M^\dagger M` and :math:`M M^\dagger` dont have the same size,
+        This means that :math:`M^{\dagger} M` and :math:`M M^{\dagger}` dont have the same size,
         and we need to disregard those eigenvectors of the larger one, that have eigenvalue zero,
         since we dont have corresponding eigenvalues of the smaller one.
 

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -669,6 +669,7 @@ class QRBasedTEBDEngine(TEBDEngine):
         self.psi.set_B(i0, B_L, form='B')
         self.psi.set_SL(i1, S)
         self.psi.set_B(i1, B_R, form='B')
+        self._trunc_err_bonds[i] = self._trunc_err_bonds[i] + trunc_err
         return trunc_err
 
     def update_bond_imag(self, i, U_bond):
@@ -694,6 +695,7 @@ class QRBasedTEBDEngine(TEBDEngine):
         self.psi.set_B(i0, A_L, form='A')
         self.psi.set_SL(i1, S)
         self.psi.set_B(i1, B_R, form='B')
+        self._trunc_err_bonds[i] = self._trunc_err_bonds[i] + trunc_err
 
         return trunc_err
 

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -763,8 +763,6 @@ def _eig_based_svd(A, need_U: bool = True, need_Vd: bool = True, inner_labels=[N
         )
         return U, S, Vd, trunc_err, renormalize
 
-    logger.debug(f'A._labels = {A._labels}')
-
     if need_U:
         Vd = None
         A_Ahc = npc.tensordot(A, A.conj(), [1, 1])
@@ -775,7 +773,6 @@ def _eig_based_svd(A, need_U: bool = True, need_Vd: bool = True, inner_labels=[N
         U = None
         Ahc_A = npc.tensordot(A.conj(), A, [0, 0])
         L, V = npc.eigh(Ahc_A, sort='>')
-        logger.info(f'V._labels={V._labels}')
         S = np.sqrt(np.abs(L))  # abs to avoid `nan` due to accidentially negative values close to zero
         Vd = V.iconj().itranspose().ireplace_label('eig*', inner_labels[1])
     else:

--- a/tests/test_tebd.py
+++ b/tests/test_tebd.py
@@ -26,11 +26,13 @@ def test_trotter_decomposition():
 
             
 @pytest.mark.slow
-@pytest.mark.parametrize('bc_MPS, which_engine', 
-                         [(bc_MPS, which_engine) 
-                          for bc_MPS in ['finite', 'infinite'] 
-                          for which_engine in ['standard', 'qr']])
-def test_tebd(bc_MPS, which_engine, g=0.5):
+@pytest.mark.parametrize('bc_MPS, which_engine, compute_err',
+                         [('finite', 'standard', None),
+                          ('infinite', 'standard', None),
+                          ('finite', 'qr', True),
+                          ('infinite', 'qr', True),
+                          ('finite', 'qr', False)])
+def test_tebd(bc_MPS, which_engine, compute_err, g=0.5):
     L = 2 if bc_MPS == 'infinite' else 6
     #  xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS=bc_MPS)
     #  M = XXZChain(xxz_pars)
@@ -48,15 +50,23 @@ def test_tebd(bc_MPS, which_engine, g=0.5):
         'trunc_params': {
             'chi_max': 50,
             'trunc_cut': 1.e-13
-        }
+        },
     }
     if which_engine == 'standard':
         engine = tebd.TEBDEngine(psi, M, tebd_param)
     elif which_engine == 'qr':
+        tebd_param['compute_err'] = compute_err
         engine = tebd.QRBasedTEBDEngine(psi, M, tebd_param)
     else:
         raise RuntimeError
+    
     engine.run_GS()
+
+    if compute_err is False:
+        assert np.isnan(engine.trunc_err.eps)
+        assert np.isnan(engine.trunc_err.ov)
+    else:
+        assert engine.trunc_err.eps >= 0
 
     print("norm_test", psi.norm_test())
     if bc_MPS == 'finite':

--- a/tests/test_tebd.py
+++ b/tests/test_tebd.py
@@ -25,7 +25,6 @@ def test_trotter_decomposition():
             npt.assert_array_almost_equal_nulp(evolved, N * np.ones([2]), N * 2)
 
             
-# TODO (JU) also test real time evolution?
 @pytest.mark.slow
 @pytest.mark.parametrize('bc_MPS, which_engine', 
                          [(bc_MPS, which_engine) 

--- a/tests/test_tebd.py
+++ b/tests/test_tebd.py
@@ -24,10 +24,14 @@ def test_trotter_decomposition():
                 evolved[k] += dt[j]
             npt.assert_array_almost_equal_nulp(evolved, N * np.ones([2]), N * 2)
 
-
+            
+# TODO (JU) also test real time evolution?
 @pytest.mark.slow
-@pytest.mark.parametrize('bc_MPS', ['finite', 'infinite'])
-def test_tebd(bc_MPS, g=0.5):
+@pytest.mark.parametrize('bc_MPS, which_engine', 
+                         [(bc_MPS, which_engine) 
+                          for bc_MPS in ['finite', 'infinite'] 
+                          for which_engine in ['standard', 'qr']])
+def test_tebd(bc_MPS, which_engine, g=0.5):
     L = 2 if bc_MPS == 'infinite' else 6
     #  xxz_pars = dict(L=L, Jxx=1., Jz=3., hz=0., bc_MPS=bc_MPS)
     #  M = XXZChain(xxz_pars)
@@ -47,7 +51,12 @@ def test_tebd(bc_MPS, g=0.5):
             'trunc_cut': 1.e-13
         }
     }
-    engine = tebd.QRBasedTEBDEngine(psi, M, tebd_param)
+    if which_engine == 'standard':
+        engine = tebd.TEBDEngine(psi, M, tebd_param)
+    elif which_engine == 'qr':
+        engine = tebd.QRBasedTEBDEngine(psi, M, tebd_param)
+    else:
+        raise RuntimeError
     engine.run_GS()
 
     print("norm_test", psi.norm_test())

--- a/tests/test_tebd.py
+++ b/tests/test_tebd.py
@@ -47,7 +47,7 @@ def test_tebd(bc_MPS, g=0.5):
             'trunc_cut': 1.e-13
         }
     }
-    engine = tebd.TEBDEngine(psi, M, tebd_param)
+    engine = tebd.QRBasedTEBDEngine(psi, M, tebd_param)
     engine.run_GS()
 
     print("norm_test", psi.norm_test())
@@ -109,3 +109,5 @@ def test_RandomUnitaryEvolution():
     eng.run()
     print(eng.psi.chi)
     assert tuple(eng.psi.chi) == (16, 8)
+
+


### PR DESCRIPTION
## TODO before merging:
- [x] Properly extract truncation error! Currently, only the error of the SVD of `Xi` is returned, while errors introduced by `_qr_based_svd` are ignored
- [x] Are there easy diagnostics that we can run to detect that `expand` was too small?
  - no good ideas for now, writing a ``.. todo ::`` for now
- [x] Even [if not expand](https://github.com/tenpy/tenpy/blob/281e929c1b0f43fba48d1da3e69caa76e4deb3ce/tenpy/algorithms/tebd.py#L617) we should still call svd_theta, because self.trunc_params could have a svd_min that needs to be respected, right?
- [x] We probably want more elaborate control over `expand`. E.g. even if a moderate expansion ratio of 10% is eventually appropriate, it may be prohibitive in the beginning, e.g. for the very first time-step starting from a product state.
- [x] Make `expand` an option in the config, not an arg of `update_bond`, same for `use_eig_based_svd`
- [x] docstring