### PR TITLE
Predict ram

### DIFF
--- a/tenpy/__init__.py
+++ b/tenpy/__init__.py
@@ -191,10 +191,16 @@ def console_main(*command_line_args):
                           FutureWarning)
             del options['simulation_class_name']
         options['simulation_class'] = args.sim_class
-    if 'RAM' in options:
+    if args.RAM:
         # get simulation
         sim = simulations.init_simulation(**options)
-        print(sim.estimate_RAM())
+        ram = sim.estimate_RAM()
+        if ram < 1024:      # if less then 1MB: print in kB
+            print("Estimated RAM usage: %d kB" % ram)
+        elif ram < 1024**2: # if less then 1GB: print in MB
+            print("Estimated RAM usage: %d MB" % (ram/1024))
+        else:               # if larger than 1MB print in GB
+            print("Estimated RAM usage: %.1f GB" % (ram/(1024**2)))
         exit(0)
     if 'sequential' not in options:
         run_simulation(**options)
@@ -253,7 +259,7 @@ def _setup_arg_parser(width=None):
                         "Options are 'error', 'first' or 'last'.")
     parser.add_argument('--RAM',
                         '-M',
-                        default='error',
+                        action="store_true",
                         help="Estimates the required RAM. This argument does not execute any code, but prints the prediction in kB and then exits.")
     parser.add_argument('parameters_file',
                         nargs='*',

--- a/tenpy/__init__.py
+++ b/tenpy/__init__.py
@@ -252,7 +252,7 @@ def _setup_arg_parser(width=None):
     parser.add_argument('--RAM',
                         '-M',
                         default='error',
-                        help="Estimates the required ram. This argument does not execute any code, but prints the prediction in MB and then exits")
+                        help="Estimates the required RAM. This argument does not execute any code, but prints the prediction in kB and then exits.")
     parser.add_argument('parameters_file',
                         nargs='*',
                         help="Yaml (*.yml) file with the simulation parameters/options. "

--- a/tenpy/__init__.py
+++ b/tenpy/__init__.py
@@ -192,7 +192,9 @@ def console_main(*command_line_args):
             del options['simulation_class_name']
         options['simulation_class'] = args.sim_class
     if 'RAM' in options:
-        print(simulation.estimate_RAM())
+        # get simulation
+        sim = simulations.init_simulation(**options)
+        print(sim.estimate_RAM())
         exit(0)
     if 'sequential' not in options:
         run_simulation(**options)

--- a/tenpy/__init__.py
+++ b/tenpy/__init__.py
@@ -191,6 +191,9 @@ def console_main(*command_line_args):
                           FutureWarning)
             del options['simulation_class_name']
         options['simulation_class'] = args.sim_class
+    if 'RAM' in options:
+        print(simulation.estimate_RAM())
+        exit(0)
     if 'sequential' not in options:
         run_simulation(**options)
     else:
@@ -246,6 +249,10 @@ def _setup_arg_parser(width=None):
                         default='error',
                         help="Selects how to merge conflicts in case of multiple yaml files. "
                         "Options are 'error', 'first' or 'last'.")
+    parser.add_argument('--RAM',
+                        '-M',
+                        default='error',
+                        help="Estimates the required ram. This argument does not execute any code, but prints the prediction in MB and then exits")
     parser.add_argument('parameters_file',
                         nargs='*',
                         help="Yaml (*.yml) file with the simulation parameters/options. "

--- a/tenpy/algorithms/algorithm.py
+++ b/tenpy/algorithms/algorithm.py
@@ -199,7 +199,7 @@ class Algorithm:
 
         Returns
         -------
-        usage : float
+        usage : int
             Required RAM in kB. It always returns a minimum of mini=50 MB.
         """
         import numpy as np
@@ -286,7 +286,7 @@ class Algorithm:
         RAM *= saving_factor
         logger.info("Total RAM expectation:\t\t\t%d kB" % (RAM//1024))
 
-        return max(RAM / 1024, mini) # in kB
+        return int(max(RAM / 1024, mini)) # in kB
 
 
 

--- a/tenpy/algorithms/algorithm.py
+++ b/tenpy/algorithms/algorithm.py
@@ -182,12 +182,18 @@ class Algorithm:
         else:
             return {'psi': self.psi}
 
-    def estimate_RAM(self, mini=50_000):
+    def estimate_RAM(self, saving_factor=None, mini=50_000):
         """Gives an approximate prediction for the required memory usage.
-        This calculation is based on the requested bond dimension, local Hilbert space dimension, the number of sites and the boundary conditions.
+        This calculation is based on the requested bond dimension, the local Hilbert space dimension, the number of sites, and the boundary conditions.
 
         Parameters
         ----------
+        saving_factor : float
+            Represents the amount of RAM saved due to conservation laws. By default, it is 'None' and is extracted from the model automatically. However, this is only possible in a few cases and needs to be estimated in most cases. This is due to the fact that it is dependent on the model parameters.
+            If one has a better estimate, one can pass the value directly.
+            This value can be extracted by building the initial state 'psi' (usually by performing DMRG ) and then calling
+            ''print(psi.get_B(0).sparse_stats())''
+            TeNPy will automatically print the fraction of nonzero entries in the first line (for example, 6 of 16 entries (=0.375) nonzero). This fraction corresponds to the saving_factor; in our example, it is 0.375.
         mini : float
             The minimum amount of RAM in kB to be returned. By default 50 MB.
 
@@ -245,12 +251,35 @@ class Algorithm:
                 # The shape is ordered like (wL, wR, p, p*)
                 env_RAM += chis[i]**2 * max(W.shape[0], W.shape[1])
 
+            lanczos_RAM = 0
+            # Additional RAM, if Lanczos is performed
+            # We need to construct (1) the effective Hamiltonian and (2) the two-site wave-function
+            # (1) H_eff
+            W = MPO.get_W(L//2)
+            # Left and right part from H_eff -> 2 times environment
+            # The third comes from the first contraction from 2-site wave function to left H_eff
+            lanczos_RAM += 3 * H_dim[L//2]**2 * (chis[L//2]**2 * max(W.shape[0], W.shape[1]))
+            #              |         |                          | 
+            #       occurrences   from W                environment RAM
+            #                    contraction
+
+            # (2) 2-site wave-function
+
+            lanczos_RAM += 2 * chis[L//2]**2 * H_dim[L//2]**2
+            #              |            |           | 
+            #         occurrences    virtual     physical
+            #       (top & bottom)    legs         legs
+
+
             logger.debug("Extracted MPS environment RAM usage as\t%d kB" % (env_RAM*entry_size // 1024))
             logger.debug("Extracted MPO RAM usage as\t\t%d kB" % (MPO_RAM // 128))
+            logger.debug("Extracted extra RAM from Lanczos as\t%d kB" % (lanczos_RAM // 128))
             RAM += env_RAM
             RAM += MPO_RAM
+            RAM += lanczos_RAM
 
-        saving_factor = self.model.estimate_RAM_saving_factor()
+        if saving_factor == None:
+            saving_factor = self.model.estimate_RAM_saving_factor()
         logger.debug("Each entry uses %d byte" % (entry_size))
         RAM *= entry_size
         logger.debug("We have a saving factor of %d" % (1/saving_factor))

--- a/tenpy/algorithms/algorithm.py
+++ b/tenpy/algorithms/algorithm.py
@@ -182,14 +182,19 @@ class Algorithm:
         else:
             return {'psi': self.psi}
 
-    def estimate_RAM(self):
+    def estimate_RAM(self, mini=50_000):
         """Gives an approximate prediction for the required memory usage.
         This calculation is based on the requested bond dimension, local Hilbert space dimension, the number of sites and the boundary conditions.
+
+        Parameters
+        ----------
+        mini : float
+            The minimum amount of RAM in kB to be returned. By default 50 MB.
 
         Returns
         -------
         usage : float
-            Required RAM in kB.
+            Required RAM in kB. It always returns a minimum of mini=50 MB.
         """
         import numpy as np
         # get memory per item
@@ -249,9 +254,11 @@ class Algorithm:
         saving_factor = self.model.estimate_RAM_saving_factor()
         logger.debug("Each entry uses %d byte" % (entry_size))
         RAM *= entry_size
-        logger.debug("We have a saving factor of %d" % (saving_factor))
+        logger.debug("We have a saving factor of %d" % (1/saving_factor))
         RAM *= saving_factor
-        return RAM / 1024 # in kB
+        logger.info("Total RAM expectation:\t\t\t%d kB" % (RAM//1024))
+
+        return max(RAM / 1024, mini) # in kB
 
 
 

--- a/tenpy/linalg/np_conserved.py
+++ b/tenpy/linalg/np_conserved.py
@@ -2339,6 +2339,7 @@ class Array:
         """
         if self is other:
             return True
+        if not isinstance(other, Array): raise NotImplementedError
         if other.chinfo != self.chinfo:
             raise ValueError("other array has different charges!")
         other = other._transpose_same_labels(self._labels)

--- a/tenpy/linalg/np_conserved.py
+++ b/tenpy/linalg/np_conserved.py
@@ -2339,7 +2339,7 @@ class Array:
         """
         if self is other:
             return True
-        if not isinstance(other, Array): raise NotImplementedError
+        if not isinstance(other, Array): return NotImplemented
         if other.chinfo != self.chinfo:
             raise ValueError("other array has different charges!")
         other = other._transpose_same_labels(self._labels)

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -89,6 +89,30 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         model_params.setdefault('lattice', "Chain")
         CouplingMPOModel.__init__(self, model_params)
 
+    def estimate_RAM_saving_factor(self):
+        """Returns the expected saving factor for RAM based on charge conservation.
+        For the BoseHubbardChain this factor was found to be between 1/7 and 1/10, therefore it is by default to 1/8 (for particle number conservation).
+
+        Returns
+        -------
+        factor : int
+            saving factor, due to conservation
+
+        Options
+        -------
+        .. cfg:configoptions :: Model
+
+            saving_factor :: None | int
+                Quantizes the RAM saving, due to conservation laws. By default it is 1/8 for the BoseHubbardChain. However, this factor might be overwritten, if a better approximation is known. In this case one can pass it via the argument ''saving_factor'' to the model.
+
+        """
+        chinfo = self.lat.unit_cell[0].leg.chinfo
+        savings = 1
+        for mod in chinfo.mod:
+            if mod == 1:
+                savings *= 1/8 # this is what we found empirically
+        return self.options.get("saving_factor", savings)
+
 
 class FermiHubbardModel(CouplingMPOModel):
     r"""Spin-1/2 Fermi-Hubbard model.

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -98,12 +98,6 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         factor : int
             saving factor, due to conservation
 
-        Options
-        -------
-        .. cfg:configoptions :: Model
-
-            saving_factor :: None | int
-                Quantizes the RAM saving, due to conservation laws. By default it is 1/8 for the BoseHubbardChain. However, this factor might be overwritten, if a better approximation is known. In this case one can pass it via the argument ''saving_factor'' to the model.
 
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
@@ -111,7 +105,7 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         for mod in chinfo.mod:
             if mod == 1:
                 savings *= 1/8 # this is what we found empirically
-        return self.options.get("saving_factor", savings)
+        return savings
 
 
 class FermiHubbardModel(CouplingMPOModel):

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -97,8 +97,6 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         -------
         factor : int
             saving factor, due to conservation
-
-
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
         savings = 1

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -9,7 +9,7 @@ Different algorithms require different representations of the Hamiltonian.
 For example for DMRG, the Hamiltonian needs to be given as an MPO,
 while TEBD needs the Hamiltonian to be represented by 'nearest neighbor' bond terms.
 This module contains the base classes defining these possible representations,
-namley the :class:`MPOModel` and :class:`NearestNeighborModel`.
+namely the :class:`MPOModel` and :class:`NearestNeighborModel`.
 
 A particular model like the :class:`~tenpy.models.models.xxz_chain.XXZChain` should then
 yet another class derived from these classes. In it's __init__, it needs to explicitly call
@@ -254,9 +254,26 @@ class Model(Hdf5Exportable):
         model_params['time'] = new_time
         return cls(model_params)
 
+    def estimate_RAM_saving_factor(self):
+        """Returns the expected saving factor for RAM based on charge conservation.
+
+        Returns
+        -------
+        factor : int
+            saving factor, due to conservation
+        """
+        chinfo = self.lat.unit_cell[0].leg.chinfo
+        savings = 1
+        for mod in chinfo.mod:
+            if mod == 1:
+                savings *= 1/4 # this is what we found empirically
+            else:
+                savings *= 1/mod
+        print(savings)
+        return savings
 
 class NearestNeighborModel(Model):
-    r"""Base class for a model of nearest neigbor interactions w.r.t. the MPS index.
+    r"""Base class for a model of nearest neighbor interactions w.r.t. the MPS index.
 
     In this class, the Hamiltonian :math:`H = \sum_{i} H_{i,i+1}` is represented by
     "bond terms" :math:`H_{i,i+1}` acting only on two neighboring sites `i` and `i+1`,
@@ -305,7 +322,7 @@ class NearestNeighborModel(Model):
     def from_MPOModel(cls, mpo_model):
         """Initialize a NearestNeighborModel from a model class defining an MPO.
 
-        This is especially usefull in combination with :meth:`MPOModel.group_sites`.
+        This is especially useful in combination with :meth:`MPOModel.group_sites`.
 
         Parameters
         ----------
@@ -397,7 +414,7 @@ class NearestNeighborModel(Model):
         factor : int
             The new number of sites in the MPS unit cell will be increased from `N_sites` to
             ``factor*N_sites_per_ring``. Since MPS unit cells are repeated in the `x`-direction
-            in our convetion, the lattice shape goes from
+            in our convention, the lattice shape goes from
             ``(Lx, Ly, ..., Lu)`` to ``(Lx*factor, Ly, ..., Lu)``.
         """
         super().enlarge_mps_unit_cell(factor)
@@ -635,7 +652,7 @@ class MPOModel(Model):
         factor : int
             The new number of sites in the MPS unit cell will be increased from `N_sites` to
             ``factor*N_sites_per_ring``. Since MPS unit cells are repeated in the `x`-direction
-            in our convetion, the lattice shape goes from
+            in our convention, the lattice shape goes from
             ``(Lx, Ly, ..., Lu)`` to ``(Lx*factor, Ly, ..., Lu)``.
         """
         super().enlarge_mps_unit_cell(factor)
@@ -759,7 +776,7 @@ class CouplingModel(Model):
 
     .. deprecated:: 0.4.0
         `bc_coupling` will be removed in 1.0.0. To specify the full geometry in the lattice,
-        use the `bc` parameter of the :class:`~tenpy.model.latttice.Lattice`.
+        use the `bc` parameter of the :class:`~tenpy.model.lattice.Lattice`.
 
     Parameters
     ----------
@@ -794,7 +811,7 @@ class CouplingModel(Model):
         ``self.add_coupling(..., plus_hc=True)`` was used.
         Note that :meth:`add_onsite`, :meth:`add_coupling`, :meth:`add_multi_coupling`
         and :meth:`add_exponentially_decaying_coupling` respect this flag, ensuring that the
-        *represented* Hamiltonian is indepentent of the `explicit_plus_hc` flag.
+        *represented* Hamiltonian is independent of the `explicit_plus_hc` flag.
     """
     def __init__(self, lattice, bc_coupling=None, explicit_plus_hc=False):
         Model.__init__(self, lattice)
@@ -1013,7 +1030,7 @@ class CouplingModel(Model):
         strength : scalar | array
             Prefactor of the coupling. May vary spatially (see above). If an array of smaller size
             is provided, it gets tiled to the required shape.
-            A single scalar number can be given to indicate a coupling which is uniform accross
+            A single scalar number can be given to indicate a coupling which is uniform across
             the lattice.
         u1 : int
             Picks the site ``lat.unit_cell[u1]`` for OP1.
@@ -1282,7 +1299,7 @@ class CouplingModel(Model):
         .. deprecated:: 0.6.0
             We switched from the three arguments `u0`, `op0` and `other_op` with
             ``other_ops=[(u1, op1, dx1), (op2, u2, dx2), ...]``
-            to a single, equivalent argment `ops` which should now read
+            to a single, equivalent argument `ops` which should now read
             ``ops=[(op0, dx0, u0), (op1, dx1, u1), (op2, dx2, u2), ...]``, where
             ``dx0 = [0]*self.lat.dim``. Note the changed order inside the tuples!
 

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -261,14 +261,6 @@ class Model(Hdf5Exportable):
         -------
         factor : int
             saving factor, due to conservation
-
-        Options
-        -------
-        .. cfg:configoptions :: Model
-
-            saving_factor :: None | float
-                Quantizes the RAM saving, due to conservation laws. By default it is 1/mod, or 1/4 in case of mod=1. However, for some classes this factor might be overwritten, if a better approximation is known. In the best case, the user has a good approximation and can pass it via the argument ``saving_factor`` to the model.
-
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
         savings = 1

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -261,6 +261,14 @@ class Model(Hdf5Exportable):
         -------
         factor : int
             saving factor, due to conservation
+
+        Options
+        -------
+        .. cfg:configoptions :: Model
+
+            saving_factor :: None | float
+                Quantizes the RAM saving, due to conservation laws. By default it is 1/mod, or 1/4 in case of mod=1. However, for some classes this factor might be overwritten, if a better approximation is known. In the best case, the user has a good approximation and can pass it via the argument ``saving_factor`` to the model.
+
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
         savings = 1
@@ -269,7 +277,6 @@ class Model(Hdf5Exportable):
                 savings *= 1/4 # this is what we found empirically
             else:
                 savings *= 1/mod
-        print(savings)
         return savings
 
 class NearestNeighborModel(Model):
@@ -1904,6 +1911,12 @@ class CouplingMPOModel(CouplingModel, MPOModel):
         self.init_H_from_terms()
         # finally checks for misspelled parameter names
         model_params.warn_unused()
+
+
+    def estimate_RAM_saving_factor(self):
+        est = super().estimate_RAM_saving_factor()
+        return self.options.get("RAM_saving_factor", est)
+
 
     @property
     def verbose(self):

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -251,7 +251,7 @@ class Simulation:
         Returns
         -------
         RAM : int
-            The expected RAM usage in MB.
+            The expected RAM usage in kB.
         """
         self.init_model()       # model, required for algorithm
         self.init_state()       # psi, required for algorithm

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -49,7 +49,7 @@ __all__ = [
 class Simulation:
     """Base class for simulations.
 
-    The prefered way to run simulations is in a `with` statement, which allows us to redirect
+    The preferred way to run simulations is in a `with` statement, which allows us to redirect
     error messages to the log files, timely warn about unused parameters and to properly close any
     open files. In other words, use the simulation class like this::
 
@@ -80,7 +80,7 @@ class Simulation:
         log_params : dict
             Log parameters; see :cfg:config:`log`.
         overwrite_output : bool
-            Whether an exisiting file may be overwritten.
+            Whether an existing file may be overwritten.
             Otherwise, if the file already exists we try to replace
             ``filename.ext`` with ``filename_01.ext`` (and further increasing numbers).
         random_seed : int | None
@@ -115,7 +115,7 @@ class Simulation:
             Information of the used library/code versions and simulation class.
             See :meth:`get_version_info`.
         finished_run : bool
-            Usefull to check whether the output file finished or was generated at a checkpoint.
+            Useful to check whether the output file finished or was generated at a checkpoint.
             This flag is set to `True` only right at the end of :meth:`run`
             (or :meth:`resume_run`) before saving.
         measurements : dict
@@ -128,8 +128,8 @@ class Simulation:
             Not part of `self.results`, but only added in :meth:`prepare_results_for_save` with
             the most up-to-date `resume_data` from
             :meth:`~tenpy.algorithms.algorithm.Algorithm.get_resume_data`.
-            Only included if :cfg:option:`Simultion.save_resume_data` is True.
-            Note that this contains anoter (reference or even copy of) `psi`.
+            Only included if :cfg:option:`Simulation.save_resume_data` is True.
+            Note that this contains another (reference or even copy of) `psi`.
 
     cache : :class:`~tenpy.tools.cache.DictCache`
         Cache that can be used by algorithms.
@@ -245,6 +245,20 @@ class Simulation:
             "See https://tenpy.readthedocs.io/en/latest/intro/logging.html", FutureWarning, 2)
         return self.options.get('verbose', 1.)
 
+    def estimate_RAM(self):
+        """Estimates the RAM usage for the simulation, without running it.
+
+        Returns
+        -------
+        RAM : int
+            The expected RAM usage in MB.
+        """
+        self.init_model()       # model, required for algorithm
+        self.init_state()       # psi, required for algorithm
+        self.init_algorithm()   # create engine (subclass of Algorithm)
+
+        return self.engine.estimate_RAM()
+
     def run(self):
         """Run the whole simulation.
 
@@ -276,7 +290,7 @@ class Simulation:
     def from_saved_checkpoint(cls, filename=None, checkpoint_results=None, **kwargs):
         """Re-initialize a given simulation class from checkpoint results.
 
-        You should probably call :meth:`resume_run` after sucessfull initialization.
+        You should probably call :meth:`resume_run` after successful initialization.
 
         Instead of calling this directly, consider using :func:`resume_from_checkpoint`.
 
@@ -287,7 +301,7 @@ class Simulation:
             You can either specify the `filename` or the `checkpoint_results`.
         checkpoint_results : None | dict
             Alternatively to `filename` the results of the simulation so far, i.e. directly the
-            data dicitonary saved at a simulation checkpoint.
+            data dictionary saved at a simulation checkpoint.
         **kwargs :
             Further keyword arguments given to the `Simulation.__init__`.
         """
@@ -489,10 +503,10 @@ class Simulation:
                 Class or name of a subclass of :class:`~tenpy.algorithms.algorithm.Algorithm`.
                 The engine of the algorithm to be run.
             algorithm_params : dict
-                Dictionary with parameters for the algortihm; see the decoumentation of the
+                Dictionary with parameters for the algorithm; see the documentation of the
                 `algorithm_class`.
             connect_algorithm_checkpoint : list of tuple
-                Functions to connect to the :attr:`~tenpy.algorithms.Algorith.checkpoint` event
+                Functions to connect to the :attr:`~tenpy.algorithms.Algorithm.checkpoint` event
                 of the algorithm.
                 Each tuple can be of length 2 to 4, with entries
                 ``(module, function, kwargs, priority)``, the last two optionally.
@@ -553,7 +567,7 @@ class Simulation:
         """
         self._connect_measurements()
         if self.options.get('measure_initial', True):
-            self.make_measurements()  # sets up self.results['measurements'] if necesssary
+            self.make_measurements()  # sets up self.results['measurements'] if necessary
 
     def _connect_measurements(self):
         if self.options.get('use_default_measurements', True):
@@ -881,7 +895,7 @@ class Simulation:
         Parameters
         ----------
         results : dict | None
-            The results to be safed. If not specified, call :meth:`prepare_results_for_save`
+            The results to be saved. If not specified, call :meth:`prepare_results_for_save`
             to allow last-minute adjustments to the saved :attr:`results`.
         """
         if results is None:
@@ -1281,7 +1295,7 @@ def run_seq_simulations(sequential,
     Parameters
     ----------
     sequential : dict
-        Paramters specifying the sequential simulation, see :cfg:config:`sequential` above.
+        Parameters specifying the sequential simulation, see :cfg:config:`sequential` above.
     resume_data : None | dict
         Usually None if you didn't already run a simulation that you want to continue.
         Otherwise the `resume_data` as given to the Simulation class.

--- a/tests/test_predict_ram.py
+++ b/tests/test_predict_ram.py
@@ -1,0 +1,49 @@
+"""Short test for vmem prediction."""
+# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+
+
+import tenpy.algorithms as algo
+import tenpy.models as mods
+import tenpy.networks.mps as mps
+from tenpy.algorithms import dmrg
+import numpy as np
+
+
+def test_bosonic_model_TEBD():
+    """Test with a bosonic chain."""
+    L = 15
+    model = mods.hubbard.BoseHubbardChain({"conserve":None, "U":1, "t":1, "bc_MPS": "finite", "L": L, "n_max": 4})
+    # Test TEBD first
+    psi = mps.MPS.from_product_state(model.lat.mps_sites(), [0]*L)
+    engine = algo.tebd.TEBDEngine(psi, model, {"trunc_params": {"chi_max": 33}})
+    # expected value:
+    # bond | 0   | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 | 13 | 14 | 15 |
+    # chi  | 5   | 25 | 33 | 33 | 33 | 33 | 33 | 33 | 33 | 33 | 33 | 33 | 33 | 33 | 25 | 5  |
+    # add matrices:
+    num_entries = 5*25 + 25*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*33 + 33*25 + 25*5
+    num_entries *= 5 # physical leg
+    # expected MPS vmem:
+    MPS_vmem = (num_entries * 8) / 1024
+    assert abs(engine.estimate_RAM(mini=0) - MPS_vmem) < 1e-10, "TEBD RAM did not match expectation (expected: %d, gotten:%d)" % (MPS_vmem, engine.estimate_RAM(mini=0))
+
+
+def test_bosonic_model_DMRG():
+    """Test with a bosonic chain."""
+    L = 15
+    model = mods.hubbard.BoseHubbardChain({"U":1, "t":1, "bc_MPS": "finite", "L": L, "n_max": 4})
+    psi = mps.MPS.from_product_state(model.lat.mps_sites(), [0]*L)
+    engine = algo.dmrg.TwoSiteDMRGEngine(psi, model, {"trunc_params": {"chi_max": 99}})
+    # expected value:
+    # bond | 0   | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 | 13 | 14 | 15 |
+    # chi  | 5   | 25 | 99 | 99 | 99 | 99 | 99 | 99 | 99 | 99 | 99 | 99 | 99 | 99 | 25 | 5  |
+    # add matrices:
+    num_entries = 5*25 + 25*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*99 + 99*25 + 25*5
+    num_entries *= 5 # physical leg
+    # expected MPS vmem:
+    MPS_vmem = (num_entries * 8) / 1024
+    # environment:
+    MPS_env_vmem = sum(np.array([5, 25, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 25])**2 * 4) * 8 / 1024
+    MPO_vmem = (4**2*5**2 * (L-2) + 2*4*5**2 * 2) * 8 / 1024
+
+    assert engine.estimate_RAM(mini=0) == (MPS_vmem+MPS_env_vmem+MPO_vmem)/8, "DMRG RAM did not match expectation (expected: %d, gotten:%d)" % ((MPS_vmem+MPS_env_vmem+MPO_vmem)/8, engine.estimate_RAM(mini=0))
+

--- a/tests/test_predict_ram.py
+++ b/tests/test_predict_ram.py
@@ -1,5 +1,5 @@
 """Short test for vmem prediction."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2023 TeNPy Developers, GNU GPLv3
 
 
 import tenpy.algorithms as algo
@@ -24,7 +24,7 @@ def test_bosonic_model_TEBD():
     num_entries *= 5 # physical leg
     # expected MPS vmem:
     MPS_vmem = (num_entries * 8) / 1024
-    assert abs(engine.estimate_RAM(mini=0) - MPS_vmem) < 1e-10, "TEBD RAM did not match expectation (expected: %d, gotten:%d)" % (MPS_vmem, engine.estimate_RAM(mini=0))
+    assert abs(engine.estimate_RAM(mini=0) - int(MPS_vmem)) < 1e-10, "TEBD RAM did not match expectation (expected: %d, gotten:%d)" % (MPS_vmem, engine.estimate_RAM(mini=0))
 
 
 def test_bosonic_model_DMRG():
@@ -46,5 +46,5 @@ def test_bosonic_model_DMRG():
     MPO_vmem = (4**2*5**2 * (L-2) + 2*4*5**2 * 2) * 8 / 1024
     # add lanczos:
     RAM_lanczos = (3 * 5**2 * (99**2 * 4) + 2 * 99**2 * 5**2) * 8 / 1024
-    assert engine.estimate_RAM(mini=0) == (MPS_vmem+MPS_env_vmem+MPO_vmem+RAM_lanczos)/8, "DMRG RAM did not match expectation (expected: %d, gotten:%d)" % ((MPS_vmem+MPS_env_vmem+MPO_vmem+RAM_lanczos)/8, engine.estimate_RAM(mini=0))
+    assert engine.estimate_RAM(mini=0) == int((MPS_vmem+MPS_env_vmem+MPO_vmem+RAM_lanczos)/8), "DMRG RAM did not match expectation (expected: %d, gotten:%d)" % ((MPS_vmem+MPS_env_vmem+MPO_vmem+RAM_lanczos)/8, engine.estimate_RAM(mini=0))
 

--- a/tests/test_predict_ram.py
+++ b/tests/test_predict_ram.py
@@ -44,6 +44,7 @@ def test_bosonic_model_DMRG():
     # environment:
     MPS_env_vmem = sum(np.array([5, 25, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 25])**2 * 4) * 8 / 1024
     MPO_vmem = (4**2*5**2 * (L-2) + 2*4*5**2 * 2) * 8 / 1024
-
-    assert engine.estimate_RAM(mini=0) == (MPS_vmem+MPS_env_vmem+MPO_vmem)/8, "DMRG RAM did not match expectation (expected: %d, gotten:%d)" % ((MPS_vmem+MPS_env_vmem+MPO_vmem)/8, engine.estimate_RAM(mini=0))
+    # add lanczos:
+    RAM_lanczos = (3 * 5**2 * (99**2 * 4) + 2 * 99**2 * 5**2) * 8 / 1024
+    assert engine.estimate_RAM(mini=0) == (MPS_vmem+MPS_env_vmem+MPO_vmem+RAM_lanczos)/8, "DMRG RAM did not match expectation (expected: %d, gotten:%d)" % ((MPS_vmem+MPS_env_vmem+MPO_vmem+RAM_lanczos)/8, engine.estimate_RAM(mini=0))
 


### PR DESCRIPTION
This code predicts the RAM usage required to perform an algorithm in TeNPy (for example, DMRG).
Closes #48

The following features are implemented:
- [x] Implemented usage for MPS, MPO and environments
- [x] Implemented saving due to conservation laws
- [x] Extracted saving factor for particle number conservation in the Bose-Hubbard model

It is compatible with infinite and finite MPS system sizes and was benchmarked for the following cases:

**1) Finite 1D:**
- [x] Tested with finite 1D Ising model (Parity conservation)
- [x] Tested with finite 1D Bose-Hubbard model (Particle number conservation)

**2) Infinite 1D:**
- [x] Tested with infinite 1D Bose-Hubbard model (Particle number conservation)
- [x] Tested with infinite 1D Ising model (Parity conservation)

**3) 2D Lattice:**
- [x] Tested with 2D triangular Heisenberg model

Remark: All RAM tests were performed on the TUM cluster running on Linux. For finite size MPS, the length L was varied; for iMPS, the bond dimension was varied. The ram was extracted using psutil as well as tracemalloc.