### PR TITLE
Revise public attributes of VectorSpaces

### DIFF
--- a/tenpy/linalg/backends/abstract_backend.py
+++ b/tenpy/linalg/backends/abstract_backend.py
@@ -161,7 +161,7 @@ class AbstractBackend(ABC):
     def to_dense_block(self, a: Tensor) -> Block:
         """Forget about symmetry structure and convert to a single block.
         This includes a permutation of the basis, specified by the legs of `a`.
-        (see VectorSpace.sector_perm or VectorSpace.index_perm).
+        (see e.g. VectorSpace._sector_perm).
         """
         ...
 
@@ -171,7 +171,7 @@ class AbstractBackend(ABC):
         to a single 1D block.
         This is the diagonal of the respective non-symmetric 2D tensor.
         This includes a permutation of the basis, specified by the legs of `a`.
-        (see VectorSpace.sector_perm or VectorSpace.index_perm).
+        (see e.g. VectorSpace._sector_perm).
 
         Equivalent to self.block_get_diagonal(a.to_full_tensor().to_dense_block())
         """
@@ -184,7 +184,7 @@ class AbstractBackend(ABC):
         If the block is not symmetric, measured by ``allclose(a, projected, atol, rtol)``,
         where ``projected`` is `a` projected to the space of symmetric tensors
         This includes a permutation of the basis, specified by the legs of `a`.
-        (see VectorSpace.sector_perm or VectorSpace.index_perm).
+        (see e.g. VectorSpace._sector_perm).
         """
         ...
 
@@ -192,7 +192,7 @@ class AbstractBackend(ABC):
     def diagonal_from_block(self, a: Block, leg: VectorSpace) -> DiagonalData:
         """DiagonalData from a 1D block.
         This includes a permutation of the basis, specified by the legs of `a`.
-        (see VectorSpace.sector_perm or VectorSpace.index_perm).
+        (see e.g. VectorSpace._sector_perm).
         """
         ...
 
@@ -384,7 +384,7 @@ class AbstractBackend(ABC):
         ----------
         idx
             The index for both legs. Checks have already been performed, i.e. we may assume that
-            - 0 <= idx < leg.dim
+            ``0 <= idx < leg.dim``
         """
         ...
 
@@ -424,7 +424,7 @@ class AbstractBackend(ABC):
     @abstractmethod
     def diagonal_data_from_full_tensor(self, a: Tensor, check_offdiagonal: bool) -> DiagonalData:
         """Get the DiagonalData corresponding to a tensor with two legs.
-        Can assume that the two legs are either equal or dual, such that their ._sectors match"""
+        Can assume that the two legs are either equal or dual, such that their ._non_dual_sorted_sectors match"""
         ...
 
     @abstractmethod

--- a/tenpy/linalg/backends/nonabelian.py
+++ b/tenpy/linalg/backends/nonabelian.py
@@ -475,6 +475,7 @@ def all_fusion_trees(space: VectorSpace, coupled: Sector = None) -> Iterator[Fus
         for coupled in coupled_sectors(space):
             yield from all_fusion_trees(space, coupled=coupled)
     else:
+        # TODO double checs this is the right spaces attribute!
         for uncoupled in space.sectors:
             yield from fusion_trees(uncoupled, coupled)
 
@@ -482,8 +483,8 @@ def all_fusion_trees(space: VectorSpace, coupled: Sector = None) -> Iterator[Fus
 def coupled_sectors(codomain: ProductSpace, domain: ProductSpace) -> SectorArray:
     """The coupled sectors which are admitted by both codomain and domain"""
     # TODO think about duality!
-    codomain_coupled = codomain._sectors
-    domain_coupled = domain._sectors
+    codomain_coupled = codomain._non_dual_sorted_sectors
+    domain_coupled = domain._non_dual_sorted_sectors
     # OPTIMIZE: find the sectors which appear in both codomain_coupled and domain_coupled
     #  can probably be done much more efficiently, in particular since they are sorted.
     #  look at np.intersect1d for inspiration?

--- a/tenpy/linalg/symmetries/spaces.py
+++ b/tenpy/linalg/symmetries/spaces.py
@@ -67,8 +67,8 @@ class VectorSpace:
         The permutation of sectors induced by the above sorting
     _sorted_multiplicities : 1D numpy array of int
         The multiplicities ordered like `_non_dual_sorted_sectors`, i.e. `_multiplicities == multiplicities[sector_perm]`.
-    _slices : 2D numpy array of int
-        The slices ordered like `_sectors`, i.e. `_slices == slices[sector_perm]`.
+    _sorted_slices : 2D numpy array of int
+        The slices ordered like `_sectors`, i.e. `_sorted_slices == slices[sector_perm]`.
         
     Parameters
     ----------

--- a/tests/linalg/conftest.py
+++ b/tests/linalg/conftest.py
@@ -145,8 +145,8 @@ def tensor_rng(backend, backend_data_rng, vector_space_rng, np_random):
             if compatible_leg.num_sectors > max_num_blocks:
                 keep = np_random.choice(compatible_leg.num_sectors, max_num_blocks, replace=False)
                 compatible_leg = spaces.VectorSpace(compatible_leg.symmetry,
-                                                    compatible_leg._sectors[keep, :],
-                                                    np.maximum(compatible_leg.multiplicities[keep],
+                                                    compatible_leg._non_dual_sorted_sectors[keep, :],
+                                                    np.maximum(compatible_leg._sorted_multiplicities[keep],
                                                                 max_block_size),
                                                     compatible_leg.is_real,
                                                     compatible_leg.is_dual)


### PR DESCRIPTION
Define "public" attributes via properties that hide the implementation detail of sector-sorting from users.