### PR TITLE
Fix typos in docs

### DIFF
--- a/doc/contr/build_doc.rst
+++ b/doc/contr/build_doc.rst
@@ -1,4 +1,4 @@
-Bulding the documentation
+Building the documentation
 =========================
 
 You can use `Sphinx <https://www.sphinx-doc.org>`_ to generate the full documentation 
@@ -24,7 +24,7 @@ Afterwards, simply go to the folder ``doc/`` and run the following command::
     make html
 
 This should generate the html documentation in the folder `doc/sphinx_build/html`.
-Open this folder (or to be precise: the file `index.html` in it) in your webbroser
+Open this folder (or to be precise: the file `index.html` in it) in your webbrowser
 and enjoy this and other documentation beautifully rendered, with cross links, math formulas
 and even a search function.
 Other output formats are available as other make targets, e.g., ``make latexpdf``.

--- a/doc/contr/guidelines.rst
+++ b/doc/contr/guidelines.rst
@@ -23,7 +23,7 @@ However, these are just guidelines - it still helps if you contribute something,
   The documentation uses `reStructuredText`. If you are new to `reStructuredText`, read this `introduction <http://www.sphinx-doc.org/en/stable/rest.html>`_.
   We use the `numpy` style for doc-strings (with the `napoleon <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_ extension to sphinx).
   You can read about them in these `Instructions for the doc strings <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
-  In addition, you can take a look at the following `example file <http://github.com/numpy/numpy/blob/master/doc/example.py>`_.
+  In addition, you can take a look at the following `example file <https://github.com/numpy/numpydoc/blob/main/doc/example.py>`_.
   Helpful hints on top of that::
 
         r"""<- this r makes me a raw string, thus '\' has no special meaning.

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -6,7 +6,7 @@ Toy codes
 
 These "toy codes" are meant to give you a flavor of the different algorithms,
 while keeping the codes as readable and simple as possible.
-They can be found in a separte [TeNPyToycodes]_ repository https://github.com/tenpy/tenpy_notebooks in the folder ``tenpy_toycodes/``.
+They can be found in a separate [TeNPyToycodes]_ repository https://github.com/tenpy/tenpy_notebooks in the folder ``tenpy_toycodes/``.
 The only requirements to run them are Python 3, Numpy, and Scipy, (and jupyter for running the notebooks). 
 For reference, we include them here as examples.
 

--- a/doc/install/conda.rst
+++ b/doc/install/conda.rst
@@ -6,7 +6,7 @@ We provide a package for the [conda]_ package manager in the `conda-forge` chann
     conda install --channel=conda-forge physics-tenpy
 
 
-Following the recommondation of `conda-forge <https://conda-forge.org/docs/user/introduction.html>`_, you can also make
+Following the recommendation of `conda-forge <https://conda-forge.org/docs/user/introduction.html>`_, you can also make
 conda-forge the default channel as follows::
 
     conda config --add channels conda-forge
@@ -24,7 +24,7 @@ If you have done this, you don't need to specify the ``--channel=conda-forge`` e
 
 .. warning ::
 
-    If you use the `conda-forge` channe and don't pin BLAS to the MKL version as outlined in the above version,
+    If you use the `conda-forge` channel and don't pin BLAS to the MKL version as outlined in the above version,
     but nevertheless have mkl-devel installed during compilation of TeNPy, this can have *crazy* effects on the number
     of threads used: `numpy` will call openblas and open up ``$OMP_NUM_THREADS - 1`` new threads, 
     while MKL called from tenpy will open another ``$MKL_NUM_THREADS - 1`` threads, making it very hard to control the

--- a/doc/install/extra.rst
+++ b/doc/install/extra.rst
@@ -54,11 +54,11 @@ As outlined in :doc:`/install/conda`, on Linux/Mac you also need to pin blas to 
 
 Compile linking agains MKL
 --------------------------
-When you compile the Cython files of TeNPy, you have the option to explicilty link against MKL, such
+When you compile the Cython files of TeNPy, you have the option to explicitly link against MKL, such
 that e.g. :func:`tenpy.linalg.np_conserved.tensordot` is guaranteed to call the corresponding `dgemm` or `zgemm`
 function in the BLAS from MKL.
 To link against MKL, the MKL library *including the headers* must be available during the compilation of TeNPy's Cython
-files. If you have the MKL library installed, you can export the environemnt variable `MKLROOT` to point to the
+files. If you have the MKL library installed, you can export the environment variable `MKLROOT` to point to the
 root folder.
 Alternatively, TeNPy will recognise if you are in an active conda environment and have the `mkl` *and* `mkl-devel` conda
 packages installed during compilation. In this case, it will link against the MKL provided as conda package.

--- a/doc/install/from_source.rst
+++ b/doc/install/from_source.rst
@@ -12,7 +12,7 @@ Getting the source
 The following instructions are for (some kind of) Linux, and tested on Ubuntu. 
 However, the code itself should work on other operating systems as well (in particular MacOS and Windows).
 
-The offical repository is at https://github.com/tenpy/tenpy.git.
+The official repository is at https://github.com/tenpy/tenpy.git.
 To get the latest version of the code, you can clone it with [git]_ using the following commands::
 
     git clone https://github.com/tenpy/tenpy.git $HOME/TeNPy

--- a/doc/install/pip.rst
+++ b/doc/install/pip.rst
@@ -7,7 +7,7 @@ Preparation: install requirements
 If you have the [conda]_ package manager from `anaconda <https://www.anaconda.com/distribution>`_, you can just download the 
 `environment.yml <https://raw.githubusercontent.com/tenpy/tenpy/main/environment.yml>`_ file (using the `conda-forge`
 channel, or the `environment_other.yml <https://raw.githubusercontent.com/tenpy/tenpy/main/environment_other.yml>`_ for all other channels) out of the repository
-and create a new environment (called ``tenpy``, if you don't speficy another name) for TeNPy with all the required packages::
+and create a new environment (called ``tenpy``, if you don't specify another name) for TeNPy with all the required packages::
 
     conda env create -f environment.yml
     conda activate tenpy
@@ -52,7 +52,7 @@ To get the latest development version from the github main branch, you can use::
 
     pip install git+git://github.com/tenpy/tenpy.git
 
-This should already have the lastest features described in :doc:`/changelog/latest`.
+This should already have the latest features described in :doc:`/changelog/latest`.
 Disclaimer: this might sometimes be broken, although we do our best to keep to keep it stable as well.
 
 Installation from the downloaded source folder

--- a/doc/intro/JordanWigner.rst
+++ b/doc/intro/JordanWigner.rst
@@ -1,7 +1,7 @@
 Fermions and the Jordan-Wigner transformation
 =============================================
 
-The `Jordan-Wigner tranformation <https://en.wikipedia.org/wiki/Jordan-Wigner_transformation>`_
+The `Jordan-Wigner transformation <https://en.wikipedia.org/wiki/Jordan-Wigner_transformation>`_
 maps fermionic creation- and annihilation operators to (bosonic) spin-operators.
 
 
@@ -27,7 +27,7 @@ a site, they actually act on all sites ``l <= j``!
 Thus, clearly the operators ``C`` and ``Cd`` defined in the :class:`~tenpy.networks.site.FermionSite` do *not* directly correspond to :math:`c_j` and
 :math:`c^\dagger_j`.
 The part :math:`(-1)^{\sum_{l < j} n_l}` is called Jordan-Wigner string and in the :class:`~tenpy.networks.site.FermionSite` is given by the local operator 
-:math:`JW := (-1)^{n_l}` acting all sites ``l < j``.
+:math:`JW := (-1)^{n_l}` acting on all sites ``l < j``.
 Since this important, let me stress it again:
 
 .. warning ::
@@ -38,7 +38,7 @@ On the sites itself, the onsite operators ``C`` and ``Cd`` in the :class:`~tenpy
 The ``JW`` string is necessary to ensure the anti-commutation for operators acting on different sites.
 
 Written in terms of `onsite` operators defined in the :class:`~tenpy.networks.site.FermionSite`, 
-with the `i`-th entry entry in the list acting on site `i`, the relations are thus::
+with the `i`-th entry in the list acting on site `i`, the relations are thus::
 
     ["JW", ..., "JW", "C",  "Id", ..., "Id"]   # for the annihilation operator
     ["JW", ..., "JW", "Cd", "Id", ..., "Id"]   # for the creation operator
@@ -81,8 +81,8 @@ but this time acting *after* ``C``::
 
 Higher dimensions
 -----------------
-For an MPO or MPS, you always have to define an ordering of all your sites. This ordering effectifely maps the
-higher-dimensional lattice to a 1D chain, usually at the expence of long-range hopping/interactions.
+For an MPO or MPS, you always have to define an ordering of all your sites. This ordering effectively maps the
+higher-dimensional lattice to a 1D chain, usually at the expense of long-range hopping/interactions.
 With this mapping, the Jordan-Wigner transformation generalizes to higher dimensions in a straight-forward way.
 
 
@@ -182,7 +182,7 @@ However, if you use the :meth:`~tenpy.models.model.CouplingModel.add_coupling` m
 (or the generalization :meth:`~tenpy.models.model.CouplingModel.add_multi_coupling` for more than 2 operators),
 TeNPy can use the information from the `Site` class to *automatically add Jordan-Wigner* strings as needed.
 Indeed, with the default argument ``op_string=None``, `add_coupling` will automatically check whether the operators
-need Jordan-Wigner strings and correspondlingly set ``op_string='JW', str_on_first=True``, if necessary.
+need Jordan-Wigner strings and correspondingly set ``op_string='JW', str_on_first=True``, if necessary.
 For `add_multi_coupling`, you can't even explicitly specify the correct Jordan-Wigner strings, but you **must use**
 ``op_string=None``, from which it will automatically determine where Jordan-Wigner strings are needed.
 

--- a/doc/intro/lattices.rst
+++ b/doc/intro/lattices.rst
@@ -110,7 +110,7 @@ Boundary conditions
 -------------------
 
 The :class:`~tenpy.models.lattice.Lattice` defines the **boundary conditions** `bc` in each direction. 
-It can be one of the usual ``'open'`` or ``'periodic'`` in each direcetion and will be used by the
+It can be one of the usual ``'open'`` or ``'periodic'`` in each direction and will be used by the
 :class:`~tenpy.models.model.CouplingModel` to determine whether there should be added periodic couplings in the
 corresponding directions.
 
@@ -162,7 +162,7 @@ The :class:`~tenpy.models.lattice.IrregularLattice` allows you to add or remove 
 The doc-string of :class:`~tenpy.models.lattice.IrregularLattice` contains several examples. Let us consider another one
 here, where we use the IrregularLattice to "fix" the boundary of the Honeycomb lattice.
 When we use ``"open"`` boundary conditions for a finite system, there are two sites (shown on the lower left, and upper right corners of the figure below),
-wich are not included into any hexagonal. The following example shows how to remove them from the system:
+which are not included into any hexagonal. The following example shows how to remove them from the system:
 
 .. plot ::
     :include-source:

--- a/doc/intro/logging.rst
+++ b/doc/intro/logging.rst
@@ -68,7 +68,7 @@ Moreover, you can easily adjust the log levels with simple parameters, for examp
         logger_levels:
             tenpy.tools.params : WARNING  # suppres INFO/DEBUG output for any logging of parameters
 
-Of course, you can also explicilty call the :func:`~tenpy.tools.misc.setup_logging` yourself, if you don't use the `Simulation` classes::
+Of course, you can also explicitly call the :func:`~tenpy.tools.misc.setup_logging` yourself, if you don't use the `Simulation` classes::
 
     tenpy.tools.misc.setup_logging({'to_stdout': None, 'to_file': 'INFO', 'filename': 'my_log.txt',
                                     'log_levels': {'tenpy.tools.params': 'WARNING'}})
@@ -99,7 +99,7 @@ but it's actually straight-forward, and just requires at most two steps.
         In that case you can even **skip** this step and just use ``self.logger`` instead of ``logger`` in the snippets
         below.
 
-2.  Inside your funtions/methods/..., make calls like this::
+2.  Inside your functions/methods/..., make calls like this::
 
         if is_likely_bad(options['parameter']):
             # this can be fixed by the user!
@@ -121,4 +121,4 @@ In summary, instead of just ``print("do X")`` statements, use ``self.logger.info
 ``logger.info("do X")`` for the module-wide logger, which you can initialize right at the top of your file with the import
 statements. If you have non-string arguments, add a formatter string, e.g. replace ``print(max(psi.chi))`` with
 ``logger.info("%d", max(psi.chi))``, or even better, ``logger.info("max(chi)=%d", max(psi.chi))``.
-For genereic types, use ``"%s"`` or ``"%r"``, which converts the other arguments to strings with ``str(...)`` or ``repr(...)``, respectively.
+For generic types, use ``"%s"`` or ``"%r"``, which converts the other arguments to strings with ``str(...)`` or ``repr(...)``, respectively.

--- a/doc/intro/measurements.rst
+++ b/doc/intro/measurements.rst
@@ -12,7 +12,7 @@ running it.
 
 .. note ::
     For variational ground state searches, e.g. DMRG, the situation is better: we're not
-    interested in how we got to the ground state, but only properties of the ground state itselft.
+    interested in how we got to the ground state, but only properties of the ground state itself.
     In this case, we can first run DMRG, save the state, and then perform additional
     measurements and analysis *after* finishing the simulation, so it is not crucial to
     define all the measurements before the simulation.
@@ -43,14 +43,14 @@ Measurement functions
 In the simplest case, a measurement function is just a function, which can take the keyword arguments
 ``results, psi, model, simulation`` and saves the measurement results in the dictionary `results`.
 The other arguments `psi` and `model` are the current MPS and model that can be used for measurements, 
-and `simulation` gives access to the full simulation class, in case other addiontal data is needed.
+and `simulation` gives access to the full simulation class, in case other additional data is needed.
 
 Within TeNPy, we use the convention that measurement functions (taking these arguments and saving to `results` instead
 of simply returning values) start with an ``m_`` in their name.
 A few generic measurement functions are defined in :mod:`~tenpy.simulations.measurement`.
 
 As a first, somewhat trivial example, let us look at the source code of
-:func:`tenpy.simulations.measurement.m_entropy`::
+:func:`~tenpy.simulations.measurement.m_entropy`::
 
     def m_entropy(results, psi, model, simulation, results_key='entropy'):
         results[results_key] = psi.entanglement_entropy()
@@ -61,7 +61,7 @@ Note that usually the `psi` and `model` arguments are the same as the simulation
 In most cases, you should directly use the passed `psi` and `model`.
 
 Of course, you can also do some actual calculations in the measurement functions.
-A good example of this is the :func:`tenpy.simulations.measurement.m_onsite_expectation_value` - take a look at it's
+A good example of this is the :func:`~tenpy.simulations.measurement.m_onsite_expectation_value` - take a look at it's
 source code. Another example could be the `m_pollmann_turner_inversion` measurement function defined in the
 :doc:`/examples/model_custom` example from the :doc:`/intro/simulations` guide.
 
@@ -69,14 +69,14 @@ source code. Another example could be the `m_pollmann_turner_inversion` measurem
 The connect_measurements parameter
 ----------------------------------
 
-The :cfg:option:`Simulation.connect_measurements` parameter is a list with one entry for each measurment function to be
+The :cfg:option:`Simulation.connect_measurements` parameter is a list with one entry for each measurement function to be
 used. Each function is specified by a tuple ``module, func_name, extra_kwargs, priority``.
-Here, `module` and `func` specfiy the module and name of the function, `extra_kwargs` are (optional) additional keyword
+Here, `module` and `func` specify the module and name of the function, `extra_kwargs` are (optional) additional keyword
 arguments to be given to the function, and `priority` allows to control the order in which the measurement functions get
 called. The latter is usefull if you want to "post-process" results of another measurement function.
 
 For example, say you want to measure local expectation values of both `Sz` and `Sx` with
-:func:`tenpy.simulations.measurment.m_onsite_expectation_value`, then you could use
+:func:`~tenpy.simulations.measurement.m_onsite_expectation_value`, then you could use
 
 .. code :: yaml
 

--- a/doc/intro/model.rst
+++ b/doc/intro/model.rst
@@ -15,7 +15,7 @@ For example, let us consider a spin-1/2 Heisenberg model described by the Hamilt
 Note that a few things are defined more or less implicitly.
 
 - The local Hilbert space: it consists of Spin-1/2 degrees of freedom with the usual spin-1/2 operators :math:`S^x, S^y, S^z`.
-- The geometric (lattice) strucuture: above, we spoke of a 1D "chain".
+- The geometric (lattice) structure: above, we spoke of a 1D "chain".
 - The boundary conditions: do we have open or periodic boundary conditions?
   The "chain" suggests open boundaries, which are in most cases preferable for MPS-based methods.
 - The range of `i`: How many sites do we consider (for a 2D system: in each direction)?
@@ -41,7 +41,7 @@ we need a :class:`~tenpy.models.model.NearestNeighborModel`, in which the Hamilt
 two-site bond-terms to allow a Suzuki-Trotter decomposition of the time-evolution operator::
 
     class MyNewModel2(NearestNeighborModel):
-        """General strucutre for a model suitable for TEBD."""
+        """General structure for a model suitable for TEBD."""
         def __init__(self, model_params):
             lattice = somehow_generate_lattice(model_params)
             H_bond = somehow_generate_H_bond(lattice, model_params)
@@ -123,7 +123,7 @@ of couplings on a given lattice.
 Once initialized, its methods :meth:`~tenpy.models.CouplingModel.add_onsite` and
 :meth:`~tenpy.models.model.CouplingModel.add_coupling` allow to add onsite and coupling terms repeated over the different
 unit cells of the lattice.
-In that way, it basically allows a straight-forward translation of the Hamiltonian given as a math forumla
+In that way, it basically allows a straight-forward translation of the Hamiltonian given as a math formula
 :math:`H = \sum_{i} A_i B_{i+dx} + ...` with onsite operators `A`, `B`,... into a model class.
 
 The general structure for a new model based on the :class:`~tenpy.models.model.CouplingModel` is then::
@@ -170,13 +170,13 @@ In the initialization method ``__init__(self, ...)`` of this class you can then 
       :meth:`~tenpy.models.model.CouplingModel.add_coupling` for more details.
 
    Note that the `strength` arguments of these functions can be (numpy) arrays for site-dependent couplings.
-   If you need to add or multipliy some parameters of the model for the `strength` of certain terms,
+   If you need to add or multiply some parameters of the model for the `strength` of certain terms,
    it is recommended use ``np.asarray`` beforehand -- in that way lists will also work fine.
 7. Finally, if you derived from the :class:`~tenpy.models.model.MPOModel`, you can call
    :meth:`~tenpy.models.model.CouplingModel.calc_H_MPO` to build the MPO and use it for the initialization
    as ``MPOModel.__init__(self, lat, self.calc_H_MPO())``.
 8. Similarly, if you derived from the :class:`~tenpy.models.model.NearestNeighborModel`, you can call
-   :meth:`~tenpy.models.model.CouplingModel.calc_H_bond` to initialze it
+   :meth:`~tenpy.models.model.CouplingModel.calc_H_bond` to initialize it
    as ``NearestNeighborModel.__init__(self, lat, self.calc_H_bond())``.
    Calling ``self.calc_H_bond()`` will fail for models which are not nearest-neighbors (with respect to the MPS ordering),
    so you should only subclass the :class:`~tenpy.models.model.NearestNeighborModel` if the lattice is a simple
@@ -227,7 +227,7 @@ The general structure of this class is like this::
             # and then read out the class attribute `default_lattice`,
             # initialize an arbitrary pre-defined lattice
             # using model_params['lattice']
-            # and enure it's the default lattice if the class attribute
+            # and ensure it's the default lattice if the class attribute
             # `force_default_lattice` is True.
 
         def init_terms(self, model_param):
@@ -250,7 +250,7 @@ lattice cylinder - although it's intuitively clear, what the Hamiltonian there s
 coupling on each bond of the 2D lattice.
 
 It's not possible to generalize a :class:`~tenpy.models.model.NearestNeighborModel` to an arbitrary lattice where it's
-no longer nearest Neigbors in the MPS sense, but we can go the other way around:
+no longer nearest Neighbors in the MPS sense, but we can go the other way around:
 first write the model on an arbitrary 2D lattice and then restrict it to a 1D chain to make it a :class:`~tenpy.models.model.NearestNeighborModel`.
 
 Let me illustrate this with another standard example model: the transverse field Ising model, implemented in the module
@@ -306,7 +306,7 @@ Finally, if you wanted a reduction in MPO bond dimension, you would need to set 
 Non-uniform terms and couplings
 -------------------------------
 The CouplingModel-methods :meth:`~tenpy.models.model.CouplingModel.add_onsite`, :meth:`~tenpy.models.model.CouplingModel.add_coupling`, 
-and :meth:`~tenpy.models.model.CouplingModel.add_multi_coupling` add a sum over a "couplig" term shifted by lattice
+and :meth:`~tenpy.models.model.CouplingModel.add_multi_coupling` add a sum over a "coupling" term shifted by lattice
 vectors. However, some models are not that "uniform" over the whole lattice.
 
 First of all, you might have some local term that gets added only at one specific location in the lattice.
@@ -345,7 +345,7 @@ but also on the boundary conditions of the lattice. Given a term, you can call
 To avoid any ambiguity, the shape of the `strength` always has to fit, at least after a tiling performed by :func:`~tenpy.tools.misc.to_array`.
 
 For example, consider the Su-Schrieffer-Heeger model, a spin-less :class:`~tenpy.models.fermions.FermionChain` with hopping strength alternating between two values, say `t1` and `t2`.
-You can generete this model for example like this::
+You can generate this model for example like this::
     
     L = 30 # or whatever you like...
     t1, t2 = 0.5, 1.5

--- a/doc/intro/npc.rst
+++ b/doc/intro/npc.rst
@@ -32,7 +32,7 @@ However, you should definitely know a few basic facts about the usage of charge 
   This class is defined in :mod:`~tenpy.linalg.np_conserved` (the name standing for "numpy with charge conservation").
   Internally, it stores only non-zero blocks of the tensor, which are "compatible" with the charges of the indices.
   It **has to have a well defined overall charge** :class:`~tenpy.linalg.np_conserved.Array.qtotal`.
-  This **expludes certain operators** (like :math:`S^x` for Sz conservation) and MPS which are a superpositions of states in different charge sectors.
+  This **excludes certain operators** (like :math:`S^x` for Sz conservation) and MPS which are a superpositions of states in different charge sectors.
 - There is a class :class:`~tenpy.linalg.charges.ChargeInfo` holding the general information what kind of charges we have,
   and a :class:`~tenpy.linalg.charges.LegCharge` for the charge data on a given leg. The leg holds a flag `qconj` which
   is +1 or -1, depending on whether the leg goes into the tensor (representing a vector space) 
@@ -42,7 +42,7 @@ However, you should definitely know a few basic facts about the usage of charge 
   These function have a very similar call structure as the corresponding numpy functions, but they act on our tensor
   Array class, and preserve the block structure (and exploit it for speed, wherever possible).
 - The only allowed "reshaping" operations for those tensors are to combine legs and to split previously combined legs.
-  See the correspoding :ref:`section below <leg_pipes>`.
+  See the corresponding :ref:`section below <leg_pipes>`.
 - It is convenient to use string labels instead of numbers to refer to the various legs of a tensor.
   The rules how these labels change during the various operations are also described a :ref:`section below <leg_labeling>`.
 
@@ -52,7 +52,7 @@ However, you should definitely know a few basic facts about the usage of charge 
 Introduction to combine_legs, split_legs and LegPipes
 -----------------------------------------------------
 
-Often, it is necessary to "combine" multiple legs into one: for example to perfom a SVD, a tensor needs to be viewed as a matrix.
+Often, it is necessary to "combine" multiple legs into one: for example to perform a SVD, a tensor needs to be viewed as a matrix.
 For a flat array, this can be done with ``np.reshape``, e.g., if ``A`` has shape ``(10, 3, 7)`` then ``B = np.reshape(A, (30, 7))`` will
 result in a (view of the) array with one less dimension, but a "larger" first leg. By default (``order='C'``), this
 results in ::
@@ -120,7 +120,7 @@ So here is how it works:
 - Labels will be intelligently inherited through the various operations of `np_conserved`.
     - Under `transpose`, labels are permuted.
     - Under `tensordot`, labels are inherited from uncontracted legs. If there is a collision, both labels are dropped.
-    - Under `combine_legs`, labels get concatenated with a ``.`` delimiter and sourrounded by brackets.
+    - Under `combine_legs`, labels get concatenated with a ``.`` delimiter and surrounded by brackets.
       Example: let ``a.labels = {'a': 1, 'b': 2, 'c': 3}``.
       Then if ``b = a.combine_legs([[0, 1], [2]])``, it will have ``b.labels = {'(a.b)': 0, '(c)': 1}``.
       If some sub-leg of a combined leg isn't named, then a ``'?#'`` label is inserted (with ``#`` the leg index), e.g., ``'a.?0.c'``.
@@ -160,7 +160,7 @@ The 'indices' can be:
 - a ``slice(start, stop, step)`` or ``start:stop:step``: keep only the indices specified by the slice. This is also implemented with `iproject`.
 - an 1D int `ndarray` ``mask``: keep only the indices specified by the array. This is also implemented with `iproject`.
 
-For slices and 1D arrays, additional permuations may be perfomed with the help of :meth:`~tenpy.linalg.np_conserved.Array.permute`.
+For slices and 1D arrays, additional permutations may be performed with the help of :meth:`~tenpy.linalg.np_conserved.Array.permute`.
 
 If the number of indices is less than `rank`, the remaining axes remain free, so for a rank 4 Array ``A``, ``A[i0, i1] == A[i0, i1, ...] == A[i0, i1, :, :]``.
 
@@ -199,9 +199,9 @@ An **index** of a leg is a particular value :math:`a_i \in \lbrace 0, ... ,n_i-1
 
 The **rank** is the number of legs, the **shape** is :math:`(n_0, ..., n_{rank-1})`.
 
-We restrict ourselfes to abelian charges with entries in :math:`\mathbb{Z}` or in :math:`\mathbb{Z}_m`.
+We restrict ourselves to abelian charges with entries in :math:`\mathbb{Z}` or in :math:`\mathbb{Z}_m`.
 The nature of a charge is specified by :math:`m`; we set :math:`m=1` for charges corresponding to :math:`\mathbb{Z}`.
-The number of charges is refered to as **qnumber** as a short hand, and the collection of :math:`m` for each charge is called **qmod**.
+The number of charges is referred to as **qnumber** as a short hand, and the collection of :math:`m` for each charge is called **qmod**.
 The qnumber, qmod and possibly descriptive names of the charges are saved in an instance of :class:`~tenpy.linalg.charges.ChargeInfo`.
 
 To each index of each leg, a value of the charge(s) is associated.
@@ -261,7 +261,7 @@ The different formats for LegCharge
 +++++++++++++++++++++++++++++++++++
 As mentioned above, we assign charges to each index of each leg of a tensor.
 This can be done in three formats: **qflat**, as **qind** and as **qdict**.
-Let me explain them with examples, for simplicity considereing only a single charge (the most inner array has one entry
+Let me explain them with examples, for simplicity considering only a single charge (the most inner array has one entry
 for each charge).
 
 **qflat** form: simply a list of charges for each index. 
@@ -417,7 +417,7 @@ This leads to the following convention:
 
    When an npc algorithm makes tensors which share a bond (either with the input tensors, as for tensordot, or amongst the output tensors, as for SVD),
    the algorithm is free, but not required, to use the **same** :class:`LegCharge` for the tensors sharing the bond, *without* making a copy.
-   Thus, if you want to modify a LegCharge, you **must** make a copy first (e.g. by using methods of LegCharge for what you want to acchive).
+   Thus, if you want to modify a LegCharge, you **must** make a copy first (e.g. by using methods of LegCharge for what you want to achieve).
 
 
 Assigning charges to non-physical legs
@@ -435,7 +435,7 @@ As a concrete example, consider an MPS on just two spin 1/2 sites::
     |          |p            |p
 
 The two legs ``p`` are the physical legs and share the same charge, as they both describe the same local Hilbert space.
-For better distincition, let me label the indices of them by :math:`\uparrow=0` and :math:`\downarrow=1`.
+For better distinction, let me label the indices of them by :math:`\uparrow=0` and :math:`\downarrow=1`.
 As noted above, we can associate the charges 1 (:math:`p=\uparrow`) and -1 (:math:`p=\downarrow`), respectively, so we define::
 
     chinfo = npc.ChargeInfo([1], ['2*Sz'])
@@ -443,7 +443,7 @@ As noted above, we can associate the charges 1 (:math:`p=\uparrow`) and -1 (:mat
 
 For the ``qconj`` signs, we stick to the convention used in our MPS code and indicated by the
 arrows in above 'picture': physical legs are incoming (``qconj=+1``), and from left to right on the virtual bonds.
-This is acchieved by using ``[p, x, y.conj()]`` as `legs` for ``A``, and ``[p, y, z.conj()]`` for ``B``, with the
+This is achieved by using ``[p, x, y.conj()]`` as `legs` for ``A``, and ``[p, y, z.conj()]`` for ``B``, with the
 default ``qconj=+1`` for all ``p, x, y, z``: ``y.conj()`` has the same charges as ``y``, but opposite ``qconj=-1``.
 
 The legs ``x`` and ``z`` of an ``L=2`` MPS, are 'dummy' legs with just one index ``0``.
@@ -515,7 +515,7 @@ and a :class:`~tenpy.linalg.charges.LegCharge` instance for each of the legs.
 Indirect creation by manipulating existing arrays
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Of course, a new :class:`~tenpy.linalg.np_conserved.Array` can also created using the charge data from exisiting Arrays,
+Of course, a new :class:`~tenpy.linalg.np_conserved.Array` can also created using the charge data from existing Arrays,
 for example with :meth:`~tenpy.linalg.np_conserved.Array.zeros_like` or creating a (deep or shallow) :meth:`~tenpy.linalg.np_conserved.Array.copy`.
 Further, there are many higher level functions like :func:`~tenpy.linalg.np_conserved.tensordot` or :func:`~tenpy.linalg.np_conserved.svd`,
 which also return new Arrays.
@@ -616,8 +616,8 @@ So, if sorted (with :meth:`~tenpy.linalg.np_conserved.Array.isort_qdata`, the ``
 
 Note that `np.lexsort` chooses the right-most column to be the dominant key, a convention we follow throughout.
 
-If ``_qdata_sorted == True``, ``_qdata`` and ``_data`` are guaranteed to be lexsorted. If ``_qdata_sorted == False``, there is no gaurantee.
-If an algorithm modifies ``_qdata``, it **must** set ``_qdata_sorted = False`` (unless it gaurantees it is still sorted).
+If ``_qdata_sorted == True``, ``_qdata`` and ``_data`` are guaranteed to be lexsorted. If ``_qdata_sorted == False``, there is no guarantee.
+If an algorithm modifies ``_qdata``, it **must** set ``_qdata_sorted = False`` (unless it guarantees it is still sorted).
 The routine :meth:`~tenpy.linalg.np_conserved.Array.sort_qdata` brings the data to sorted form.
 
 
@@ -625,7 +625,7 @@ The routine :meth:`~tenpy.linalg.np_conserved.Array.sort_qdata` brings the data 
 See also
 --------
 - The module :mod:`tenpy.linalg.np_conserved` should contain all the API needed from the point of view of the algorithms.
-  It contians the fundamental :class:`~tenpy.linalg.np_conserved.Array` class and functions for working with them (creating and manipulating).
+  It contains the fundamental :class:`~tenpy.linalg.np_conserved.Array` class and functions for working with them (creating and manipulating).
 - The module :mod:`tenpy.linalg.charges` contains implementations for the charge structure, for example the classes
   :class:`~tenpy.linalg.charges.ChargeInfo`, :class:`~tenpy.linalg.charges.LegCharge`, and :class:`~tenpy.linalg.charges.LegPipe`.
   As noted above, the 'public' API is imported to (and accessible from) :mod:`~tenpy.linalg.np_conserved`.

--- a/doc/intro/options.rst
+++ b/doc/intro/options.rst
@@ -3,15 +3,15 @@ Parameters and options
 
 (We use `parameter` and `option` synonymously. See also the section on parameters in :doc:`/intro/simulations`.
 
-Standard simulations in TeNPy can be defined by just set of options collected in a dictionary (possibly containing
+Standard simulations in TeNPy can be defined by just a set of options collected in a dictionary (possibly containing
 other parameter dictionaries).
 It can be convenient to represent these options in a [yaml]_ file, say ``parameters.yml``, which might look like this:
 
 .. literalinclude:: /../examples/userguide/i_dmrg_parameters.yml
 
 Note that the default values and even the allowed/used option names often depend on other parameters.
-For example, the `model_class` parameter above given to a :class:`~tenpy.simulations.Simulation` selects a model class,
-and diffent model classes might have completely different parameters.
+For example, the `model_class` parameter above given to a :class:`~tenpy.simulations.simulation.Simulation` selects a model class,
+and different model classes might have completely different parameters.
 This gives you freedom to easily define your own parameters when you implement a model, 
 but it also makes it a little bit harder to keep track of allowed values.
 
@@ -26,7 +26,7 @@ into the :cfg:config:`TEBDEngine` config, similarly to the sub-classing used.
 During runtime, the :class:`~tenpy.tools.params.Config` class logs the first use of any parameter (with DEBUG log-level, if
 the default is used, and with INFO log-level, if it is non-default). Moreover, the default is saved into the parameter
 dictionary. Hence, it will contain the *full set of all used parameters*, default and non-default, at the end of a
-simulation, e.g., in the `sim_params` of the `results` returned by :meth:`tenpy.simulations.Simulation.run`.
+simulation, e.g., in the `sim_params` of the `results` returned by :meth:`~tenpy.simulations.Simulation.run`.
 
 .. note ::
 

--- a/doc/intro/overview.rst
+++ b/doc/intro/overview.rst
@@ -12,7 +12,7 @@ tenpy
     (This file is also necessary to mark the folder as part of the python package.
     Consequently, other subfolders of the git repo should not include a ``__init__.py`` file.)
 toycodes
-    Simple toy codes completely independet of the remaining library (i.e., codes in ``tenpy/``).
+    Simple toy codes completely independent of the remaining library (i.e., codes in ``tenpy/``).
     These codes should be quite readable and try to give a flavor of how (some of) the algorithms work.
 examples
     Some example files demonstrating the usage and interface of the library, including pure python files, jupyter
@@ -53,10 +53,10 @@ High-level simulations
 ----------------------
 The high-level interface is given by simulations, which probably handle everything you want to run on a computing cluster job:
 Given a set of parameters (often in the form of a parameter input file), 
-the simulation consists of initialiing the model, tensor network and algorithms, running the algorithm,
+the simulation consists of initializing the model, tensor network and algorithms, running the algorithm,
 performing some measurements and finally saving the results to disk.
 It also provides some extra functionality like the ability to resume an interrupted simulation, 
-e.g., if your job got killed on the cluster due to runtime limitis.
+e.g., if your job got killed on the cluster due to runtime limits.
 Ideally, the simulation (sub) class represents the whole simulation from start to end, giving reproducible results
 depending only on the parameters given to it.
 

--- a/doc/intro/simulations.rst
+++ b/doc/intro/simulations.rst
@@ -39,7 +39,7 @@ An minimal example to run finite DMRG for a Spin-1/2 Heisenberg :class:`~tenpy.m
 
 Parallelization: controlling the number of threads
 --------------------------------------------------
-Almost all of the TeNPy code is "only" using thread-based paralellization provided by the underlying LAPACK/BLAS package linked to by Numpy/Scipy, and/or TeNPy's Cython code when you compile it.
+Almost all of the TeNPy code is "only" using thread-based parallelization provided by the underlying LAPACK/BLAS package linked to by Numpy/Scipy, and/or TeNPy's Cython code when you compile it.
 (A notable exception is the :class:`~tenpy.tools.cache.ThreadedStorage` for caching.)
 In practice, you can control the number of threads in the same way as if you use just plain numpy - by default, this uses all the CPU cores on a given machine. 
 
@@ -50,8 +50,8 @@ If you run things on a cluster, it is often required to only use a fixed number 
     export OMP_NUM_THREADS=4
     python -m tenpy parameters.yml
 
-If you linked against MKL, you can use ``export MKL_NUM_THREADS=4`` instead. In some cases, it might also be necessary to additionaly ``export MKL_DYNAMIC=FALSE``.
-Universities usually have some kind of local cluster documentation with examples - try to follow those, and doulbe check
+If you linked against MKL, you can use ``export MKL_NUM_THREADS=4`` instead. In some cases, it might also be necessary to additionally ``export MKL_DYNAMIC=FALSE``.
+Universities usually have some kind of local cluster documentation with examples - try to follow those, and double check
 that you only use the cores you request.
 
 
@@ -106,7 +106,7 @@ Adjusting the output
 If specified, output files are saved in a given :cfg:option:`Simulation.directory`.
 As shown in the parameter example above, you can simply give an :cfg:option:`Simulation.output_filename` parameter.
 Alternatively, one can specify the :cfg:option:`Simulation.output_filename_params` to make the filename depend on other
-simulation paramters (specified as keys of the `parts`), e.g:
+simulation parameters (specified as keys of the `parts`), e.g:
 
 .. code-block :: yaml
 
@@ -157,7 +157,7 @@ The general structure is listed in :attr:`~tenpy.simulations.simulation.Simulati
 Possible entries depend on the simulation class run, and some options like `save_psi` or specified measurements.
 
 Let us consider our initial DMRG example.
-The :class:`~tenpy.simulations.ground_state_search.GroundStateSearch` performs two measurements: one on the inital
+The :class:`~tenpy.simulations.ground_state_search.GroundStateSearch` performs two measurements: one on the initial
 state (unless disabled with :cfg:option:`measure_initial` and one on the final state.
 Further, MPS-based simulations by default measure the entanglement entropies for cutting at the various MPS bonds, 
 such that we can read out the final half-chain entanglement entropy like this::
@@ -225,7 +225,7 @@ A full example with custom python code
 --------------------------------------
 
 While there are plenty of predefined models and algorithms, there is a good chance that you need to tweak and adjust
-them further by writing your own python code. Examples could be custom models and/or lattices, measurment functions, or
+them further by writing your own python code. Examples could be custom models and/or lattices, measurement functions, or
 even adjustments to any other class (tensor networks, algorithms, simulations...).
 
 As a concrete example, let's try to reproduce some results of :cite:`pollmann2012`, namely the :math:`\mathcal{O}_I` defined in eq. (15) of that paper.
@@ -249,7 +249,7 @@ You can then run this simulation, say for three different `D` values specified d
 
 .. note ::
 
-    If you use the setup from the [TeNPyProjectTemplate]_ repository, the ``cluster_jobs.py`` helps to manage submiting
+    If you use the setup from the [TeNPyProjectTemplate]_ repository, the ``cluster_jobs.py`` helps to manage submitting
     jobs with similar parameters to a computing cluster; 
     it includes this very example as a starting point for customization.
 
@@ -289,7 +289,7 @@ particular for flux pump experiments, or to get a stable scaling with bond dimen
 To achieve this, you need to call :func:`~tenpy.run_seq_simulations` instead of just :func:`~tenpy.run_simulation`, and
 specify the :cfg:config:`sequential` parameters for the simulation (at the top level of the yaml files), in particular
 the `recursive_keys` for the parameters to be changed. The values for those parameters can be specified as 
-:cfg:option:`sequential.value_lists`, or as lists in the original localtion of the yaml file.
+:cfg:option:`sequential.value_lists`, or as lists in the original location of the yaml file.
 
 .. code-block :: yaml
 

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -2,7 +2,7 @@ Troubleshooting and FAQ
 =======================
 
 I updated to a new version and now I get an error/warning.
-    Take a look at the section "Backwards incomptatible changes" in the :doc:`/releases` of the corresponding versions
+    Take a look at the section "Backwards incompatible changes" in the :doc:`/releases` of the corresponding versions
     since when you updated.
 
 Where did all the output go?
@@ -33,7 +33,7 @@ How can I double check the installed TeNPy version?
 
 I get an error when ...
 -----------------------
-... I try to measure ``Sx_i Sx_j`` correlations in a state with `Sz` conseration.
+... I try to measure ``Sx_i Sx_j`` correlations in a state with `Sz` conservation.
     Right now this is not possible. See the basic facts in :doc:`/intro/npc`.
 
 


### PR DESCRIPTION
A list of typos I (and some credit goes to my IDE) found whilst reading the documentation over the last while :)