### PR TITLE
Fix typos in changelog/latest

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -19,16 +19,16 @@ Added
 ^^^^^
 - :class:`~tenpy.models.tj_model.tJModel` and :class:`~tenpy.networks.site.SpinHalfHoleSite`
 - :class:`~tenpy.algorithms.tebd.QRBasedTEBDEngine`
-- :class:`~tenpy.models.clock.ClockModel`, :class:`~tenpy.models.clock.ClockChain` and :class:`~tenpy.models.sites.ClockSite` 
+- :class:`~tenpy.models.clock.ClockModel`, :class:`~tenpy.models.clock.ClockChain` and :class:`~tenpy.models.sites.ClockSite`
 - Simulation parameters :cfg:option:`Simulation.measure_at_algorithm_checkpoints` and
-  :cfg:option:`Simulation.canonicalize_before_measurement'
+  :cfg:option:`Simulation.canonicalize_before_measurement`
 
 Changed
 ^^^^^^^
 - Change the build system and metadata declaration to ``pyproject.toml`` format.
   This makes installation more future-proof and stable, but should not affect how tenpy is used,
   once installed.
-- Allow `couplings` parameters in the :class:`~tenpy.models.mixed_xk.MixedXKModel` methods 
+- Allow `couplings` parameters in the :class:`~tenpy.models.mixed_xk.MixedXKModel` methods
   :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_inter_ring_hopping`,
   :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_intra_ring_hopping`,
   :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_inter_ring_interaction`, and
@@ -49,6 +49,6 @@ Fixed
   norm with `renormalize=False`.
 - We now update the norm of the MPS in :meth:`~tenpy.algorithms.tebd.TEBDEngine.update_bond`.
   If the parameter ``preserve_norm`` is ``True`` (which is the default for real time evolution)
-  this has no effect when using :meth:`~tenpy.algorithms.tebd.TEBDEngine.run` or similat, 
+  this has no effect when using :meth:`~tenpy.algorithms.tebd.TEBDEngine.run` or similar,
   since the MPS norm is reset after the timestep anyway.
   It does, however, change the behavior if ``preserve_norm`` is ``False``.


### PR DESCRIPTION
In particular, a mis-typed backtick caused the doctest to fail