### PR TITLE
GitHub actions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+exclude = 
+    .git,
+    __pycache__,
+    build,
+    dist
+max-complexity = 10
+select = E9,F63,F7,F82
+show-source = True
+statistics = True
+count = True

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -11,26 +11,34 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+        shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
       with:
+        submodules: false
+    - name: Update submodules
+      run: |
+        git submodule update --init --recursive
+        git submodule update --remote --merge --recursive
+    - name: Setup miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        activate-environment: tenpydoc
+        environment-file: doc/environment.yml
         python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r doc/requirements.txt
-    - name : Build package
-      run: |
-        pip install .  # include all extra dependencies
     - name: Build documentation
-      # building html is necessary to include the module docstrings with autodoc
+      # -W treats warnings as errors, i.e. the action fails if there are warnings from sphinx
+      # --keep-going causes sphinx to not quit on a warning/error, so we get to see all of them
       run: |
-        python -m sphinx -b html ./doc ./doc/sphinx_build
+        conda activate tenpydoc
+        python -m sphinx -W --keep-going -b html ./doc ./doc/sphinx_build
     - name: Run doctests
-      # building html is necessary to include the module docstrings with autodoc
-      run: |
-        python -m sphinx -b doctest ./doc ./doc/sphinx_build
+      run: python -m sphinx -b doctest ./doc ./doc/sphinx_build
+ 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,35 @@
+name: linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: false
+    - name: Update submodules
+      run: |
+        git submodule update --init --recursive
+        git submodule update --remote --merge --recursive
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade flake8
+    - name: Run linter
+      # uses options from .flake8 config file
+      run: |
+        flake8 .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,18 +16,19 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name : Build
-      run: |
-        pip install .
+        python -m pip install --upgrade setuptools build
+    - name: Build
+      run: python -m build .
+    - name: Install
+      run: python -m pip install .
 #    - name: Lint with flake8
 #      run: |
 #        pip install flake8

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools>=30.3.0
   - h5py
   - pyyaml
-  - sphinx
+  - sphinx=6.2.1
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex
   - matplotlib


### PR DESCRIPTION
- linting workflow:
  Create a new workflow that lints the code using flake8 with parameters in a `.flake8` config file.
  For now, it only checks for a minimal ruleset, will later expand, see #230.
    
- pytest workflow
  Change to the new build system introduced in #237 

- docbuild workflow
  - Change to the new build system introduced in #237 
  - Properly sync the submodules before building the documentation
  - Let the workflow fail if sphinx raises warnings
  - use a miniconda to install all dependencies of a full docbuild from `doc/environment.yml`
  - sepcify `sphinx=6.1.0` in `doc/environment.yml` until we comply with `7.0.0`, see #250 