### PR TITLE
Support move_right=None

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -46,6 +46,10 @@ Changed
   :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_inter_ring_interaction`, and
   :meth:`~tenpy.models.mixed_xk.MixedXKModel.add_intre_ring_interaction` to vary with `x`.
 - Renamed the module :mod:`~tenpy.linalg.lanczos` to :mod:`tenpy.linalg.krylov_based`.
+- The :attr:`~tenpy.algorithms.mps_common.Sweep.move_right` attribute of
+  :class:`~tenpy.algorithms.mps_common.Sweep` now supports a third value, ``None``, in addition
+  to ``True, False``. ``None`` means that the sweep will not move at all, i.e. the next update
+  will be at the same position than the current one. This happens e.g. in TDVP.
 
 Fixed
 ^^^^^

--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -297,8 +297,8 @@ class SubspaceExpansion(Mixer):
             right move, or ``'vL', '(p0.vR)'`` for left move.
         i0 : int
             The site index where `theta` lives.
-        move_right : bool
-            Whether we move to the right (``True``) or left (``False``).
+        move_right : bool | None
+            Whether we move to the right (``True``), left (``False``), or dont move (``None``).
 
         Returns
         -------
@@ -351,7 +351,7 @@ class SubspaceExpansion(Mixer):
                                          inner_labels=['vR', 'vL'])
             VH = VH.split_legs('(wR.vR)')
             VH = VH.take_slice(IdL, 'wR')  # project back such that U-S-VH is original theta
-        else:  # move left
+        else:  # move left (DMRG guarantees mover_right in [True, False])
             RHeff = _get_RHeff(engine.env, i0, engine.eff_H)  # on site i0, but with p1 label
             RHeff = RHeff.transpose(['(p1*.vL)', 'wL', '(p1.vL*)'])
             if not explicit_plus_hc and IdR is not None:
@@ -1046,6 +1046,7 @@ class DMRGEngine(Sweep):
                 # growing the bond dimension with chi_list, so we should also reactivate the mixer
                 self.mixer_activate()
         res = super().sweep(optimize)
+        assert self.move_right is not None  # Can assume move_right in [True, False] DMRG functions
         if optimize:
             # update mixer
             if self.mixer is not None:

--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -674,9 +674,6 @@ class EffectiveH(NpcLinearOperator):
     combine : bool
         Whether to combine legs into pipes as far as possible. This reduces the overhead of
         calculating charge combinations in the contractions.
-    move_right : bool | None
-        Whether the sweeping algorithm that calls for an `EffectiveH` is moving to the right,
-        to the left or not moving.
     """
     length = None
     acts_on = None
@@ -1139,8 +1136,6 @@ class ZeroSiteH(EffectiveH):
     acts_on : list of str
         Labels of the state on which `self` acts. NB: class attribute.
         Overwritten by normal attribute, if `combine`.
-    combine, move_right : bool
-        See above.
     LHeff, RHeff : :class:`~tenpy.linalg.np_conserved.Array`
         Only set if :attr:`combine`, and only one of them depending on :attr:`move_right`.
         If `move_right` was True, `LHeff` is set with labels ``'(vR*.p0)', 'wR', '(vR.p0*)'``

--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -91,9 +91,10 @@ class Sweep(Algorithm):
     i0 : int
         Only set during sweep.
         Left-most of the `EffectiveH.length` sites to be updated in :meth:`update_local`.
-    move_right : bool
+    move_right : bool | None
         Only set during sweep.
-        Whether the next `i0` of the sweep will be right or left of the current one.
+        Whether the next `i0` of the sweep will be right (`True`), left (`False`) or at the same
+        position (`None`) as the current one.
     update_LP_RP : (bool, bool)
         Only set during a sweep, see :meth:`get_sweep_schedule`.
         Indicates whether it is necessary to update the `LP` and `RP` in :meth:`update_env`.
@@ -409,8 +410,9 @@ class Sweep(Algorithm):
             Schedule for the sweep. Each entry is ``(i0, move_right, (update_LP, update_RP))``,
             where `i0` is the leftmost of the ``self.EffectiveH.length`` sites to be updated in
             :meth:`update_local`, `move_right` indicates whether the next `i0` in the schedule is
-            right (`True`) of the current one, and `update_LP`, `update_RP` indicate
-            whether it is necessary to update the `LP` and `RP` of the environments.
+            right (`True`), left (`False`) or equal (`None`) of the current one, and `update_LP`,
+            `update_RP` indicate whether it is necessary to update the `LP` and `RP` of the
+            environments.
         """
         # warning: set only those `LP` and `RP` to True, which can/will be used later again
         # otherwise, the assumptions in :meth:`free_no_longer_needed_envs` will not hold,
@@ -448,6 +450,8 @@ class Sweep(Algorithm):
             }
             if move_right:
                 kwargs['preload_RP'] = i0 + 2
+            elif move_right is None:
+                pass  # not moving. nothing to preload
             else:
                 kwargs['preload_LP'] = i0 - 1
         elif self.n_optimize == 1:
@@ -456,6 +460,11 @@ class Sweep(Algorithm):
                     'short_term_LP': [i0, i0 + 1],
                     'short_term_RP': [i0],
                     'preload_RP': i0 + 1,
+                }
+            elif move_right is None:
+                kwargs = {
+                    'short_term_LP': [i0],
+                    'short_term_RP': [i0],
                 }
             else:
                 kwargs = {
@@ -569,6 +578,7 @@ class Sweep(Algorithm):
             i_L = self.i0
             i_R = self.i0 + 1
         else:  # n == 1 and left moving
+            # TODO is this also correct if move_right is None?
             i_L = self.i0 - 1
             i_R = self.i0
         return i_L, i_R
@@ -610,7 +620,7 @@ class Sweep(Algorithm):
                 # so current LP[i_L] is useless
                 for env in all_envs:
                     env.del_LP(i_L)
-            elif not self.move_right and update_LP:
+            elif (self.move_right is False) and update_LP:
                 # will update site i_R coming from the right in the future
                 # so current RP[i_R] is useless
                 for env in all_envs:
@@ -644,8 +654,9 @@ class EffectiveH(NpcLinearOperator):
     combine : bool, optional
         Whether to combine legs into pipes as far as possible. This reduces the overhead of
         calculating charge combinations in the contractions.
-    move_right : bool, optional
-        Whether the sweeping algorithm that calls for an `EffectiveH` is moving to the right.
+    move_right : bool | None, optional
+        Whether the sweeping algorithm that calls for an `EffectiveH` is moving to the right,
+        to the left or not moving.
 
     Attributes
     ----------
@@ -663,8 +674,9 @@ class EffectiveH(NpcLinearOperator):
     combine : bool
         Whether to combine legs into pipes as far as possible. This reduces the overhead of
         calculating charge combinations in the contractions.
-    move_right : bool
-        Whether the sweeping algorithm that calls for an `EffectiveH` is moving to the right.
+    move_right : bool | None
+        Whether the sweeping algorithm that calls for an `EffectiveH` is moving to the right,
+        to the left or not moving.
     """
     length = None
     acts_on = None
@@ -748,8 +760,9 @@ class OneSiteH(EffectiveH):
         into pipes. This reduces the overhead of calculating charge combinations in the
         contractions, but one :meth:`matvec` is formally more expensive, :math:`O(2 d^3 \chi^3 D)`.
         Is originally from the wo-site method; unclear if it works well for 1 site.
-    move_right : bool
-        Whether the the sweep is moving right or left for the next update.
+    move_right : bool | None
+        Whether the sweeping algorithm that calls for an `EffectiveH` is moving to the right,
+        to the left or not moving.
 
     Attributes
     ----------
@@ -900,7 +913,7 @@ class OneSiteH(EffectiveH):
             env.get_LP(i, store=True)
 
     def update_RP(self, env, i, VH=None):
-        if self.combine and not self.move_right:
+        if self.combine and (self.move_right is False):
             assert i == self.i0 - 1
             RP = npc.tensordot(VH, self.RHeff, axes=['(p.vR)', '(p0*.vL)'])
             RP = npc.tensordot(RP, VH.conj(), axes=['(p0.vL*)', '(p*.vR*)'])
@@ -934,8 +947,8 @@ class TwoSiteH(EffectiveH):
         physical leg for the left site (when moving right) or right side (when moving left)
         into pipes. This reduces the overhead of calculating charge combinations in the
         contractions, but one :meth:`matvec` is formally more expensive, :math:`O(2 d^3 \chi^3 D)`.
-    move_right : bool
-        Whether the the sweep is moving right or left for the next update.
+    move_right : bool | None
+        Whether the the sweep is moving right or left for the next update (or doesnt move).
         Ignored for the :class:`TwoSiteH`.
 
     Attributes

--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -168,7 +168,7 @@ class TwoSiteTDVPEngine(TDVPEngine):
         L = self.psi.L
         if self.finite:
             i0s = list(range(0, L - 2)) + list(range(L - 2, -1, -1))
-            move_right = [True] * (L - 2) + [False] * (L - 1)
+            move_right = [True] * (L - 2) + [False] * (L - 2) + [None]
             update_LP_RP = [[True, False]] * (L - 2) + [[False, True]] * (L - 2) + [[False, False]]
         else:
             raise NotImplementedError("Only finite TDVP is implemented")
@@ -206,8 +206,10 @@ class TwoSiteTDVPEngine(TDVPEngine):
         if self.move_right:
             # note that i0 == L-2 is left-moving
             self.one_site_update(i0 + 1, 0.5j * self.dt)
-        elif i0 != 0:  # no one-site update on last update of the sweep
+        elif (self.move_right is False):
             self.one_site_update(i0, 0.5j * self.dt)
+        # for the last update of the sweep, where move_right is None, there is no one_site_update
+        
         return update_data
 
     def update_env(self, **update_data):
@@ -264,7 +266,7 @@ class SingleSiteTDVPEngine(TDVPEngine):
         L = self.psi.L
         if self.finite:
             i0s = list(range(0, L - 1)) + list(range(L - 1, -1, -1))
-            move_right = [True] * (L - 1) + [False] * L
+            move_right = [True] * (L - 1) + [False] * (L - 1) + [None]
             update_LP_RP = [[True, False]] * (L - 1) + [[False, True]] * (L - 1) + [[False, False]]
         else:
             raise NotImplementedError("Only finite TDVP is implemented")
@@ -283,6 +285,8 @@ class SingleSiteTDVPEngine(TDVPEngine):
         if self.move_right:
             self.right_moving_update(i0, theta)
         else:
+            # note: left_moving_update() also covers the "non-moving" case move_right=None
+            # of the last update in a sweep
             self.left_moving_update(i0, theta)
         return {}  # no truncation error in single-site TDVP!
 


### PR DESCRIPTION
It is currently not well-defined what the value of the `Sweep.move_right` attribute should be, if the sweep is not actually moving, i.e. if the next update is at the same position.
This happens e.g. in TDVP, where after the last update of a sweep at `i0=0`, the same site `i0=0` is updated again at the start of the next sweep.

Both TDVP engines set ``(i0, move_right) == (0, False)`` for the last update, which contradicts the definition from the docstring of `Sweep`:
```
move_right : bool
        Only set during sweep.
        Whether the next `i0` of the sweep will be right or left of the current one.
```

This causes problems in `Sweep._cache_optimize`:

> ```python
> ...
> if self.n_optimize == 2:
>     kwargs = {
>         'short_term_LP': [i0, i0 + 1],
>         'short_term_RP': [i0, i0 + 1],
>     }
>     if move_right:
>         kwargs['preload_RP'] = i0 + 2
>     else:
>         kwargs['preload_LP'] = i0 - 1
> ...
> ```

, where `not move_right` is interpreted as "we are moving to the left".

This PR addresses this by introducing support a third option for `move_right`, namely `None`, which means "not moving at all, next i0 is the same as the current".
`Sweep._cache_optimize` could then distinguish three cases.

I have added a "goal" version in the first commit, which breaks backwards compatibility and then introduced backwards compatible wrappers in the second commit which issue an appropriate warning.
We can then undo the changes from the second commit when moving to v1.0.

