### PR TITLE
Enhance iDMRG stability by avoiding inverses of singular values

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -34,6 +34,7 @@ Added
   ``from tenpy import MPS, tensordot, TwoSiteDMRGEngine`` or ``import tenpy as tp`` and then use
   ``tp.tensordot`` etc. All objects which are not "private" and/or "implementation details" are
   exposed in the subpackage namespace, e.g. you can ``from tenpy.networks import MPOGraph``.
+- MPS methods :meth:`~tenpy.networks.mps.MPS.move_orthogonality_center` and :meth:`~tenpy.networks.mps.MPS.find_orthogonality_center`.
 
 Changed
 ^^^^^^^

--- a/tenpy/networks/mpo.py
+++ b/tenpy/networks/mpo.py
@@ -2218,21 +2218,21 @@ class MPOEnvironment(BaseEnvironment):
     def _contract_LP(self, i, LP):
         """Contract LP with the tensors on site `i` to form ``self._LP[i+1]``"""
         # same as MPSEnvironment._contract_LP, but also contract with `H.get_W(i)`
-        LP = npc.tensordot(LP, self.ket.get_B(i, form='A'), axes=('vR', 'vL'))
+        LP = npc.tensordot(LP, self.ket.get_B(i, form='A', avoid_S_inverse=True), axes=('vR', 'vL'))
         LP = npc.tensordot(self.H.get_W(i), LP, axes=(['p*', 'wL'], ['p', 'wR']))
         axes = (self.bra._get_p_label('*') + ['vL*'], self.ket._p_label + ['vR*'])
         # for a ususal MPS, axes = (['p*', 'vL*'], ['p', 'vR*'])
-        LP = npc.tensordot(self.bra.get_B(i, form='A').conj(), LP, axes=axes)
+        LP = npc.tensordot(self.bra.get_B(i, form='A', avoid_S_inverse=True).conj(), LP, axes=axes)
         return LP  # labels 'vR*', 'wR', 'vR'
 
     def _contract_RP(self, i, RP):
         """Contract RP with the tensors on site `i` to form ``self._RP[i-1]``"""
         # same as MPSEnvironment._contract_RP, but also contract with `H.get_W(i)`
-        RP = npc.tensordot(self.ket.get_B(i, form='B'), RP, axes=('vR', 'vL'))
+        RP = npc.tensordot(self.ket.get_B(i, form='B', avoid_S_inverse=True), RP, axes=('vR', 'vL'))
         RP = npc.tensordot(RP, self.H.get_W(i), axes=(['p', 'wL'], ['p*', 'wR']))
         axes = (self.ket._p_label + ['vL*'], self.ket._get_p_label('*') + ['vR*'])
         # for a ususal MPS, axes = (['p', 'vL*'], ['p*', 'vR*'])
-        RP = npc.tensordot(RP, self.bra.get_B(i, form='B').conj(), axes=axes)
+        RP = npc.tensordot(RP, self.bra.get_B(i, form='B', avoid_S_inverse=True).conj(), axes=axes)
         return RP  # labels 'vL', 'wL', 'vL*'
 
     def _contract_LHeff(self, i, label_p='p0', pipe=None):

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -3547,7 +3547,7 @@ class MPS(BaseMPSExpectationValue):
         M = self.get_B(L - 1, form)
         M = npc.tensordot(R, M, axes=['vR', 'vL'])
         if self.bc == 'segment':
-            # also neet to calculate new singular values on the very right
+            # also need to calculate new singular values on the very right
             U, S, VR_segment = npc.svd(M.combine_legs(['vL'] + self._p_label),
                                        cutoff=cutoff,
                                        inner_labels=['vR', 'vL'])
@@ -5442,17 +5442,17 @@ class MPSEnvironment(BaseEnvironment, BaseMPSExpectationValue):
         return contr * self.bra.norm * self.ket.norm
 
     def _contract_LP(self, i, LP):
-        LP = npc.tensordot(LP, self.ket.get_B(i, form='A'), axes=('vR', 'vL'))
+        LP = npc.tensordot(LP, self.ket.get_B(i, form='A', avoid_S_inverse=True), axes=('vR', 'vL'))
         axes = (self.ket._get_p_label('*') + ['vL*'], self.ket._p_label + ['vR*'])
         # for a ususal MPS, axes = (['p*', 'vL*'], ['p', 'vR*'])
-        LP = npc.tensordot(self.bra.get_B(i, form='A').conj(), LP, axes=axes)
+        LP = npc.tensordot(self.bra.get_B(i, form='A', avoid_S_inverse=True).conj(), LP, axes=axes)
         return LP  # labels 'vR*', 'vR'
 
     def _contract_RP(self, i, RP):
-        RP = npc.tensordot(self.ket.get_B(i, form='B'), RP, axes=('vR', 'vL'))
+        RP = npc.tensordot(self.ket.get_B(i, form='B', avoid_S_inverse=True), RP, axes=('vR', 'vL'))
         axes = (self.ket._p_label + ['vL*'], self.ket._get_p_label('*') + ['vR*'])
         # for a ususal MPS, axes = (['p', 'vL*'], ['p*', 'vR*'])
-        RP = npc.tensordot(RP, self.bra.get_B(i, form='B').conj(), axes=axes)
+        RP = npc.tensordot(RP, self.bra.get_B(i, form='B', avoid_S_inverse=True).conj(), axes=axes)
         return RP  # labels 'vL', 'vL*'
 
     # methods for Expectation values

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -1843,8 +1843,9 @@ class MPS(BaseMPSExpectationValue):
                       down='down',
                       lonely=[],
                       lonely_state='up',
-                      bc='finite'):
-        """Create an MPS of entangled singlets.
+                      bc='finite',
+                      form='B'):
+        """Create an MPS of entangled singlets, also known as valence bold solid.
 
         Parameters
         ----------
@@ -1864,6 +1865,8 @@ class MPS(BaseMPSExpectationValue):
             The state for the lonely sites.
         bc : {'infinite', 'finite', 'segment'}
             MPS boundary conditions. See docstring of :class:`MPS`.
+        form  : ``'B' | 'A' | 'C' | 'G' | None``
+            The canonical form of the resulting MPS, see module doc-string.
 
         Returns
         -------
@@ -1946,7 +1949,10 @@ class MPS(BaseMPSExpectationValue):
             Ss.append(np.ones(N) / (N**0.5))
             Ts = next_Ts
             labels_L = labels_R
-        return cls([site] * L, Bs, Ss, bc=bc, form=forms)
+        res = cls([site] * L, Bs, Ss, bc=bc, form=forms)
+        if form is not None:
+            res.convert_form(form, avoid_S_inverse=True)
+        return res
 
     @property
     def L(self):

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -4153,6 +4153,8 @@ class MPS(BaseMPSExpectationValue):
             opB = npc.tensordot(op, self._B[i], axes=['p*', 'p'])
             self.set_B(i, opB, self.form[i])
         else:
+            if not unitary:
+                self.move_orthogonality_center(i)
             th = self.get_theta(i, n)
             th = npc.tensordot(op, th, axes=[pstar, p])
             # use MPS.from_full to split the sites
@@ -4164,6 +4166,8 @@ class MPS(BaseMPSExpectationValue):
                 self.set_B(i + j, split_th._B[j], split_th.form[j])
             for j in range(n - 1):
                 self.set_SR(i + j, split_th._S[j + 1])
+            if not unitary:
+                self.move_orthogonality_center(to_i=0, from_i=i)
         if not unitary:
             self.canonical_form(renormalize=renormalize)
 

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -2222,7 +2222,7 @@ class MPS(BaseMPSExpectationValue):
             theta = npc.tensordot(theta, B, axes=['vR', 'vL'])
         return theta
 
-    def convert_form(self, new_form='B'):
+    def convert_form(self, new_form='B', avoid_S_inverse=False):
         """Tranform self into different canonical form (by scaling the legs with singular values).
 
         Parameters
@@ -2230,6 +2230,9 @@ class MPS(BaseMPSExpectationValue):
         new_form : (list of) {``'B' | 'A' | 'C' | 'G' | 'Th' | None`` | tuple(float, float)}
             The form the stored 'matrices'. The table in module doc-string.
             A single choice holds for all of the entries.
+        avoid_S_inverse : bool
+            If True, try to avoid taking inverses of singular values at the cost of additional
+            SVDs to move the orthogonality center locally. See :meth:`get_B`.
 
         Raises
         ------
@@ -2237,7 +2240,8 @@ class MPS(BaseMPSExpectationValue):
         """
         new_forms = self._parse_form(new_form)
         for i, new_form in enumerate(new_forms):
-            new_B = self.get_B(i, form=new_form, copy=False)  # calculates the desired form.
+            # get_B() calculates the desired form.
+            new_B = self.get_B(i, form=new_form, copy=False, avoid_S_inverse=avoid_S_inverse)
             self.set_B(i, new_B, form=new_form)
 
     def find_orthogonality_center(self, strict=None, find_all=False):

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -307,7 +307,8 @@ def test_orthogonality_center():
         assert "No strict orthogonality center" in str(excinfo.value)
     cs = psi.find_orthogonality_center(strict=False, find_all=True)
     assert cs == [1, 3]
-    psi = mps.MPS.from_product_state([s]*L, ['up']*L, form=['A', 'A', 'Th', 'B', 'B'])
+    psi = mps.MPS.from_singlets(s, L, [[0, 2], [3, 4]], lonely=[1],
+                                form=['A', 'A', 'Th', 'B', 'B'])
     assert psi.find_orthogonality_center() == 2
     psi.move_orthogonality_center(to_i=1)
     assert psi.find_orthogonality_center() == 1

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -292,6 +292,31 @@ def test_canonical_form(bc, method):
             assert A_err < 1.e-13
 
 
+def test_orthogonality_center():
+    s = site.SpinHalfSite(None)
+    L = 5
+    psi = mps.MPS.from_product_state([s]*L, ['up']*L, form='B')
+    assert psi.find_orthogonality_center() == 0
+    assert psi.find_orthogonality_center(strict=False) == 0
+    psi = mps.MPS.from_product_state([s]*L, ['up']*L, form='A')
+    assert psi.find_orthogonality_center() == psi.L - 1
+    assert psi.find_orthogonality_center(strict=False) == psi.L - 1
+    psi = mps.MPS.from_product_state([s]*L, ['up']*L, form=['A', 'A', 'B', 'A', 'B'])
+    with pytest.raises(ValueError) as excinfo:
+        c = psi.find_orthogonality_center()
+        assert "No strict orthogonality center" in str(excinfo.value)
+    cs = psi.find_orthogonality_center(strict=False, find_all=True)
+    assert cs == [1, 3]
+    psi = mps.MPS.from_product_state([s]*L, ['up']*L, form=['A', 'A', 'Th', 'B', 'B'])
+    assert psi.find_orthogonality_center() == 2
+    psi.move_orthogonality_center(to_i=1)
+    assert psi.find_orthogonality_center() == 1
+    psi.move_orthogonality_center(to_i=4)
+    assert psi.find_orthogonality_center() == 4
+    psi.move_orthogonality_center(to_i=0)
+    assert psi.find_orthogonality_center() == 0
+
+
 @pytest.mark.parametrize("bc", ['finite', 'infinite'])
 def test_apply_op(bc, eps=1.e-13):
     s = site.SpinHalfSite(None)


### PR DESCRIPTION
While the finite DMRG sweeps moves the orthogonality center and thus should never need inverses of singular values,
the insertion of the iDMRG unit cell *does* require it so far.
Reasoning: iDMRG looks at a segment of the unit cell and has the MPS in center canonical form with A on the left and B on the right. But to insert a unit cell, we need a unit cell of only B tensors on the right, or all A on the left, respectively.
Hence, we apparently need to take inverse of singular values when inserting the unit cells, at least for the initial guess of the local theta: e.g. for the two-site DMRG with a two-site unit cell, we perform updates
```
                                A[0] S B[1]
-> insert unit cell on right    A[0] S B[1] inv(S) A[0] S B[1]
-> update(1,2)                         A[1]    S   B[0]
-> insert unit cell on left     A[0]   A[1]    S   B[0] inv(S) A[1] S B[0]
-> update(0,1)                                     A[0]    S   B[0]
```
Note that we (should) only absorb B tensors in the right environments (and A into the left one, respectively).

The idea of this pull request is to avoid the inverse singular values all together, at least during the iDMRG sweeps.
This happens at the cost of an additional (single-site) SVD shifting the orthogonality center:
E.g. for the `inv(S) A[0] S` to get `B[0]` for the first update, we can actually do an SVD of ` U s V = svd(A[0] S)` with the physical leg bent to the right, and calculate the two-site theta as `S B[1] U V`. Essentially, the `U V` is the unitary part of a polar decomposition, similar in spirit as in VUMPS. Note that the `UV` is an isometry as expected from B by construction as long as `U` is a unitary, which is the case if the dimensions of charge blocks of the `vL` of `A[0] S` are smaller than in the pipe `(p.vR)` going to the right. 
The `s` should just be the singular values in the center, if the state is translation invariant.  If the `S` in the center (for which we try to avoid the inverse) is not diagonal, e.g. for a mixer, we need to incorporate another basis transformation, since the `B[1]` has the `vR` leg *right* of the center S, while the `A[0]` leg has the `vL` leg *left* of the center S. But we  can get that basis transformation again by doing an SVD of the (matrix) `S`, `X Y Z = svd(S)` and get the `B[0]` as  `dagger(X Z) U V` in this case.

This PR implments the suggestion above in the `MPS._scale_B_inverse_free()` method, to be used by `MPS.get_B(i,form='B')` if the saved tensor is in `'A'` form (and similar with A<->B).
