### PR TITLE
Regrouping to NearestNeighborModel in Simulation

### DIFF
--- a/tenpy/simulations/measurement.py
+++ b/tenpy/simulations/measurement.py
@@ -110,7 +110,9 @@ def m_bond_energies(results, psi, model, simulation, results_key='bond_energies'
     results, psi, model, simulation, results_key :
         See :func:`~tenpy.simulation.measurement.measurement_index`.
     """
-    results[results_key] = model.bond_energies(psi)
+    # use simulation.psi and simulation.model since default 'energy' measurement is
+    # obtained from model.get_extra_default_measurements() in _connect_measurements() after regrouping
+    results[results_key] = simulation.model.bond_energies(simulation.psi)
 
 
 def m_simulation_parameter(results, psi, model, simulation, recursive_key, results_key=None, **kwargs):

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -164,7 +164,6 @@ class Simulation:
     default_measurements = [
         ('tenpy.simulations.measurement', 'm_measurement_index', {}, 1),
         ('tenpy.simulations.measurement', 'm_bond_dimension'),
-        ('tenpy.simulations.measurement', 'm_energy_MPO'),
         ('tenpy.simulations.measurement', 'm_entropy'),
     ]
 
@@ -557,7 +556,7 @@ class Simulation:
 
     def _connect_measurements(self):
         if self.options.get('use_default_measurements', True):
-            def_meas = self.default_measurements
+            def_meas = self.default_measurements + self.model.get_extra_default_measurements()
         else:
             def_meas = []
         con_meas = list(self.options.get('connect_measurements', []))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -244,6 +244,31 @@ def test_RealTimeEvolution():
     assert np.all(meas['dummy_value'] == [-1] + [expected_dummy_value] * (N - 1))
 
 
+regrouping_params = copy.deepcopy(simulation_params)
+regrouping_params['final_time'] = 4.
+regrouping_params['group_to_NearestNeighborModel'] = True
+regrouping_params['group_sites'] = 2
+
+
+def test_regrouping_and_group_to_NearestNeighborModel():
+    sim_params = copy.deepcopy(regrouping_params)
+    sim = RealTimeEvolution(sim_params)
+    results = sim.run()
+    assert sim.model.lat.bc_MPS == 'infinite'  # check whether model parameters were used
+    assert 'psi' in results  # should be by default
+    meas = results['measurements']
+    # expect two measurements: once in `init_measurements` and in `final_measurement`.
+    alg_params = sim_params['algorithm_params']
+    expected_times = np.arange(0., sim_params['final_time'] + 1.e-10,
+                               alg_params['N_steps'] * alg_params['dt'])
+    N = len(expected_times)
+    assert np.allclose(meas['evolved_time'], expected_times)
+    assert np.all(meas['measurement_index'] == np.arange(N))
+    assert np.all(meas['dummy_value'] == [-1] + [expected_dummy_value] * (N - 1))
+    # after group_to_NearestNeighborModel, we should measure the bond_energies instead of energy_MPO
+    assert 'bond_energies' in meas and 'energy_MPO' not in meas
+
+
 def test_output_filename_from_dict():
     options = copy.deepcopy(simulation_params)
     assert output_filename_from_dict(options) == 'result.h5', "hard-coded default values changed"


### PR DESCRIPTION
Currently the `Simulation` class has `energy_MPO` as a default measurement.
If in a simulation the model is regrouped to a `NearestNeighborModel`, `energy_MPO` can no longer be measured.
The `Model` class includes now an extra method `get_extra_default_measurements`  which allows to pass a list of model-specific extra default measurements. The new method gets called in `connect_measurements` (after regrouping in the simulation)