### PR TITLE
Make splitting of op names consistent in Site

### DIFF
--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -432,7 +432,7 @@ class Site(Hdf5Exportable):
             The operator given by `name`, with labels ``'p', 'p*'``.
             If name already was an npc Array, it's directly returned.
         """
-        names = name.split(' ')
+        names = name.split()
         op = getattr(self, names[0], None)
         if op is None:
             raise ValueError("{0!r} doesn't have the operator {1!r}".format(self, names[0]))
@@ -458,7 +458,7 @@ class Site(Hdf5Exportable):
         hc_op_name : str
             Operator name for the hermitian conjugate operator.
         """
-        names = name.split(' ')
+        names = name.split()
         hc_names = []
         for name2 in reversed(names):
             hc_name_2 = self.hc_ops.get(name2)


### PR DESCRIPTION
We currently use a single space as separator in `get_op` and `get_hc_op_name`, but any whitespace in `op_needs_JW` and `valid_opname`.
We should be consistent.
The docs say "separated by whitespace", so i chose to support any whitespace in all four.
Or should we only do single space @jhauschild ?