### PR TITLE
Fix version conflict for docbuild action

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - graphviz
   - pandoc
   - sphinx-copybutton
+  - sphinxcontrib-bibtex!=2.6


### PR DESCRIPTION
The problem with the docbuild action is caused by the sphinxcontrib-bibtex version bump to `2.6.0` which went live yesterday.
Excluding that version fixes it.