### PR TITLE
Fix #289 and enhancements of MPS.correlation_length()

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -68,3 +68,4 @@ Fixed
 - :issue:`265` that MPO methods :meth:`~tenpy.networks.mpo.MPO.make_U_I`, `make_U_II`, `apply_naively` and `apply_zipup` 
   just ignored the `explicit_plus_hc` flag of the MPO, possibly giving completely wrong results without raising errors.
 - Make sure that :func:`~tenpy.linalg.np_conserved.eigh` doesn't have a :class:`~tenpy.linalg.charges.LegPipe` on the second (=new) leg.
+- :issue:`289` that :meth:`~tenpy.networks.mps.MPS.correlation_length` raised errors for `charge_sector` np ndarrays.

--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -69,3 +69,4 @@ Fixed
   just ignored the `explicit_plus_hc` flag of the MPO, possibly giving completely wrong results without raising errors.
 - Make sure that :func:`~tenpy.linalg.np_conserved.eigh` doesn't have a :class:`~tenpy.linalg.charges.LegPipe` on the second (=new) leg.
 - :issue:`289` that :meth:`~tenpy.networks.mps.MPS.correlation_length` raised errors for `charge_sector` np ndarrays.
+  Also, provide a :meth:`~tenpy.networks.mps.MPS.correlation_length_charge_sectors` convenience function to return valid charge sectors

--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -69,4 +69,5 @@ Fixed
   just ignored the `explicit_plus_hc` flag of the MPO, possibly giving completely wrong results without raising errors.
 - Make sure that :func:`~tenpy.linalg.np_conserved.eigh` doesn't have a :class:`~tenpy.linalg.charges.LegPipe` on the second (=new) leg.
 - :issue:`289` that :meth:`~tenpy.networks.mps.MPS.correlation_length` raised errors for `charge_sector` np ndarrays.
-  Also, provide a :meth:`~tenpy.networks.mps.MPS.correlation_length_charge_sectors` convenience function to return valid charge sectors
+  Further, allow to pass multiplie charge sectors to loop over at once, add argument `return_charges`.
+  Also, provide a :meth:`~tenpy.networks.mps.MPS.correlation_length_charge_sectors` convenience function to return valid charge sectors.

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -590,9 +590,13 @@ def test_correlation_length():
     # generate test-MPS with non-trivial correlation length
     model_AKLT = AKLTChain({'bc_MPS': 'infinite', 'L': 2})
     psi_AKLT = model_AKLT.psi_AKLT()
+    # eigenvalues of AKLT single-site TM are [1, 1./3., 1./3., 1/3.] for charges [0, 0, +2, -2]
     xi_AKLT = 1./np.log(3)
     xi = psi_AKLT.correlation_length()
     assert abs(xi - xi_AKLT) < 1.e-13
+    xi = psi_AKLT.correlation_length(charge_sector=[-2])
+    assert abs(xi - xi_AKLT) < 1.e-13
+
 
 
 def test_MPSEnvironment_expectation_values():

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.testing as npt
 import warnings
 from tenpy.models.xxz_chain import XXZChain
+from tenpy.models.aklt import AKLTChain
 from tenpy.models.lattice import Square, Chain, Honeycomb
 
 from tenpy.tools import misc
@@ -578,6 +579,20 @@ def test_expectation_value_multisite():
     env1 = mps.MPSEnvironment(psi1, psi)
     ev = env1.expectation_value(SpSm) # = <psi|dagger(SpSm)_2 SpSm_i |psi>
     npt.assert_almost_equal(ev, np.array([+0.25, 0., 0.5, 0., 0.25]))
+
+
+def test_correlation_length():
+    spin_half = site.SpinHalfSite(conserve=None, sort_charge=True)
+    up_state = ['up'] * 4
+    psi_product = mps.MPS.from_product_state([spin_half] * 4, up_state, bc='infinite')
+    assert psi_product.correlation_length() == 0.
+
+    # generate test-MPS with non-trivial correlation length
+    model_AKLT = AKLTChain({'bc_MPS': 'infinite', 'L': 2})
+    psi_AKLT = model_AKLT.psi_AKLT()
+    xi_AKLT = 1./np.log(3)
+    xi = psi_AKLT.correlation_length()
+    assert abs(xi - xi_AKLT) < 1.e-13
 
 
 def test_MPSEnvironment_expectation_values():

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -585,7 +585,8 @@ def test_correlation_length():
     spin_half = site.SpinHalfSite(conserve=None, sort_charge=True)
     up_state = ['up'] * 4
     psi_product = mps.MPS.from_product_state([spin_half] * 4, up_state, bc='infinite')
-    assert psi_product.correlation_length() == 0.
+    assert psi_product.correlation_length() == 0.  # trivial
+    ch_s = psi_product.correlation_length_charge_sectors()
 
     # generate test-MPS with non-trivial correlation length
     model_AKLT = AKLTChain({'bc_MPS': 'infinite', 'L': 2})
@@ -594,9 +595,22 @@ def test_correlation_length():
     xi_AKLT = 1./np.log(3)
     xi = psi_AKLT.correlation_length()
     assert abs(xi - xi_AKLT) < 1.e-13
-    xi = psi_AKLT.correlation_length(charge_sector=[-2])
+    charges = psi_AKLT.correlation_length_charge_sectors()
+    npt.assert_array_equal(charges[np.argsort(charges[:, 0])], [[0], [2]]) # dropped [-2]
+    xis, charges = psi_AKLT.correlation_length(target=3, charge_sector=None, return_charges=True)
+    assert len(xis) == 3
+    assert np.all(np.abs(xi - xi_AKLT) < 1.e-13 )
+    charges = np.asarray(charges)
+    npt.assert_array_equal(charges[np.argsort(charges[:, 0])], [[-2], [0], [2]])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        xi_m2, charges = psi_AKLT.correlation_length(target=1, charge_sector=[-2], return_charges=True)
+        npt.assert_array_equal(charges, [-2])
+        assert abs(xi_m2 - xi_AKLT) < 1.e-13
+        # note: sectors have only one entry, so target only changes resulting
+        xi_p2 = psi_AKLT.correlation_length(target=2, charge_sector=np.array([+2]), tol_ev0=None)
+        assert abs(xi_p2[0] - xi_AKLT) < 1.e-13
     assert abs(xi - xi_AKLT) < 1.e-13
-
 
 
 def test_MPSEnvironment_expectation_values():


### PR DESCRIPTION
This closes #289.
I've also
- added a test for MPS.correlation_lenght(), which we didn't have yet (oops...)
- added a convenience function `MPS.correlation_length_charge_sectors`
For the MPS.correlation_length, I've
- added an argument `return_charges` such that one can also get the information which sector is relevant when using `charge_sector=None`.
- allowed to pass multiple charge sectors at once and loop over them.
