### PR TITLE
Fix typos in mixed_xk.py documentation

### DIFF
--- a/tenpy/models/mixed_xk.py
+++ b/tenpy/models/mixed_xk.py
@@ -5,7 +5,7 @@ as described in :cite:`motruk2016`.
 
 We consider infinite cylinders in real-space along the cylinder axis,
 but transform to momentum space around the cylinder.
-The DMRG unit cell consists of `N_rings` "rings" on they cylinder with a given x-coordinate `i`.
+The DMRG unit cell consists of `N_rings` "rings" on the cylinder with a given x-coordinate `i`.
 Inside each ring, we consider `Ly` repetitions of `N_orb` independent fermionic orbitals around
 the cylinder. Each orbital is one fermionic state that can be occupied or empty and corresponds to
 a unique creation/annihilation operator in second quantization.
@@ -19,19 +19,19 @@ and orbital :math:`l = 0, ... N_{orb}`.
 We transform them into momentum space with the convention (for all :math:`x,l` independently):
 
 .. math ::
-    c^\dagger_{x,k,l} = 1/\sqrt{L_y} \sum_k \exp(- \frac{2\pi i}{L_y} * k * y) c^\dagger_{x,y,l}
+    c^\dagger_{x,k,l} = 1/\sqrt{L_y} \sum_y \exp(- \frac{2\pi i}{L_y} * k * y) c^\dagger_{x,y,l}
     \\
-    c_{x,k,l}         = 1/\sqrt{L_y} \sum_k \exp(+ \frac{2\pi i}{L_y} * k * y) c_{x,y,l}
+    c_{x,k,l}         = 1/\sqrt{L_y} \sum_y \exp(+ \frac{2\pi i}{L_y} * k * y) c_{x,y,l}
     \\
-    c^\dagger_{x,y,l} = 1/\sqrt{L_y} \sum_y \exp(+ \frac{2\pi i}{L_y} * k * y) c^\dagger_{x,k,l}
+    c^\dagger_{x,y,l} = 1/\sqrt{L_y} \sum_k \exp(+ \frac{2\pi i}{L_y} * k * y) c^\dagger_{x,k,l}
     \\
-    c_{x,y,l}         = 1/\sqrt{L_y} \sum_y \exp(- \frac{2\pi i}{L_y} * k * y) c_{x,k,l}
+    c_{x,y,l}         = 1/\sqrt{L_y} \sum_k \exp(- \frac{2\pi i}{L_y} * k * y) c_{x,k,l}
 
 
 We use the indices ``k = 0, ... Ly-1`` and define the actual momentum as
 :math:`k_y = 2 \pi i / L_y * k` for :math:`k \leq Ly/2` and
 and shift to :math:`k_y = 2 \pi i * (k-L_y) / L_y ` for :math:`k > Ly/2` such that
-:math:`k_y \in (-\pi, pi]`.
+:math:`k_y \in (-\pi, \pi]`.
 The momenta fulfill the usual relations
 
 .. math ::


### PR DESCRIPTION
Fixing a few typos in documentation