### PR TITLE
allow coupling parameter in MixedXKModel.add_{inter,intra}_ring_{hopping,interaction}() to depend on x

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -26,6 +26,11 @@ Changed
 - Change the build system and metadata declaration to ``pyproject.toml`` format.
   This makes installation more future-proof and stable, but should not affect how tenpy is used,
   once installed.
+- Allow `couplings` parameters in the :class:`~tenpy.models.mixed_xk.MixedXKModel` methods 
+  :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_inter_ring_hopping`,
+  :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_intra_ring_hopping`,
+  :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_inter_ring_interaction`, and
+  :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_intre_ring_interaction` to vary with `x`.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
The methods for adding coulings in the MIxedXKModel didn't work for x-dependent terms, but e.g. the Hofstadter model needs them, see e.g. [this forum thread](https://tenpy.johannes-hauschild.de/viewtopic.php?t=417). Hence this is a small generalization adding this.