### PR TITLE
Update year in copyright notices

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,6 +8,7 @@ import inspect
 import sphinx_rtd_theme
 import io
 import warnings
+from datetime import datetime
 
 # ensure parent folder is in sys.path to allow import of tenpy
 REPO_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -71,7 +72,7 @@ pygments_style = 'sphinx'  # syntax highlighting style
 
 # General information about the project.
 project = 'TeNPy'
-copyright = '2016-2020, TeNPy Developers'
+copyright = f'2016-{datetime.today().strftime("%Y")}, TeNPy Developers'
 author = 'TeNPy Developers'
 version = tenpy.__version__  # The short X.Y version.
 release = tenpy.__full_version__  # The full version, including alpha/beta/rc tags.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 #
 import sys
 import os

--- a/examples/a_np_conserved.py
+++ b/examples/a_np_conserved.py
@@ -13,7 +13,7 @@ Note that this example uses only np_conserved, but no other modules.
 Compare it to the example `b_mps.py`,
 which does the same steps using a few predefined classes like MPS and MPO.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.np_conserved as npc
 import numpy as np

--- a/examples/advanced/central_charge_ising.py
+++ b/examples/advanced/central_charge_ising.py
@@ -6,7 +6,7 @@ the previous simulation, which can be seen at the "age".
 
 For the theoretical background why :math:`S = c/6 log(xi)`, see :cite:`pollmann2009`.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tenpy

--- a/examples/advanced/mpo_exponential_decay.py
+++ b/examples/advanced/mpo_exponential_decay.py
@@ -10,7 +10,7 @@ form (see the grid below).
 We run the iDMRG algorithm to find the ground state and energy density of the
 system in the thermodynamic limit.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tenpy.linalg.np_conserved as npc

--- a/examples/advanced/tfi_phase_transition.py
+++ b/examples/advanced/tfi_phase_transition.py
@@ -4,7 +4,7 @@ This example uses DMRG to find the ground state of the transverse field Ising mo
 through the phase transition by changing the field `g`.
 It plots a few observables in the end.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/advanced/xxz_corr_length.py
+++ b/examples/advanced/xxz_corr_length.py
@@ -5,7 +5,7 @@ through the phase transition by changing the field `hz`. It uses
 :meth:`~tenpy.networks.mps.MPS.correlation_length` to extract the correlation length of the ground
 state, and plots it vs. hz in the end.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/b_mps.py
+++ b/examples/b_mps.py
@@ -12,7 +12,7 @@ This example includes the following steps:
 Note that this example performs the same steps as `a_np_conserved.py`,
 but makes use of other predefined classes except npc.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.np_conserved as npc
 import numpy as np

--- a/examples/c_tebd.py
+++ b/examples/c_tebd.py
@@ -3,7 +3,7 @@
 The example functions in this class do the same as the ones in `toycodes/c_tebd.py`, but make use
 of the classes defined in tenpy.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/chern_insulators/chiral_pi_flux.py
+++ b/examples/chern_insulators/chiral_pi_flux.py
@@ -3,7 +3,7 @@
 Based on the model in [Neupert2011]_
 """
 
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/chern_insulators/haldane.py
+++ b/examples/chern_insulators/haldane.py
@@ -3,7 +3,7 @@
 Reproduces Fig. 2.a,b) in [Grushin2015]_
 """
 
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/chern_insulators/haldane_C3.py
+++ b/examples/chern_insulators/haldane_C3.py
@@ -3,7 +3,7 @@
 Based on the model in [Yang2012]_
 """
 
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/chern_insulators/haldane_FCI.py
+++ b/examples/chern_insulators/haldane_FCI.py
@@ -6,7 +6,7 @@ Based on Eq.1 of [Grushin2015]_ with:
 - 1/2 filling of the lowest band (i.e. 1/4 total filling)
 """
 
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/examples/d_dmrg.py
+++ b/examples/d_dmrg.py
@@ -3,7 +3,7 @@
 The example functions in this class do the same as the ones in `toycodes/d_dmrg.py`,
 but make use of the classes defined in tenpy.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/examples/e_tdvp.py
+++ b/examples/e_tdvp.py
@@ -4,7 +4,7 @@ As of now, we have TDVP only for finite systems. The call structure is quite sim
 difference is that we can run one-site TDVP or two-site TDVP. In the former, the bond dimension can
 not grow; the latter allows to grow the bond dimension and hence requires a truncation.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 import numpy as np
 import tenpy.linalg.np_conserved as npc
 import tenpy

--- a/examples/tfi_exact.py
+++ b/examples/tfi_exact.py
@@ -4,7 +4,7 @@ The Hamiltonian reads
 .. math ::
     H = - J \\sum_{i} \\sigma^x_i \\sigma^x_{i+1} - g \\sum_{i} \\sigma^z_i
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import scipy.sparse as sparse

--- a/examples/z_exact_diag.py
+++ b/examples/z_exact_diag.py
@@ -2,7 +2,7 @@
 
 Sorry that this is not well documented! ED is meant to be used for debugging only ;)
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.np_conserved as npc
 from tenpy.models.xxz_chain import XXZChain

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from setuptools import setup, Extension
 try:
     from Cython.Build import cythonize

--- a/tenpy/__init__.py
+++ b/tenpy/__init__.py
@@ -6,7 +6,7 @@ designed to study the physics of strongly correlated quantum systems.
 The code is intended to be accessible for newcommers
 and yet powerful enough for day-to-day research.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 # This file marks this directory as a python package.
 
 import warnings

--- a/tenpy/__main__.py
+++ b/tenpy/__main__.py
@@ -1,5 +1,5 @@
 """The tenpy entry point, called by ``python -m tenpy``."""
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy
 

--- a/tenpy/algorithms/__init__.py
+++ b/tenpy/algorithms/__init__.py
@@ -18,7 +18,7 @@
     exact_diag
     disentangler
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from . import algorithm, truncation, dmrg, dmrg_parallel, disentangler, mps_common, tebd, tdvp, \
     exact_diag, purification, network_contractor, mpo_evolution

--- a/tenpy/algorithms/algorithm.py
+++ b/tenpy/algorithms/algorithm.py
@@ -1,5 +1,5 @@
 """This module contains some base classes for algorithms."""
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 import time

--- a/tenpy/algorithms/disentangler.py
+++ b/tenpy/algorithms/disentangler.py
@@ -7,7 +7,7 @@ For now, this is written for disentangling purifications; could be generalized t
 
 .. autodata:: disentanglers_atom_parse_dict
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import logging

--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -30,7 +30,7 @@ crucial, as the one-site algorithm cannot increase the MPS bond dimension by its
 A generic protocol for approaching a physics question using DMRG is given in
 :doc:`/intro/dmrg-protocol`.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import time

--- a/tenpy/algorithms/dmrg_parallel.py
+++ b/tenpy/algorithms/dmrg_parallel.py
@@ -3,7 +3,7 @@
 .. warning ::
     This module is still under active development. Use with care!
 """
-# Copyright 2021-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2021-2024 TeNPy Developers, GNU GPLv3
 
 from ..tools.thread import Worker
 

--- a/tenpy/algorithms/exact_diag.py
+++ b/tenpy/algorithms/exact_diag.py
@@ -13,7 +13,7 @@ This might be used to obtain the spectrum, the ground state or highly excited st
     but just the ability to diagonalize the defined models for small system sizes
     without additional extra work.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/algorithms/mpo_evolution.py
+++ b/tenpy/algorithms/mpo_evolution.py
@@ -1,6 +1,6 @@
 """Time evolution using the WI or WII approximation of the time evolution operator."""
 
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import time

--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -18,7 +18,7 @@ effective Hamiltonians mentioned above. Currently, effective Hamiltonians for
 The :class:`VariationalCompression` and :class:`VariationalApplyMPO`
 implemented here also directly use the :class:`Sweep` class.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from ..linalg import np_conserved as npc
 from .algorithm import Algorithm

--- a/tenpy/algorithms/mps_sweeps.py
+++ b/tenpy/algorithms/mps_sweeps.py
@@ -5,7 +5,7 @@ This module is just around for backwards compatibility.
 .. deprecated :: 0.7.0
     This module is just around for backwards compatibility.
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 

--- a/tenpy/algorithms/network_contractor.py
+++ b/tenpy/algorithms/network_contractor.py
@@ -12,7 +12,7 @@ by Robert N. C. Pfeifer, Glen Evenbly, Sukhwinder Singh, Guifre Vidal, see :arxi
         (:arxiv:`1304.6112`)
     - implement or deprecate the outer_product in sequence behavior
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/algorithms/purification.py
+++ b/tenpy/algorithms/purification.py
@@ -1,6 +1,6 @@
 """Algorithms for using Purification."""
 
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import logging

--- a/tenpy/algorithms/purification_tebd.py
+++ b/tenpy/algorithms/purification_tebd.py
@@ -6,7 +6,7 @@ and the various disentanglers are in :mod:`tenpy.algorithms.disentangler`
 .. deprecated :: 0.7.1
     This module is just around for backwards compatibility.
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 from .purification import PurificationTEBD, PurificationTEBD2
 from .disentangler import *

--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -29,7 +29,7 @@ Much of the code is very similar to DMRG, and also based on the
 .. todo ::
     allow for increasing bond dimension in SingleSiteTDVPEngine, similar to DMRG Mixer
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from ..linalg.krylov_based import LanczosEvolution
 from .truncation import svd_theta, TruncationError

--- a/tenpy/algorithms/tebd.py
+++ b/tenpy/algorithms/tebd.py
@@ -37,7 +37,7 @@ If one chooses imaginary :math:`dt`, the exponential projects
     Yet, imaginary TEBD might be useful for cross-checks and testing.
 
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import time

--- a/tenpy/algorithms/truncation.py
+++ b/tenpy/algorithms/truncation.py
@@ -41,7 +41,7 @@ is the discarded part (orthogonal to the kept part) and the
     There might be other sources of error as well, for example TEBD has also an discretization
     error depending on the chosen time step.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 from ..linalg import np_conserved as npc

--- a/tenpy/linalg/__init__.py
+++ b/tenpy/linalg/__init__.py
@@ -21,7 +21,7 @@ so you probably won't need to import `charges` directly.
     krylov_based
 
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from . import charges, np_conserved, krylov_based, random_matrix, sparse, svd_robust
 from .charges import *

--- a/tenpy/linalg/_npc_helper.pyx
+++ b/tenpy/linalg/_npc_helper.pyx
@@ -8,7 +8,7 @@ functions/classes defined here to overwrite those written in pure Python wheneve
 decorator ``@use_cython`` is used in other python files of tenpy.
 If this module was not compiled and could not be imported, a warning is issued.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 DEF DEBUG_PRINT = 0  # set this to 1 for debug output (e.g. benchmark timings within the functions)
 DEF USE_MKL_GEMM_BATCH = 1 # whether to use ?gemm_batch function of MKL

--- a/tenpy/linalg/charges.py
+++ b/tenpy/linalg/charges.py
@@ -19,7 +19,7 @@ For further details, see the definition of :func:`~tenpy.tools.optimization.use_
 
 .. autodata:: QTYPE
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import copy

--- a/tenpy/linalg/krylov_based.py
+++ b/tenpy/linalg/krylov_based.py
@@ -1,5 +1,5 @@
 """Lanczos algorithm for np_conserved arrays."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 import numpy as np

--- a/tenpy/linalg/lanczos.py
+++ b/tenpy/linalg/lanczos.py
@@ -1,5 +1,5 @@
 """Lanczos algorithm for np_conserved arrays."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 import warnings
 from .krylov_based import *
 

--- a/tenpy/linalg/np_conserved.py
+++ b/tenpy/linalg/np_conserved.py
@@ -81,7 +81,7 @@ Overview
     speigs
 
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import scipy.linalg

--- a/tenpy/linalg/random_matrix.py
+++ b/tenpy/linalg/random_matrix.py
@@ -29,7 +29,7 @@ corresponding ensemble, for example::
     npc.Array.from_func_square(GOE, [leg, leg.conj()])
 
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/linalg/sparse.py
+++ b/tenpy/linalg/sparse.py
@@ -7,7 +7,7 @@ implementations of these algorithms (e.g., :mod:`~tenpy.linalg.lanczos`). Moreov
 :class:`FlatLinearOperator` allows to use all the scipy sparse methods by providing functionality
 to convert flat numpy arrays to and from np_conserved arrays.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 from . import np_conserved as npc

--- a/tenpy/linalg/svd_robust.py
+++ b/tenpy/linalg/svd_robust.py
@@ -34,7 +34,7 @@ The idea is that you just import the `svd` from this module and use it as replac
 >>> from tenpy.linalg.svd_robust import svd
 >>> U, S, VT = svd([[1., 1.], [0., 1.]])
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import scipy

--- a/tenpy/models/__init__.py
+++ b/tenpy/models/__init__.py
@@ -33,7 +33,7 @@ All other modules in this folder contain model classes derived from these base c
     mixed_xk
     clock
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from . import lattice, model
 from . import tf_ising, xxz_chain, spins, spins_nnn

--- a/tenpy/models/aklt.py
+++ b/tenpy/models/aklt.py
@@ -4,7 +4,7 @@ The AKLT model is famous for having a very simple ground state MPS of bond dimen
 Writing down the Hamiltonian is easiest done in terms of bond couplings.
 This class thus serves as an example how this can be done.
 """
-# Copyright 2021-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2021-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/bose_hubbard.py
+++ b/tenpy/models/bose_hubbard.py
@@ -3,7 +3,7 @@
 .. deprecated :: 0.4.1
     This module is just around for backwards compatibility.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from .hubbard import BoseHubbardModel, BoseHubbardChain
 

--- a/tenpy/models/bose_hubbard_chain.py
+++ b/tenpy/models/bose_hubbard_chain.py
@@ -5,7 +5,7 @@ This module is just around for backwards compatibility.
 .. deprecated :: 0.4.1
     This module is just around for backwards compatibility.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from .hubbard import BoseHubbardModel, BoseHubbardChain
 

--- a/tenpy/models/clock.py
+++ b/tenpy/models/clock.py
@@ -2,7 +2,7 @@
 
 Generalization of transverse field Ising model to higher dimensional on-site Hilbert space.
 """
-# Copyright 2023 TeNPy Developers, GNU GPLv3
+# Copyright 2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 from .model import CouplingMPOModel, NearestNeighborModel

--- a/tenpy/models/fermion_chain.py
+++ b/tenpy/models/fermion_chain.py
@@ -3,7 +3,7 @@
 .. deprecated :: 0.4.1
     This module is just around for backwards compatibility.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from .fermions_spinless import FermionModel, FermionChain
 

--- a/tenpy/models/fermions_hubbard.py
+++ b/tenpy/models/fermions_hubbard.py
@@ -3,7 +3,7 @@
 .. deprecated :: 0.4.1
     This module is just around for backwards compatibility.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from .hubbard import FermiHubbardModel as FermionicHubbardModel
 from .hubbard import FermiHubbardChain as FermionicHubbardChain

--- a/tenpy/models/fermions_spinless.py
+++ b/tenpy/models/fermions_spinless.py
@@ -2,7 +2,7 @@
 
 .. todo ::     add further terms (e.g. c^dagger c^dagger + h.c.) to the Hamiltonian.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/haldane.py
+++ b/tenpy/models/haldane.py
@@ -1,5 +1,5 @@
 """Bosonic and fermionic Haldane models."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/hofstadter.py
+++ b/tenpy/models/hofstadter.py
@@ -4,7 +4,7 @@
     Long term: implement different lattices.
     Long term: implement variable hopping strengths Jx, Jy.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -1,5 +1,5 @@
 """Bosonic and fermionic Hubbard models."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/lattice.py
+++ b/tenpy/models/lattice.py
@@ -16,7 +16,7 @@ Further, an overview with plots of the predefined models is given in
 :doc:`/notebooks/90_overview_predefined_lattices`
 
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import itertools

--- a/tenpy/models/mixed_xk.py
+++ b/tenpy/models/mixed_xk.py
@@ -62,7 +62,7 @@ The Jordan-Wigner strings follow the *final* DMRG snake.
     exclusion principle implies a possibly large occupation on single k modes, i.e., hard-core
     bosons in x-y-space don't map to hard-core bosons in x-k-space!
 """
-# Copyright 2021-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2021-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import itertools as it

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -27,7 +27,7 @@ as base class in (most of) the predefined models in TeNPy.
 
 See also the introduction in :doc:`/intro/model`.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/models/spins.py
+++ b/tenpy/models/spins.py
@@ -2,7 +2,7 @@
 
 Uniform lattice of spin-S sites, coupled by nearest-neighbor interactions.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/spins_nnn.py
+++ b/tenpy/models/spins_nnn.py
@@ -14,7 +14,7 @@ latter by using :meth:`~tenpy.models.model.MPOModel.group_sites` and
 :meth:`~tenpy.models.model.NearestNeighborModel.from_MPOModel`.
 An example for such a case is given in the file ``examples/c_tebd.py``.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/tf_ising.py
+++ b/tenpy/models/tf_ising.py
@@ -6,7 +6,7 @@ the idea is more to serve as a pedagogical example for a 'model'.
 
 We choose the field along z to allow to conserve the parity, if desired.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/tj_model.py
+++ b/tenpy/models/tj_model.py
@@ -1,5 +1,5 @@
 """tJ model"""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from .model import CouplingMPOModel, NearestNeighborModel
 from .lattice import Chain

--- a/tenpy/models/toric_code.py
+++ b/tenpy/models/toric_code.py
@@ -3,7 +3,7 @@
 As we put the model on a cylinder, the name "toric code" is a bit misleading, but it is the
 established name for this model...
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/models/xxz_chain.py
+++ b/tenpy/models/xxz_chain.py
@@ -3,7 +3,7 @@
 The XXZ chain is contained in the more general :class:`~tenpy.models.spins.SpinChain`; the idea of
 this module is more to serve as a pedagogical example for a model.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/networks/__init__.py
+++ b/tenpy/networks/__init__.py
@@ -14,7 +14,7 @@ For example an MPS represents the contraction along the 'virtual' legs/bonds of 
     terms
     purification_mps
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from . import site, mps, mpo, purification_mps, terms
 from .site import *

--- a/tenpy/networks/mpo.py
+++ b/tenpy/networks/mpo.py
@@ -34,7 +34,7 @@ We store these indices in `IdL` and `IdR` (if there are such indices).
 Similar as for the MPS, a bond index ``i`` is *left* of site `i`,
 i.e. between sites ``i-1`` and ``i``.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 from scipy.linalg import expm

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -144,7 +144,7 @@ After applying such an evolution operator, you indeed stay in the form of a tran
 iMPS, so this is the form *assumed* when calling MPO :meth:`~tenpy.networks.mpo.MPO.apply` on an
 MPS.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from abc import ABCMeta, abstractmethod
 import numpy as np

--- a/tenpy/networks/purification_mps.py
+++ b/tenpy/networks/purification_mps.py
@@ -116,7 +116,7 @@ see :cite:`hauschild2018`.
     Moreover, we don't split the physical and auxiliary space into separate sites, which makes
     TEBD as costly as :math:`O(d^6 \chi^3)`.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import copy
 import numpy as np

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -3,7 +3,7 @@
 The :class:`Site` is the prototype, read it's docstring.
 
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import itertools

--- a/tenpy/networks/terms.py
+++ b/tenpy/networks/terms.py
@@ -5,7 +5,7 @@ acting on them. Each term is given by a collection of (onsite) operator names an
 sites it acts on. Moreover, we associate a `strength` to each term, which corresponds to the
 prefactor when specifying e.g. a Hamiltonian.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/simulations/__init__.py
+++ b/tenpy/simulations/__init__.py
@@ -12,7 +12,7 @@ The classes provided here provide a structure for the whole setup of simulations
     ground_state_search
     time_evolution
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 from . import measurement, simulation, ground_state_search, time_evolution
 from .measurement import *

--- a/tenpy/simulations/ground_state_search.py
+++ b/tenpy/simulations/ground_state_search.py
@@ -1,5 +1,5 @@
 """Simulations for ground state searches."""
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 from pathlib import Path

--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -10,7 +10,7 @@ As briefly explained in :doc:`/intro/simulations`, you can easily add custom mea
 
 Full description and details in :doc:`/intro/measurements`.
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -7,7 +7,7 @@ running the actual algorithm, possibly performing measurements and saving the re
 See :doc:`/intro/simulations` for an overview and
 :doc:`/examples` for a list of example parameter yaml files.
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import os
 import sys

--- a/tenpy/simulations/time_evolution.py
+++ b/tenpy/simulations/time_evolution.py
@@ -1,5 +1,5 @@
 """Simulations for (real) time evolution."""
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tenpy/tools/__init__.py
+++ b/tenpy/tools/__init__.py
@@ -21,7 +21,7 @@ Common to all tools is that they are not just useful for a single algorithm but 
     cache
     thread
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from . import (events, fit, hdf5_io, math, misc, params, process, string, optimization, cache,
                thread)

--- a/tenpy/tools/cache.py
+++ b/tenpy/tools/cache.py
@@ -7,7 +7,7 @@ Any cache should be handled like a file object that needs to be closed after use
 this is easiest done through a ``with`` statement, see the example in :class:`DictCache`.
 """
 
-# Copyright 2021-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2021-2024 TeNPy Developers, GNU GPLv3
 
 import pickle
 import numpy as np

--- a/tenpy/tools/events.py
+++ b/tenpy/tools/events.py
@@ -4,7 +4,7 @@ The :class:`EventHandler` is basically just holds a list of functions
 which can get called once a certain "event" happens.
 Examples are given in the class doc-string.
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 from collections import namedtuple
 import warnings

--- a/tenpy/tools/fit.py
+++ b/tenpy/tools/fit.py
@@ -1,5 +1,5 @@
 """tools to fit to an algebraic decay."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import scipy.optimize as optimize

--- a/tenpy/tools/hdf5_io.py
+++ b/tenpy/tools/hdf5_io.py
@@ -65,7 +65,7 @@ Names for the ``ATTR_TYPE`` attribute:
 
 .. autodata:: TYPES_FOR_HDF5_DATASETS
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import pickle
 import gzip

--- a/tenpy/tools/math.py
+++ b/tenpy/tools/math.py
@@ -2,7 +2,7 @@
 
 .. autodata:: LeviCivita3
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import warnings

--- a/tenpy/tools/misc.py
+++ b/tenpy/tools/misc.py
@@ -1,5 +1,5 @@
 """Miscellaneous tools, somewhat random mix yet often helpful."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import logging
 import numpy as np

--- a/tenpy/tools/optimization.py
+++ b/tenpy/tools/optimization.py
@@ -76,7 +76,7 @@ knobs you can turn to tweak the most out of this library, explained in the follo
 .. autodata:: have_cython_functions
 .. autodata:: compiled_with_MKL
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from enum import IntEnum
 import warnings

--- a/tenpy/tools/params.py
+++ b/tenpy/tools/params.py
@@ -2,7 +2,7 @@
 
 See the doc-string of :class:`Config` for details.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 import numpy as np

--- a/tenpy/tools/process.py
+++ b/tenpy/tools/process.py
@@ -13,7 +13,7 @@ which give their best to get and set the number of threads at runtime,
 while still being failsafe if the shared OpenMP library is not found.  In the latter case,
 you might also try the equivalent :func:`mkl_get_nthreads` and :func:`mkl_set_nthreads`.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 import ctypes

--- a/tenpy/tools/string.py
+++ b/tenpy/tools/string.py
@@ -1,6 +1,6 @@
 """Tools for handling strings."""
 
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 __all__ = ['is_non_string_iterable', 'vert_join', 'to_mathematica_lists']
 

--- a/tenpy/tools/thread.py
+++ b/tenpy/tools/thread.py
@@ -1,6 +1,6 @@
 """Tools for thread-based parallelization."""
 
-# Copyright 2021-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2021-2024 TeNPy Developers, GNU GPLv3
 
 import threading
 import queue

--- a/tenpy/version.py
+++ b/tenpy/version.py
@@ -10,7 +10,7 @@ The version is provided in the standard python format ``major.minor.revision`` a
 .. autodata :: full_version
 .. autodata :: version_summary
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import sys
 import subprocess

--- a/tests/benchmark/benchmark.py
+++ b/tests/benchmark/benchmark.py
@@ -11,7 +11,7 @@ Call this file with arguments, e.g,::
 Afterwards, you can plot the produced files::
     python benchmark.py -p tensordot_*_benchmark_*.txt
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from __future__ import print_function  # (backwards compatibility to python 2)
 

--- a/tests/benchmark/combine_npc.py
+++ b/tests/benchmark/combine_npc.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tenpy.linalg.np_conserved as npc

--- a/tests/benchmark/combine_numpy.py
+++ b/tests/benchmark/combine_numpy.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tensordot_npc

--- a/tests/benchmark/dmrg_infinite.py
+++ b/tests/benchmark/dmrg_infinite.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tests/benchmark/profiling.py
+++ b/tests/benchmark/profiling.py
@@ -8,7 +8,7 @@ Afterwards, you can print the produced statistics::
 
     python profiling.py -p tensordot_*_profile_*.prof --sort time --limit 10
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import cProfile

--- a/tests/benchmark/singlerun.py
+++ b/tests/benchmark/singlerun.py
@@ -4,7 +4,7 @@ Call this file with arguments, e.g:     python singlerun.py -m tensordot_npc ten
 -s 20 -S 50 -q 1 1
 """
 
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import cProfile

--- a/tests/benchmark/split_npc.py
+++ b/tests/benchmark/split_npc.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tenpy.linalg.np_conserved as npc

--- a/tests/benchmark/split_numpy.py
+++ b/tests/benchmark/split_numpy.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tensordot_npc

--- a/tests/benchmark/tebd_infinite.py
+++ b/tests/benchmark/tebd_infinite.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 

--- a/tests/benchmark/tensordot_npc.py
+++ b/tests/benchmark/tensordot_npc.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tenpy.linalg.np_conserved as npc

--- a/tests/benchmark/tensordot_numpy.py
+++ b/tests/benchmark/tensordot_numpy.py
@@ -1,5 +1,5 @@
 """To be used in the `-m` argument of benchmark.py."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import tensordot_npc

--- a/tests/export_import_test/io_test.py
+++ b/tests/export_import_test/io_test.py
@@ -7,7 +7,7 @@ generate the files, you can call the ``test_*.py`` files in this folder manually
 test_pickle.py``. This will generate the files with pre-defined data (see :func:`gen_example_data`)
 and the tenpy version in the filename.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import os

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1,5 +1,5 @@
 """Provide helper functions for test of random Arrays."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import itertools as it

--- a/tests/tdvp_numpy.py
+++ b/tests/tdvp_numpy.py
@@ -2,7 +2,7 @@
 
 .. todo ::     Make this a nice toycode! For the test, use some pre-defined values.
 """
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 from scipy.linalg import expm
 from scipy.sparse.linalg import expm_multiply

--- a/tests/test_charges.py
+++ b/tests/test_charges.py
@@ -1,5 +1,5 @@
 """A collection of tests for tenpy.linalg.charges."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.charges as charges
 import numpy as np

--- a/tests/test_consistencies.py
+++ b/tests/test_consistencies.py
@@ -1,5 +1,5 @@
 """Check for consistencies."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy
 import types

--- a/tests/test_dmrg.py
+++ b/tests/test_dmrg.py
@@ -1,5 +1,5 @@
 """A collection of tests to check the functionality of `tenpy.dmrg`"""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import itertools as it
 import tenpy.linalg.np_conserved as npc

--- a/tests/test_exact_diag.py
+++ b/tests/test_exact_diag.py
@@ -1,5 +1,5 @@
 """A collection of tests to check the functionality of algorithms.exact_diagonalization."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.np_conserved as npc
 import numpy as np

--- a/tests/test_krylov_based.py
+++ b/tests/test_krylov_based.py
@@ -1,5 +1,5 @@
 """A collection of tests for tenpy.linalg.krylov_based."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.np_conserved as npc
 import numpy as np

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -1,5 +1,5 @@
 """A collection of tests for tenpy.models.lattice."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from tenpy.models import lattice
 import tenpy.linalg.np_conserved as npc

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,5 @@
 """A collection of tests for (classes in) :mod:`tenpy.models.model`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 import itertools

--- a/tests/test_model_aklt.py
+++ b/tests/test_model_aklt.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2021-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models import aklt
 from test_model import check_general_model
 from tenpy.algorithms.dmrg import TwoSiteDMRGEngine

--- a/tests/test_model_clock.py
+++ b/tests/test_model_clock.py
@@ -1,4 +1,4 @@
-# Copyright 2023 TeNPy Developers, GNU GPLv3
+# Copyright 2024 TeNPy Developers, GNU GPLv3
 
 from tenpy.models.clock import ClockModel, ClockChain
 from test_model import check_general_model

--- a/tests/test_model_fermions_spinless.py
+++ b/tests/test_model_fermions_spinless.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 import numpy as np
 from tenpy.models.fermions_spinless import FermionChain, FermionModel
 from test_model import check_general_model

--- a/tests/test_model_haldane.py
+++ b/tests/test_model_haldane.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models.haldane import BosonicHaldaneModel, FermionicHaldaneModel
 from test_model import check_general_model
 import pytest

--- a/tests/test_model_hofstadter.py
+++ b/tests/test_model_hofstadter.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models.hofstadter import HofstadterBosons, HofstadterFermions
 from test_model import check_general_model
 import pytest

--- a/tests/test_model_hubbard.py
+++ b/tests/test_model_hubbard.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 import pytest
 from tenpy.models import hubbard
 from test_model import check_general_model

--- a/tests/test_model_mixed_xk.py
+++ b/tests/test_model_mixed_xk.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models.mixed_xk import (MixedXKLattice, MixedXKModel, SpinlessMixedXKSquare,
                                    HubbardMixedXKSquare)
 from test_model import check_general_model

--- a/tests/test_model_spins.py
+++ b/tests/test_model_spins.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models import spins
 from test_model import check_general_model
 

--- a/tests/test_model_spins_nnn.py
+++ b/tests/test_model_spins_nnn.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models import spins_nnn
 from test_model import check_general_model
 from tenpy.models.model import NearestNeighborModel

--- a/tests/test_model_tf_ising.py
+++ b/tests/test_model_tf_ising.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from tenpy.models.tf_ising import TFIModel, TFIChain
 from test_model import check_general_model

--- a/tests/test_model_tj_model.py
+++ b/tests/test_model_tj_model.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 from tenpy.models import tj_model
 from test_model import check_general_model
 

--- a/tests/test_model_toric_code.py
+++ b/tests/test_model_toric_code.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from tenpy.models.toric_code import ToricCode
 from test_model import check_general_model

--- a/tests/test_model_xxz_chain.py
+++ b/tests/test_model_xxz_chain.py
@@ -1,5 +1,5 @@
 """test of :class:`tenpy.models.XXZChain`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_mpo.py
+++ b/tests/test_mpo.py
@@ -1,5 +1,5 @@
 """A collection of tests for (classes in) :module:`tenpy.networks.mpo`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -1,5 +1,5 @@
 """A collection of tests for :module:`tenpy.networks.mps`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_network_contractor.py
+++ b/tests/test_network_contractor.py
@@ -1,5 +1,5 @@
 """a collection of tests to check the functionality of network_contractor.py."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 from tenpy.algorithms.network_contractor import contract, ncon
 import numpy as np

--- a/tests/test_np_conserved.py
+++ b/tests/test_np_conserved.py
@@ -1,5 +1,5 @@
 """A collection of tests for tenpy.linalg.np_conserved."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import tenpy.linalg.np_conserved as npc
 import numpy as np

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -1,5 +1,5 @@
 """Check if subpackages define proper __all__."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 import types
 
 import tenpy

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,5 +1,5 @@
 """A test for tenpy.tools.params."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 from tenpy.tools.params import Config, asConfig

--- a/tests/test_purification.py
+++ b/tests/test_purification.py
@@ -1,5 +1,5 @@
 """A collection of tests for :module:`tenpy.networks.purification_mps`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import warnings
 import numpy as np

--- a/tests/test_random_matrix.py
+++ b/tests/test_random_matrix.py
@@ -1,5 +1,5 @@
 """A collection of tests for :module:`tenpy.linalg.random_matrix`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,5 +1,5 @@
 """A collection of tests to check the functionality of modules in `tenpy.simulations`"""
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import copy
 import numpy as np

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,5 +1,5 @@
 """A collection of tests for :mod:`tenpy.models.site`."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 import tenpy.linalg.np_conserved as npc
 import numpy as np
 

--- a/tests/test_svd_robust.py
+++ b/tests/test_svd_robust.py
@@ -1,5 +1,5 @@
 """A collection of tests for tenpy.linalg.svd_robust."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_tdvp.py
+++ b/tests/test_tdvp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python2
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 import numpy as np
 import pytest
 from tenpy.models.spins import SpinChain

--- a/tests/test_tebd.py
+++ b/tests/test_tebd.py
@@ -1,5 +1,5 @@
 """A collection of tests to check the functionality of `tenpy.tebd`"""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy.testing as npt
 import tenpy.linalg.np_conserved as npc

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,5 +1,5 @@
 """A collection of tests for :module:`tenpy.networks.terms`."""
-# Copyright 2019-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2019-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import copy

--- a/tests/test_time_evolution.py
+++ b/tests/test_time_evolution.py
@@ -2,7 +2,7 @@ r"""Test several time evolution methods and compare to exact expectation values
 
 Setup is a time evolution with TFI Model starting from a spin polarized state.
 """
-# Copyright 2020-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2020-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import scipy.linalg as LA

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,5 @@
 """A collection of tests for tenpy.tools submodules."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import logging
 import numpy as np

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,5 +1,5 @@
 """A test for tenpy.algorithms.truncation."""
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import numpy as np
 import pytest

--- a/tests/z_test_examples.py
+++ b/tests/z_test_examples.py
@@ -3,7 +3,7 @@
 The files are only imported, so please protect example code from running with standard ``if
 __name__ == "__main__": ...`` clauses, if you want to demonstrate an interactive code.
 """
-# Copyright 2018-2023 TeNPy Developers, GNU GPLv3
+# Copyright 2018-2024 TeNPy Developers, GNU GPLv3
 
 import sys
 import os


### PR DESCRIPTION
Two commits:
- Automatically update the copyright year in the docbuild (appears e.g. at the bottom of the readthedocs page)
- Update all copyright notices in the code to 2024 and reactivate the test that checks this (was deactivated in 03b259a) 