### PR TITLE
Fixed Typos in docstrings

### DIFF
--- a/doc/contr/guidelines.rst
+++ b/doc/contr/guidelines.rst
@@ -22,7 +22,7 @@ However, these are just guidelines - it still helps if you contribute something,
 
   The documentation uses `reStructuredText`. If you are new to `reStructuredText`, read this `introduction <http://www.sphinx-doc.org/en/stable/rest.html>`_.
   We use the `numpy` style for doc-strings (with the `napoleon <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_ extension to sphinx).
-  You can read abouth them in these `Instructions for the doc strings <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
+  You can read about them in these `Instructions for the doc strings <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
   In addition, you can take a look at the following `example file <http://github.com/numpy/numpy/blob/master/doc/example.py>`_.
   Helpful hints on top of that::
 

--- a/tenpy/algorithms/algorithm.py
+++ b/tenpy/algorithms/algorithm.py
@@ -54,7 +54,7 @@ class Algorithm:
     options : :class:`~tenpy.tools.params.Config`
         Optional parameters.
     checkpoint : :class:`~tenpy.tools.events.EventHandler`
-        An event that the algorithm emits at regular intervalls when it is in a
+        An event that the algorithm emits at regular intervals when it is in a
         "well defined" step, where an intermediate status report, measurements and/or
         interrupting and saving to disk for later resume make sense.
     cache : :class:`DictCache` or subclass
@@ -99,7 +99,7 @@ class Algorithm:
         cls : class
             Subclass of :class:`Algorithm` to be initialized.
         other_engine : :class:`Algorithm`
-            The engine from which data should be transfered. Another, but not too different
+            The engine from which data should be transferred. Another, but not too different
             algorithm subclass-class; e.g. you can switch from the
             :class:`~tenpy.algorithms.dmrg.TwoSiteDMRGEngine` to the
             :class:`~tenpy.algorithms.dmrg.OneSiteDMRGEngine`.
@@ -111,7 +111,7 @@ class Algorithm:
             If not defined, `resume_data` is collected with :meth:`get_resume_data`.
         """
         # If `resume_data` is defined in the kwargs, use that.
-        # This allows subclasses to overwritinstead of calling :meth:`get_resume_data`.
+        # This allows subclasses to overwrite instead of calling :meth:`get_resume_data`.
         if 'resume_data' not in kwargs:
             kwargs['resume_data'] = other_engine.get_resume_data()
         if options is None:
@@ -133,7 +133,7 @@ class Algorithm:
 
         Needs to be implemented in subclasses.
         """
-        raise NotImplementedError("Sublcasses should implement this.")
+        raise NotImplementedError("Subclasses should implement this.")
 
     def resume_run(self):
         """Resume a run that was interrupted.

--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -20,7 +20,7 @@ They should both give the same results (up to rounding errors). However, if star
 state, :class:`SingleSiteDMRGEngine` depends critically on the use of a :class:`Mixer`, while
 :class:`TwoSiteDMRGEngine` is in principle more computationally expensive to run and has
 occasionally displayed some convergence issues..
-Which one is preffered in the end is not obvious a priori and might depend on the used model.
+Which one is preferred in the end is not obvious a priori and might depend on the used model.
 Just try both of them.
 
 A :class:`Mixer` should be used initially to avoid that the algorithm gets stuck in local energy
@@ -118,7 +118,7 @@ class Mixer:
     """Base class of a general Mixer.
 
     Since DMRG performs only local updates of the state, it can get stuck in "local minima",
-    in particular if the Hamiltonain is long-range -- which is the case if one
+    in particular if the Hamiltonian is long-range -- which is the case if one
     maps a 2D system ("infinite cylinder") to 1D -- or if one wants to do single-site updates.
     The idea of the mixer is to perturb the state with the terms of the Hamiltonian
     which have contributions in both the "left" and "right" side of the system.
@@ -427,7 +427,7 @@ class DensityMatrixMixer(Mixer):
         \rightarrow  tr_R(|\theta><\theta|) + a \sum_l h_l tr_R(|\theta><\theta|) h_l^\dagger
 
     where `a` is the (small) perturbation :attr:`amplitude` and `h_l` are the left parts of
-    the Hamiltonian going accross the center bond (i0, i0+1).
+    the Hamiltonian going across the center bond (i0, i0+1).
     This perturbs singular values on the order of that amplitude.
 
     Pictorially, the left density matrix `rho_L` is given by::
@@ -723,7 +723,7 @@ class DMRGEngine(Sweep):
         .. cfg:configoptions :: DMRGEngine
 
             diag_method : str
-                Method to be used for diagonalzation, default ``'default'``.
+                Method to be used for diagonalization, default ``'default'``.
                 For possible arguments see :meth:`DMRGEngine.diag`.
             E_tol_to_trunc : float
                 It's reasonable to choose the Lanczos convergence criteria
@@ -787,7 +787,7 @@ class DMRGEngine(Sweep):
             P_tol_min : float
                 See `P_tol_to_trunc`
             update_env : int
-                Number of sweeps without bond optimizaiton to update the
+                Number of sweeps without bond optimization to update the
                 environment for infinite boundary conditions,
                 performed every `N_sweeps_check` sweeps.
         """

--- a/tenpy/algorithms/exact_diag.py
+++ b/tenpy/algorithms/exact_diag.py
@@ -11,7 +11,7 @@ This might be used to obtain the spectrum, the ground state or highly excited st
     symmetries like translation symmetry, SU(2) symmetry or inversion symmetries.
     In other words, this code does not aim to provide state-of-the-art exact diagonalization,
     but just the ability to diagonalize the defined models for small system sizes
-    without addional extra work.
+    without additional extra work.
 """
 # Copyright 2018-2023 TeNPy Developers, GNU GPLv3
 

--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -79,7 +79,7 @@ class Sweep(Algorithm):
     Attributes
     ----------
     EffectiveH : class
-        Class attribute; a sublcass of :class:`~tenpy.algorithms.mps_common.EffectiveH`.
+        Class attribute; a subclass of :class:`~tenpy.algorithms.mps_common.EffectiveH`.
         It's length attribute determines how many sites are optimized/updated at once,
         see also :attr:`n_optimize`.
     E_trunc_list : list
@@ -183,7 +183,7 @@ class Sweep(Algorithm):
         resume_data : None | dict
             Given when resuming a simulation, as returned by :meth:`get_resume_data`.
             Can contain another dict under the key `init_env_data`; the contents of
-            `init_env_data` get passed as keyword arguments to the environment initializaiton.
+            `init_env_data` get passed as keyword arguments to the environment initialization.
         orthogonal_to : None | list of :class:`~tenpy.networks.mps.MPS` | list of dict
             List of other matrix product states to orthogonalize against.
             Instead of just the state, you can specify a dict with the state as `ket`
@@ -409,7 +409,7 @@ class Sweep(Algorithm):
             Schedule for the sweep. Each entry is ``(i0, move_right, (update_LP, update_RP))``,
             where `i0` is the leftmost of the ``self.EffectiveH.length`` sites to be updated in
             :meth:`update_local`, `move_right` indicates whether the next `i0` in the schedule is
-            rigth (`True`) of the current one, and `update_LP`, `update_RP` indicate
+            right (`True`) of the current one, and `update_LP`, `update_RP` indicate
             whether it is necessary to update the `LP` and `RP` of the environments.
         """
         # warning: set only those `LP` and `RP` to True, which can/will be used later again
@@ -1110,7 +1110,7 @@ class ZeroSiteH(EffectiveH):
             |        .---    ---.
 
 
-    Note that this class has less funcitonality than the :class:`OneSiteH` and :class:`TwoSiteH`.
+    Note that this class has less functionality than the :class:`OneSiteH` and :class:`TwoSiteH`.
 
     Parameters
     ----------
@@ -1212,7 +1212,7 @@ class VariationalCompression(Sweep):
     except that we don't have an MPO in the networks - one can think of the MPO being trivial.
 
     .. deprecated :: 0.9.1
-        Renamed the optoin `N_sweeps` to `max_sweeps`.
+        Renamed the option `N_sweeps` to `max_sweeps`.
 
     Parameters
     ----------

--- a/tenpy/algorithms/network_contractor.py
+++ b/tenpy/algorithms/network_contractor.py
@@ -8,7 +8,7 @@ by Robert N. C. Pfeifer, Glen Evenbly, Sukhwinder Singh, Guifre Vidal, see :arxi
 .. autodata :: outer_product
 
 .. todo ::
-    - implement or wrap netcon.m, a function to find optimal contractionn sequences
+    - implement or wrap netcon.m, a function to find optimal contraction sequences
         (:arxiv:`1304.6112`)
     - implement or deprecate the outer_product in sequence behavior
 """

--- a/tenpy/algorithms/purification.py
+++ b/tenpy/algorithms/purification.py
@@ -19,7 +19,7 @@ __all__ = ['PurificationTwoSiteU', 'PurificationApplyMPO', 'PurificationTEBD', '
 class PurificationTwoSiteU(TwoSiteH):
     """Variant of `TwoSiteH` suitable for purification.
 
-    The MPO gets only applied to the physical legs `p0`, `p1`, the ancialla legs `q0`, `q1` of
+    The MPO gets only applied to the physical legs `p0`, `p1`, the ancilla legs `q0`, `q1` of
     `theta` are ignored.
     """
     length = 2
@@ -105,9 +105,9 @@ class PurificationTEBD(tebd.TEBDEngine):
         called with the TEBD parameter ``'disentangle'``.
         Defaults to the trivial disentangler for ``options['disentangle']=None``.
     _disent_iterations : 1D ndarray
-        Number of iterations performed on all bonds, including trivial bonds; lenght `L`.
+        Number of iterations performed on all bonds, including trivial bonds; length `L`.
     _guess_U_disent : list of list of npc.Array
-        Same index strucuture as `self._U`: for each two-site U of the physical time evolution
+        Same index structure as `self._U`: for each two-site U of the physical time evolution
         the disentangler from the last application. Initialized to identities.
     """
     def __init__(self, psi, model, options, **kwargs):
@@ -298,7 +298,7 @@ class PurificationTEBD(tebd.TEBDEngine):
     def disentangle_global(self, pair=None):
         """Try global disentangling by determining the maximally entangled pairs of sites.
 
-        Caclulate the mutual information (in the auxiliar space) between two sites and determine
+        Calculate the mutual information (in the auxiliar space) between two sites and determine
         where it is maximal. Disentangle these two sites with :meth:`disentangle`
         """
         max_range = self.options.get('disent_gl_maxrange', 10)
@@ -385,18 +385,18 @@ class PurificationTEBD(tebd.TEBDEngine):
             raise NotImplementedError  # adjust: what's the shortest path?
         assert (i < j)
         for j0 in range(j, i + 1, -1):  # j0 = current site of `j`
-            # originial leg `j` is at j0
+            # original leg `j` is at j0
             self._update_index = None, j0
             self._swap_disentangle_bond(j0, swap=True, disentangle=False)  # swap j0-1, j0
-            # originial leg is at `j0-1`
+            # original leg is at `j0-1`
         # disentangle i, i+1
         self._update_index = None, i + 1
         self._swap_disentangle_bond(i + 1, swap=False, disentangle=True)
         for j0 in range(i + 1, j):  # j0 = current site of `j`
-            # originial leg `j` is at j0
+            # original leg `j` is at j0
             self._update_index = None, j0 + 1
             self._swap_disentangle_bond(j0 + 1, disentangle=on_way)  # swap j0, j0+1
-            # originial leg is at `j0+1`
+            # original leg is at `j0+1`
         self._update_index = None  # done
 
     def _swap_disentangle_bond(self, i, swap=True, disentangle=False):

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -1,7 +1,7 @@
 r"""Time evolving block decimation (TEBD).
 
 The TEBD algorithm (proposed in :cite:`vidal2004`) uses a trotter decomposition of the
-Hamiltonian to perform a time evoltion of an MPS. It works only for nearest-neighbor hamiltonians
+Hamiltonian to perform a time evolution of an MPS. It works only for nearest-neighbor hamiltonians
 (in tenpy given by a :class:`~tenpy.models.model.NearestNeighborModel`),
 which can be written as :math:`H = H^{even} + H^{odd}`,  such that :math:`H^{even}` contains the
 the terms on even bonds (and similar :math:`H^{odd}` the terms on odd bonds).
@@ -34,7 +34,7 @@ If one chooses imaginary :math:`dt`, the exponential projects
 
 .. note ::
     The application of DMRG is typically much more efficient than imaginary TEBD!
-    Yet, imaginary TEBD might be usefull for cross-checks and testing.
+    Yet, imaginary TEBD might be useful for cross-checks and testing.
 
 """
 # Copyright 2018-2023 TeNPy Developers, GNU GPLv3
@@ -402,7 +402,7 @@ class TEBDEngine(TimeEvolutionAlgorithm):
         """Updates the B matrices on a given bond.
 
         Function that updates the B matrices, the bond matrix s between and the
-        bond dimension chi for bond i. The correponding tensor networks look like this::
+        bond dimension chi for bond i. The corresponding tensor networks look like this::
 
         |           --S--B1--B2--           --B1--B2--
         |                |   |                |   |
@@ -558,7 +558,7 @@ class TEBDEngine(TimeEvolutionAlgorithm):
         return trunc_err
 
     def _calc_U_bond(self, i_bond, dt, type_evo, E_offset):
-        """Calculate exponential of a bond Hamitonian.
+        """Calculate exponential of a bond Hamiltonian.
 
         * ``U_bond = exp(-i dt (H_bond-E_offset_bond))`` for ``type_evo='real'``, or
         * ``U_bond = exp(- dt H_bond)`` for ``type_evo='imag'``.
@@ -917,7 +917,7 @@ class RandomUnitaryEvolution(TEBDEngine):
 
     On one hand, such an evolution is of interest in recent research (see eg. :arxiv:`1710.09827`).
     On the other hand, it also comes in handy to "randomize" an initial state, e.g. for DMRG.
-    Note that the entanglement grows very quickly, choose the truncation paramters accordingly!
+    Note that the entanglement grows very quickly, choose the truncation parameters accordingly!
 
     Options
     -------

--- a/tenpy/models/lattice.py
+++ b/tenpy/models/lattice.py
@@ -588,7 +588,7 @@ class Lattice:
         factor : int
             The new number of sites in the MPS unit cell will be increased from `N_sites` to
             ``factor*N_sites_per_ring``. Since MPS unit cells are repeated in the `x`-direction
-            in our convetion, the lattice shape goes from
+            in our convention, the lattice shape goes from
             ``(Lx, Ly, ..., Lu)`` to ``(Lx*factor, Ly, ..., Lu)``.
         """
         if self.bc_MPS != "infinite":
@@ -662,7 +662,7 @@ class Lattice:
         lat_idx : array
             First dimensions like `i`, last dimension has len `dim`+1 and contains the lattice
             indices ``(x_0, ..., x_{dim-1}, u)`` corresponding to `i`.
-            For `i` accross the MPS unit cell and "infinite" or "segment" `bc_MPS`,
+            For `i` across the MPS unit cell and "infinite" or "segment" `bc_MPS`,
             we shift `x_0` accordingly.
         """
         if self.bc_MPS != 'finite':
@@ -685,7 +685,7 @@ class Lattice:
             The last dimension corresponds to lattice indices ``(x_0, ..., x_{D-1}, u)``.
             All lattice indices should be positive and smaller than the corresponding entry in
             ``self.shape``. Exception: for "infinite" or "segment" `bc_MPS`,
-            an `x_0` outside indicates shifts accross the boundary.
+            an `x_0` outside indicates shifts across the boundary.
 
         Returns
         -------
@@ -768,7 +768,7 @@ class Lattice:
 
         Examples
         --------
-        Say you measure expection values of an onsite term for an MPS, which gives you an 1D array
+        Say you measure expectation values of an onsite term for an MPS, which gives you an 1D array
         `A`, where `A[i]` is the expectation value of the site given by ``self.mps2lat_idx(i)``.
         Then this function gives you the expectation values ordered by the lattice:
 
@@ -844,7 +844,7 @@ class Lattice:
             Specifies for each `axis` in `axes`, for which MPS indices we have values in the
             corresponding `axis` of `A`.
             Defaults to ``[np.arange(A.shape[ax]) for ax in axes]``.
-            For indices accross the MPS unit cell and "infinite" `bc_MPS`,
+            For indices across the MPS unit cell and "infinite" `bc_MPS`,
             we shift `x_0` accordingly.
         include_u : (list of) bool
             Specifies for each `axis` in `axes`, whether the `u` index of the lattice should be
@@ -983,7 +983,7 @@ class Lattice:
         :attr:`basis` and :attr:`unit_cell_positions` of the lattice).
 
         .. warning ::
-            This function ignores "wrapping" arround the cylinder in the case of periodic boundary
+            This function ignores "wrapping" around the cylinder in the case of periodic boundary
             conditions.
 
         Parameters
@@ -1127,16 +1127,16 @@ class Lattice:
         mps1, mps2 : 1D array
             For each possible two-site coupling the MPS indices for the `u1` and `u2`.
         strength_vals : 1D array
-            (Only returend if `strength` is not None.)
+            (Only returned if `strength` is not None.)
             Such that ``for (i, j, s) in zip(mps1, mps2, strength_vals):`` iterates over all
             possible couplings with `s` being the strength of that coupling.
             Couplings where ``strength_vals == 0.`` are filtered out.
         lat_indices : 2D int array
-            (Only returend if `strength` is None.)
+            (Only returned if `strength` is None.)
             Rows of `lat_indices` correspond to entries of `mps1` and `mps2` and contain the
             lattice indices of the "lower left corner" of the box containing the coupling.
         coupling_shape : tuple of int
-            (Only returend if `strength` is None.)
+            (Only returned if `strength` is None.)
             Len :attr:`dim`. The correct shape for an array specifying the coupling strength.
             `lat_indices` has only rows within this shape.
         """
@@ -1188,7 +1188,7 @@ class Lattice:
         """filter possible j sites of a coupling from :meth:`possible_couplings`"""
         return np.all(
             np.logical_or(
-                lat_j_shifted == lat_j,  # not accross the boundary
+                lat_j_shifted == lat_j,  # not across the boundary
                 np.logical_not(self.bc)),  # direction has PBC
             axis=1)
 
@@ -1240,16 +1240,16 @@ class Lattice:
             conditions of `self` (how much the `box` for given `dx` can be shifted around without
             hitting a boundary - these are the different rows).
         strength_vals : 1D array
-            (Only returend if `strength` is not None.)
+            (Only returned if `strength` is not None.)
             Such that ``for  (ijkl, s) in zip(mps_ijkl, strength_vals):`` iterates over all
             possible couplings with `s` being the strength of that coupling.
             Couplings where ``strength_vals == 0.`` are filtered out.
         lat_indices : 2D int array
-            (Only returend if `strength` is None.)
+            (Only returned if `strength` is None.)
             Rows of `lat_indices` correspond to rows of `mps_ijkl` and contain the lattice indices
             of the "lower left corner" of the box containing the coupling.
         coupling_shape : tuple of int
-            (Only returend if `strength` is None.)
+            (Only returned if `strength` is None.)
             Len :attr:`dim`. The correct shape for an array specifying the coupling strength.
             `lat_indices` has only rows within this shape.
         """
@@ -1298,7 +1298,7 @@ class Lattice:
         """Filter possible couplings from :meth:`possible_multi_couplings`"""
         return np.all(
             np.logical_or(
-                lat_ijkl_shifted == lat_ijkl,  # not accross the boundary
+                lat_ijkl_shifted == lat_ijkl,  # not across the boundary
                 np.logical_not(self.bc)),  # direction has PBC
             axis=(1, 2))
 
@@ -1310,7 +1310,7 @@ class Lattice:
         ax : :class:`matplotlib.axes.Axes`
             The axes on which we should plot.
         markers : list
-            List of values for the keywork `marker` of ``ax.plot()`` to distinguish the different
+            List of values for the keyword `marker` of ``ax.plot()`` to distinguish the different
             sites in the unit cell, a site `u` in the unit cell is plotted with a marker
             ``markers[u % len(markers)]``.
         labels : list of str
@@ -1370,7 +1370,7 @@ class Lattice:
             The axes on which we should plot.
         coupling : list of (u1, u2, dx)
             By default (``None``), use ``self.pairs['nearest_neighbors']``.
-            Specifies the connections to be plotted; iteating over lattice indices `(i0, i1, ...)`,
+            Specifies the connections to be plotted; iterating over lattice indices `(i0, i1, ...)`,
             we plot a connection from the site ``(i0, i1, ..., u1)`` to the site
             ``(i0+dx[0], i1+dx[1], ..., u2)``, taking into account the boundary conditions.
         wrap : bool
@@ -1451,7 +1451,7 @@ class Lattice:
         ax : :class:`matplotlib.axes.Axes`
             The axes on which we should plot.
         direction : int
-            The direction of the lattice along which we should mark the idenitified sites.
+            The direction of the lattice along which we should mark the identified sites.
             If ``None``, mark it along all directions with periodic boundary conditions.
         cylinder_axis : bool
             Whether to plot the cylinder axis as well.
@@ -1475,7 +1475,7 @@ class Lattice:
         x_y = []
         for i in dirs:
             if self.bc[i]:
-                raise ValueError("Boundary conditons are not periodic for given direction")
+                raise ValueError("Boundary conditions are not periodic for given direction")
             x_y.append(origin)
             x_y.append(origin + self.Ls[i] * self.basis[i])
             if self.bc_shift is not None and i > 0:
@@ -1539,7 +1539,7 @@ class Lattice:
 class TrivialLattice(Lattice):
     """Trivial lattice consisting of a single (possibly large) unit cell in 1D.
 
-    This is usefull if you need a valid :class:`Lattice` with given :meth:`mps_sites`
+    This is useful if you need a valid :class:`Lattice` with given :meth:`mps_sites`
     and don't care about the actual geometry, e.g, because you don't intend to use the
     :class:`~tenpy.models.model.CouplingModel`.
 
@@ -1555,7 +1555,7 @@ class TrivialLattice(Lattice):
 
 
 class SimpleLattice(Lattice):
-    """A lattice with a unit cell consiting of just a single site.
+    """A lattice with a unit cell consisting of just a single site.
 
     In many cases, the unit cell consists just of a single site, such that the the last entry of
     `u` of an 'lattice index' can only be ``0``.
@@ -1603,7 +1603,7 @@ class MultiSpeciesLattice(Lattice):
 
 
     An initialized  `MultiSpeciesLattice` replaces each site in the given `simple_lattice` with
-    the `species_sites`. This is usefull e.g. if you want to place spin-full fermions
+    the `species_sites`. This is useful e.g. if you want to place spin-full fermions
     (or bosons) on a regular lattice, without falling back to the
     :class:`~tenpy.networks.site.GroupedSite` causing a larger, local dimension.
 
@@ -1619,7 +1619,7 @@ class MultiSpeciesLattice(Lattice):
         You can initialize the `simple_lattice` with any local sites, e.g. ``sites=None``, since
         the sites of the MultiSpeciesLattice are defined below.
     species_sites : list of :class:`~tenpy.networks.site.Site`
-        A collection of sites representing differnt species.
+        A collection of sites representing different species.
     species_names : list of str | None
         Names for the species. Defaults to ``['0', '1', ...]``.
         Used to define separate :attr:`pairs` by appending ``'_{name}'`` to the lattice.
@@ -1655,7 +1655,7 @@ class MultiSpeciesLattice(Lattice):
         [array([0, 1]), array([1, 0])]
         >>> fs_lat = MultiSpeciesLattice(simple_lat, [f, s], ['f', 's'])
 
-    There are corresponding coupling pairs definded:
+    There are corresponding coupling pairs defined:
 
     .. doctest :: MultiSpeciesLattice
 

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -3,7 +3,7 @@
 A 'model' is supposed to represent a Hamiltonian in a generalized way.
 The :class:`~tenpy.models.lattice.Lattice` specifies the geometry and
 underlying Hilbert space, and is thus common to all models.
-It is needed to intialize the common base class :class:`Model` of all models.
+It is needed to initialize the common base class :class:`Model` of all models.
 
 Different algorithms require different representations of the Hamiltonian.
 For example for DMRG, the Hamiltonian needs to be given as an MPO,
@@ -1086,7 +1086,7 @@ class CouplingModel(Model):
             >>> for u1, u2, dx in self.lat.pairs['nearest_neighbors']:
             ...     self.add_coupling(t, u1, 'Cd', u2, 'C', dx, plus_hc=True)
 
-        Alternatively, you can add the hermitian conjugate terms explictly. The correct way is to
+        Alternatively, you can add the hermitian conjugate terms explicitly. The correct way is to
         complex conjugate the strength, take the hermitian conjugate of the operators and swap the
         order (including a swap `u1` <-> `u2`), and use the opposite direction ``-dx``, i.e.
         the `h.c.` of ``add_coupling(t, u1, 'A', u2, 'B', dx)`` is
@@ -1452,7 +1452,7 @@ class CouplingModel(Model):
             The MPS indices of the sites on which the operators acts. With `i, j, k, ... = ijkl`,
             we require that they are ordered ascending, ``i < j < k < ...`` and
             that ``0 <= i < N_sites``.
-            Inidces >= N_sites indicate couplings between different unit cells of an infinite MPS.
+            Indices >= N_sites indicate couplings between different unit cells of an infinite MPS.
         ops_ijkl : list of str
             Names of the involved operators on sites `i, j, k, ...`.
         op_string : list of str
@@ -1865,7 +1865,7 @@ class CouplingMPOModel(CouplingModel, MPOModel):
         self._called_CouplingMPOModel_init = True
         self.manually_call_init_H = getattr(self, 'manually_call_init_H', False)
         explicit_plus_hc = model_params.get('explicit_plus_hc', False)
-        # 1-4) iniitalize lattice
+        # 1-4) initalize lattice
         lat = self.init_lattice(model_params)
         # 5) initialize CouplingModel
         CouplingModel.__init__(self, lat, explicit_plus_hc=explicit_plus_hc)
@@ -2008,7 +2008,7 @@ class CouplingMPOModel(CouplingModel, MPOModel):
                 raise ValueError("Can't auto-determine parameters for the lattice. "
                                  "Overwrite the `init_lattice` in your model!")
 
-            # possibly modify/generalize the already iniialized lattice
+            # possibly modify/generalize the already initialized lattice
             if species_sites is not None:
                 lat = MultiSpeciesLattice(lat, species_sites, species_names)
             helical = model_params.get('helical_lattice', None)

--- a/tenpy/networks/mpo.py
+++ b/tenpy/networks/mpo.py
@@ -13,7 +13,7 @@ i.e. the entries of the 'matrices' are local operators.
 Valid boundary conditions of an MPO are the same as for an MPS
 (i.e. ``'finite' | 'segment' | 'infinite'``).
 (In general, you can view the MPO as an MPS with larger physical space and bring it into
-canoncial form. However, unlike for an MPS, this doesn't simplify calculations.
+canonical form. However, unlike for an MPS, this doesn't simplify calculations.
 Thus, an MPO has no `form`.)
 
 We use the following label convention for the `W` (where arrows indicate `qconj`)::
@@ -75,10 +75,10 @@ class MPO:
         Boundary conditions as described in :mod:`~tenpy.networks.mps`.
         ``'finite'`` requires ``Ws[0].get_leg('wL').ind_len = 1``.
     IdL : (iterable of) {int | None}
-        Indices on the bonds, which correpond to 'only identities to the left'.
+        Indices on the bonds, which correspond to 'only identities to the left'.
         A single entry holds for all bonds.
     IdR : (iterable of) {int | None}
-        Indices on the bonds, which correpond to 'only identities to the right'.
+        Indices on the bonds, which correspond to 'only identities to the right'.
     max_range : int | np.inf | None
         Maximum range of hopping/interactions (in unit of sites) of the MPO. ``None`` for unknown.
     explicit_plus_hc : bool
@@ -97,11 +97,11 @@ class MPO:
         Boundary conditions as described in :mod:`~tenpy.networks.mps`.
         ``'finite'`` requires ``Ws[0].get_leg('wL').ind_len = 1``.
     IdL : list of {int | None}
-        Indices on the bonds (length `L`+1), which correpond to 'only identities to the left'.
+        Indices on the bonds (length `L`+1), which correspond to 'only identities to the left'.
         ``None`` for bonds where it is not set.
         In standard form, this is `0` (except for unset bonds in finite case)
     IdR : list of {int | None}
-        Indices on the bonds (length `L`+1), which correpond to 'only identities to the right'.
+        Indices on the bonds (length `L`+1), which correspond to 'only identities to the right'.
         ``None`` for bonds where it is not set.
         In standard form, this is the last index on the bond (except for unset bonds in finite case).
     max_range : int | np.inf | None
@@ -239,10 +239,10 @@ class MPO:
         bc : {'finite' | 'segment' | 'infinite'}
             Boundary conditions as described in :mod:`~tenpy.networks.mps`.
         IdL : (iterable of) {int | None}
-            Indices on the bonds, which correpond to 'only identities to the left'.
+            Indices on the bonds, which correspond to 'only identities to the left'.
             A single entry holds for all bonds.
         IdR : (iterable of) {int | None}
-            Indices on the bonds, which correpond to 'only identities to the right'.
+            Indices on the bonds, which correspond to 'only identities to the right'.
         Ws_qtotal : (list of) total charge
             The `qtotal` to be used for each grid. Defaults to zero charges.
         legs : list of :class:`~tenpy.linalg.charge.LegCharge`
@@ -1439,7 +1439,7 @@ class MPOGraph:
     This representation is used for building H_MPO from the interactions.
     The idea is to view the MPO as a kind of 'finite state machine'.
     The **states** or **keys** of this finite state machine life on the MPO bonds *between* the
-    `Ws`. They label the indices of the virtul bonds of the MPOs, i.e., the indices on legs
+    `Ws`. They label the indices of the virtual bonds of the MPOs, i.e., the indices on legs
     ``wL`` and ``wR``. They can be anything hash-able like a ``str``, ``int`` or a tuple of them.
 
     The **edges** of the graph are the entries ``W[keyL, keyR]``, which itself are onsite operators
@@ -1447,7 +1447,7 @@ class MPOGraph:
     of the MPO. The entry ``W[keyL, keyR]`` connects the state ``keyL`` on bond ``(i-1, i)``
     with the state ``keyR`` on bond ``(i, i+1)``.
 
-    The keys ``'IdR'`` (for 'idenity left') and ``'IdR'`` (for 'identity right') are reserved to
+    The keys ``'IdR'`` (for 'identity left') and ``'IdR'`` (for 'identity right') are reserved to
     represent only ``'Id'`` (=identity) operators to the left and right of the bond, respectively.
 
     .. todo ::
@@ -1475,7 +1475,7 @@ class MPOGraph:
         Maximum range of hopping/interactions (in unit of sites) of the MPO. ``None`` for unknown.
     states : list of set of keys
         ``states[i]`` gives the possible keys at the virtual bond ``(i-1, i)`` of the MPO.
-        `L+1` enries.
+        `L+1` entries.
     graph : list of dict of dict of list of tuples
         For each site `i` a dictionary ``{keyL: {keyR: [(opname, strength)]}}`` with
         ``keyL in states[i]`` and ``keyR in states[i+1]``.

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -16,7 +16,7 @@ We store one 3-leg tensor `_B[i]` with labels ``'vL', 'vR', 'p'`` for each of th
 ``0 <= i < L``.
 Additionally, we store ``L+1`` singular value arrays `_S[ib]` on each bond ``0 <= ib <= L``,
 independent of the boundary conditions.
-``_S[ib]`` gives the singlur values on the bond ``i-1, i``.
+``_S[ib]`` gives the singular values on the bond ``i-1, i``.
 However, be aware that e.g. :attr:`~tenpy.networks.mps.MPS.chi` returns only the dimensions of the
 :attr:`~tenpy.networks.mps.MPS.nontrivial_bonds` depending on the boundary conditions.
 
@@ -31,7 +31,7 @@ Valid MPS boundary conditions (not to confuse with `bc_coupling` of
 ==========  ===================================================================================
 `bc`        description
 ==========  ===================================================================================
-'finite'    Finite MPS, ``G0 s1 G1 ... s{L-1} G{l-1}``. This is acchieved
+'finite'    Finite MPS, ``G0 s1 G1 ... s{L-1} G{l-1}``. This is achieved
             by using a trivial left and right bond ``s[0] = s[-1] = np.array([1.])``.
 'segment'   Generalization of 'finite', describes an MPS embedded in left and right
             environments. The left environment is described by ``chi[0]`` *orthonormal* states
@@ -64,13 +64,13 @@ site of the MPS in :attr:`MPS.form`.
 `form`   tuple      description
 ======== ========== ==========================================================================
 ``'B'``  (0, 1)     right canonical: ``_B[i] = -- Gamma[i] -- s[i+1]--``
-                    The default form, which algorithms asssume.
+                    The default form, which algorithms assume.
 ``'C'``  (0.5, 0.5) symmetric form: ``_B[i] = -- s[i]**0.5 -- Gamma[i] -- s[i+1]**0.5--``
 ``'A'``  (1, 0)     left canonical: ``_B[i] = -- s[i] -- Gamma[i] --``.
 ``'G'``  (0, 0)     Save only ``_B[i] = -- Gamma[i] --``.
 ``'Th'`` (1, 1)     Form of a local wave function `theta` with singular value on both sides.
                     ``psi.get_B(i, 'Th') is equivalent to ``psi.get_theta(i, n=1)``.
-``None`` ``None``   General non-canoncial form.
+``None`` ``None``   General non-canonical form.
                     Valid form for initialization, but you need to call
                     :meth:`~tenpy.networks.mps.MPS.canonical_form` (or similar)
                     before using algorithms.
@@ -181,7 +181,7 @@ class MPS:
         The singular values on *each* bond. Should always have length `L+1`.
         Entries out of :attr:`nontrivial_bonds` are ignored.
     bc : ``'finite' | 'segment' | 'infinite'``
-        Boundary conditions as described in the tabel of the module doc-string.
+        Boundary conditions as described in the table of the module doc-string.
     form : (list of) {``'B' | 'A' | 'C' | 'G' | 'Th' | None`` | tuple(float, float)}
         The form of the stored 'matrices', see table in module doc-string.
         A single choice holds for all of the entries.
@@ -221,7 +221,7 @@ class MPS:
         takes proper care of the boundary conditions.
         Sometimes (e.g. during DMRG with an enabled mixer), entries may temporarily be
         a non-diagonal :class:`tenpy.linalg.np_conserved.Array` to be inserted between the
-        left canonical 'A' tensors on the left and rigth-canonical _B[i] on the right.
+        left canonical 'A' tensors on the left and right-canonical _B[i] on the right.
     _valid_forms : dict
         Class attribute.
         Mapping for canonical forms to a tuple ``(nuL, nuR)`` indicating that
@@ -423,7 +423,7 @@ class MPS:
         """Construct an MPS from a product state given in lattice coordinates.
 
         This is a wrapper around :meth:`from_product_state`.
-        The purpuse is to make the `p_state` argument independent of the `order` of the `Lattice`,
+        The purpose is to make the `p_state` argument independent of the `order` of the `Lattice`,
         and specify it in terms of lattice indices instead.
 
         Parameters
@@ -456,7 +456,7 @@ class MPS:
             >>> fermion = tenpy.networks.site.FermionSite()
             >>> ladder_i = tenpy.models.lattice.Ladder(2, [spin_half, fermion], bc_MPS="infinite")
 
-        To initialize a state of up-spins on the spin sites and half-filled ferions, you can use:
+        To initialize a state of up-spins on the spin sites and half-filled fermions, you can use:
 
         .. doctest : MPS.from_lat_product_state
 
@@ -538,7 +538,7 @@ class MPS:
             An entry of `int` type represents the physical index of the state to be used.
             An entry which is a 1D array defines the complete wavefunction on that site; this
             allows to make a (local) superposition.
-        bc : {'infinite', 'finite', 'segmemt'}
+        bc : {'infinite', 'finite', 'segment'}
             MPS boundary conditions. See docstring of :class:`MPS`.
         dtype : type or string
             The data type of the array entries.
@@ -593,7 +593,7 @@ class MPS:
         the order of the two entries for the ``bloch_sphere_state`` would be *exactly the opposite*
         (when we keep the the north-pole of the bloch sphere being the up-state).
         The reason is that the `SpinChain` uses the general :class:`~tenpy.networks.site.SpinSite`,
-        where the states are orderd ascending from ``'down'`` to ``'up'``.
+        where the states are ordered ascending from ``'down'`` to ``'up'``.
         The :class:`~tenpy.networks.site.SpinHalfSite` on the other hand uses the order
         ``'up', 'down'`` where that the Pauli matrices look as usual.
         """
@@ -650,7 +650,7 @@ class MPS:
             The singular values on *each* bond. Should always have length `L+1`.
             By default (``None``), set all singular values to the same value.
             Entries out of :attr:`nontrivial_bonds` are ignored.
-        bc : {'infinite', 'finite', 'segmemt'}
+        bc : {'infinite', 'finite', 'segment'}
             MPS boundary conditions. See docstring of :class:`MPS`.
         dtype : type or string
             The data type of the array entries. Defaults to the common dtype of `Bflat`.
@@ -739,7 +739,7 @@ class MPS:
         bc : 'finite' | 'segment'
             Boundary conditions.
         outer_S : None | (array, array)
-            For 'semgent' `bc` the singular values on the left and right of the considered segment,
+            For 'segment' `bc` the singular values on the left and right of the considered segment,
             `None` for 'finite' boundary conditions.
 
         Returns
@@ -821,7 +821,7 @@ class MPS:
             Sites which are not included into a singlet pair.
         lonely_state : int | str
             The state for the lonely sites.
-        bc : {'infinite', 'finite', 'segmemt'}
+        bc : {'infinite', 'finite', 'segment'}
             MPS boundary conditions. See docstring of :class:`MPS`.
 
         Returns
@@ -974,7 +974,7 @@ class MPS:
 
         Raises
         ------
-        ValueError : if self is not in canoncial form and `form` is not None.
+        ValueError : if self is not in canonical form and `form` is not None.
         """
         i = self._to_valid_index(i)
         new_form = self._to_valid_form(form)
@@ -1245,7 +1245,7 @@ class MPS:
         ----------
         extra_legs : list of {None, :class:`~tenpy.linalg.charges.LegCharge`, int}
             The extra charges to be added on the virtual legs, with qconj=+1.
-            Lenght `L` +1 for finite, length `L` for infinite, with entry `i` left of site `i`.
+            Length `L` +1 for finite, length `L` for infinite, with entry `i` left of site `i`.
             If an `int` is given, fill up with a single block of charges like the Schmidt state
             with highest weight. Note that this might force the resulting state to not be in
             strict "right-canonical" B form if that charge block becomes overcomplete.

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -2594,7 +2594,7 @@ class MPS:
             warnings.warn(
                 "Inefficent evaluation of MPS.correlation_function(), "
                 "it's probably faster to use MPS.term_correlation_function_left()",
-                stracklevel=2)
+                stacklevel=2)
         if autoJW and not all([isinstance(op1, str) for op1 in ops1]):
             warnings.warn("Non-string operator: can't auto-determine Jordan-Wigner!", stacklevel=2)
             autoJW = False

--- a/tenpy/networks/purification_mps.py
+++ b/tenpy/networks/purification_mps.py
@@ -22,7 +22,7 @@ Here, we follow the third approach.
 In addition to the physical space `P`, we introduce a second 'auxiliar' space `Q`
 and define the density matrix
 of the physical system as :math:`\rho = Tr_Q(|\phi><\phi|)`, where :math:`|\phi>` is a pure state
-in the combined phyisical and auxiliar system.
+in the combined physical and auxiliary system.
 
 For :math:`T=\infty`, the density matrix :math:`\rho_\infty` is the identity matrix.
 In other words, expectation values are sums over all possible states
@@ -64,7 +64,7 @@ We  use the following label convention::
     |         p
 
 You can view the `MPO` as an MPS by combining the `p` and `q` leg and defining every physical
-operator to act trivial on the `q` leg. In expecation values, you would then sum over
+operator to act trivial on the `q` leg. In expectation values, you would then sum over
 over the `q` legs, which is exactly what we need.
 In other words, the choice :math:`B = \delta_{p,q}` with trivial (length-1) virtual bonds yields
 infinite temperature expectation values for operators action only on the `p` legs!
@@ -72,7 +72,7 @@ infinite temperature expectation values for operators action only on the `p` leg
 Now, you go a step further and also apply imaginary time evolution (acting only on `p` legs)
 to the initial infinite temperature state.
 For example, the normalized state :math:`|\psi> \propto \exp(-\beta/2 H)|\phi>`
-yields expecation values
+yields expectation values
 
 .. math ::
     <O>  = Tr(\exp(-\beta H) O) / Tr(\exp(-\beta H))
@@ -134,7 +134,7 @@ class PurificationMPS(MPS):
     r"""An MPS representing a finite-temperature ensemble using purification.
 
     Similar as an MPS, but each `B` has now the four legs ``'vL', 'vR', 'p', 'q'``.
-    From the point of algorithms, it is to be considered as a ususal MPS by combining the legs
+    From the point of algorithms, it is to be considered as a usual MPS by combining the legs
     `p` and `q`, but all physical operators act only on the `p` part.
     For example, the right-canonical form is defined as if the legs 'p' and 'q' would be combined,
     e.g. a right-canonical `B` full-fills::
@@ -330,7 +330,7 @@ class PurificationMPS(MPS):
         This function is similar as :meth:`entanglement_entropy`,
         but for more general geometry of the region `A` to be a segment of a *few* sites.
 
-        This is acchieved by explicitly calculating the reduced density matrix of `A`
+        This is achieved by explicitly calculating the reduced density matrix of `A`
         and thus works only for small segments.
 
         Parameters
@@ -343,7 +343,7 @@ class PurificationMPS(MPS):
             or `range(L)` for infinite boundary conditions.
         n : int | float
             Selects which entropy to calculate;
-            `n=1` (default) is the ususal von-Neumann entanglement entropy,
+            `n=1` (default) is the usual von-Neumann entanglement entropy,
             otherwise the `n`-th Renyi entropy.
         leg : 'p', 'q', 'pq'
             Whether we look at the entanglement entropy in both (`pq`) or

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -39,8 +39,8 @@ class Site(Hdf5Exportable):
     defining the charges of the physical leg for this site.
     Moreover, it stores (local) on-site operators, which are directly available as attribute,
     e.g., ``self.Sz`` is the Sz operator for the :class:`SpinSite`.
-    Alternatively, operators can be obained with :meth:`get_op`.
-    The operator names ``Id`` and ``JW`` are reserved for the identy and Jordan-Wigner strings.
+    Alternatively, operators can be obtained with :meth:`get_op`.
+    The operator names ``Id`` and ``JW`` are reserved for the identity and Jordan-Wigner strings.
 
     .. warning ::
         The order of the local basis can change depending on the charge conservation!


### PR DESCRIPTION
I fixed some typos in the TeNPy docstrings, whilst reading the code. 
I also found one typo in the actual code (in mps.py line 2597), that prevented the correct warning output.
