### PR TITLE
Enhance predict ram

### DIFF
--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -87,3 +87,5 @@ Fixed
   Further, allow to pass multiple charge sectors to loop over at once, add argument `return_charges`.
   Also, provide a :meth:`~tenpy.networks.mps.MPS.correlation_length_charge_sectors` convenience function to return valid charge sectors.
 - :issue:`153` that DMRG energy convergence criterion was verified after an arbitrarily large energy increase.
+- :func:`~tenpy.tools.misc.setup_logging` did not suppress logging file output with ``filename=None`` as documented, but
+  just derived the log output filename from the `output_filename`.

--- a/doc/changelog/latest.rst
+++ b/doc/changelog/latest.rst
@@ -37,6 +37,8 @@ Added
 - Overlaps of finite, shifted/translated MPS in :meth:`~tenpy.networks.mps.MPS.overlap_translate_finite`.
 - New MPS construction method :meth:`~tenpy.networks.mps.MPS.from_product_mps_covering` as a generalization of
   `from_singlets`.
+- New :func:`~tenpy.simulations.simulation.estimate_simulation_RAM` to estimate the RAM requiremensts of a simulation
+  before actually running it (:issue:`305` and :issue:`342`).
 
 Changed
 ^^^^^^^

--- a/tenpy/algorithms/algorithm.py
+++ b/tenpy/algorithms/algorithm.py
@@ -182,7 +182,7 @@ class Algorithm:
         else:
             return {'psi': self.psi}
 
-    def estimate_RAM(self, saving_factor=None):
+    def estimate_RAM(self, mem_saving_factor=None):
         """Gives an approximate prediction for the required memory usage.
 
         This calculation is based on the requested bond dimension,
@@ -190,7 +190,7 @@ class Algorithm:
 
         Parameters
         ----------
-        saving_factor : float
+        mem_saving_factor : float
             Represents the amount of RAM saved due to conservation laws.
             By default, it is 'None' and is extracted from the model automatically.
             However, this is only possible in a few cases and needs to be estimated in most cases.
@@ -201,12 +201,16 @@ class Algorithm:
             ``print(psi.get_B(0).sparse_stats())``
             TeNPy will automatically print the fraction of nonzero entries in the first line,
             for example, ``6 of 16 entries (=0.375) nonzero``.
-            This fraction corresponds to the saving_factor; in our example, it is 0.375.
+            This fraction corresponds to the `mem_saving_factor`; in our example, it is 0.375.
 
         Returns
         -------
         usage : float
             Required RAM in MB.
+
+        See also
+        --------
+        tenpy.simulations.simulation.estimate_simulation_RAM: global function calling this.
         """
         # first get memory per tensor entry in bytes
         dtypes = [self.psi.dtype]
@@ -298,15 +302,15 @@ class Algorithm:
             total_entries += MPO_entries
             total_entries += lanczos_entries
 
-        if saving_factor is None:
-            saving_factor = self.model.estimate_RAM_saving_factor()
+        if mem_saving_factor is None:
+            mem_saving_factor = self.model.estimate_RAM_saving_factor()
 
         logger.debug("We get a total of %.3e = %d entries for the RAM esitmate", entry_size, entry_size)
         logger.debug("Each entry uses %d byte", entry_size)
         RAM = total_entries * entry_size
         logger.debug("We have a saving factor of %.5f ~= 1/%d",
-                     saving_factor, int(1./saving_factor + 0.5))
-        RAM *= saving_factor
+                     mem_saving_factor, int(1./mem_saving_factor + 0.5))
+        RAM *= mem_saving_factor
         RAM_MB = RAM / 1024**2
         logger.info("Total RAM estimate: %8d MB", RAM_MB)
         return RAM_MB

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -91,7 +91,9 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
 
     def estimate_RAM_saving_factor(self):
         """Returns the expected saving factor for RAM based on charge conservation.
-        For the BoseHubbardChain this factor was found to be between 1/7 and 1/10, therefore it is by default to 1/8 (for particle number conservation).
+
+        For the BoseHubbardChain this factor was found to be between 1/7 and 1/10,
+        therefore we let it default to 1/8 (for particle number conservation).
 
         Returns
         -------
@@ -102,16 +104,19 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         -------
         .. cfg:configoptions :: Model
 
-            saving_factor :: None | int
-                Quantizes the RAM saving, due to conservation laws. By default it is 1/8 for the BoseHubbardChain. However, this factor might be overwritten, if a better approximation is known. In this case one can pass it via the argument ''saving_factor'' to the model.
+            mem_saving_factor :: None | int
+                Quantizes the RAM saving, due to conservation laws.
+                By default it is 1/8 for the BoseHubbardChain.
+                However, this factor might be overwritten, if a better approximation is known.
+                In this case one can pass it via the argument `mem_saving_factor` to the model.
 
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
-        savings = 1
+        savings = 1.
         for mod in chinfo.mod:
             if mod == 1:
-                savings *= 1/8 # this is what we found empirically
-        return self.options.get("saving_factor", savings)
+                savings *= 1/8. # this is what we found empirically
+        return self.options.get("mem_saving_factor", savings)
 
 
 class FermiHubbardModel(CouplingMPOModel):

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -98,6 +98,12 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         factor : int
             saving factor, due to conservation
 
+        Options
+        -------
+        .. cfg:configoptions :: Model
+
+            saving_factor :: None | int
+                Quantizes the RAM saving, due to conservation laws. By default it is 1/8 for the BoseHubbardChain. However, this factor might be overwritten, if a better approximation is known. In this case one can pass it via the argument ''saving_factor'' to the model.
 
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
@@ -105,7 +111,7 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         for mod in chinfo.mod:
             if mod == 1:
                 savings *= 1/8 # this is what we found empirically
-        return savings
+        return self.options.get("saving_factor", savings)
 
 
 class FermiHubbardModel(CouplingMPOModel):

--- a/tenpy/models/hubbard.py
+++ b/tenpy/models/hubbard.py
@@ -97,6 +97,8 @@ class BoseHubbardChain(BoseHubbardModel, NearestNeighborModel):
         -------
         factor : int
             saving factor, due to conservation
+
+
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
         savings = 1

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -261,6 +261,14 @@ class Model(Hdf5Exportable):
         -------
         factor : int
             saving factor, due to conservation
+
+        Options
+        -------
+        .. cfg:configoptions :: Model
+
+            saving_factor :: None | float
+                Quantizes the RAM saving, due to conservation laws. By default it is 1/mod, or 1/4 in case of mod=1. However, for some classes this factor might be overwritten, if a better approximation is known. In the best case, the user has a good approximation and can pass it via the argument ``saving_factor`` to the model.
+
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
         savings = 1

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -266,8 +266,13 @@ class Model(Hdf5Exportable):
         -------
         .. cfg:configoptions :: Model
 
-            saving_factor :: None | float
-                Quantizes the RAM saving, due to conservation laws. By default it is 1/mod, or 1/4 in case of mod=1. However, for some classes this factor might be overwritten, if a better approximation is known. In the best case, the user has a good approximation and can pass it via the argument ``saving_factor`` to the model.
+            mem_saving_factor :: None | float
+                Quantizes the RAM saving, due to conservation laws, to be used by
+                :func:`~tenpy.simulations.simulation.estimate_simulation_RAM`.
+                By default it is 1/mod, or 1/4 in case of mod=1.
+                However, for some classes this factor might be overwritten,
+                if a better approximation is known.
+                In the best case, the user can adjust this model parameter to enhance the estimate.
 
         """
         chinfo = self.lat.unit_cell[0].leg.chinfo
@@ -277,7 +282,8 @@ class Model(Hdf5Exportable):
                 savings *= 1/4 # this is what we found empirically
             else:
                 savings *= 1/mod
-        return savings
+        return self.options.get("mem_saving_factor", savings)
+
 
 class NearestNeighborModel(Model):
     r"""Base class for a model of nearest neighbor interactions w.r.t. the MPS index.
@@ -1911,12 +1917,6 @@ class CouplingMPOModel(CouplingModel, MPOModel):
         self.init_H_from_terms()
         # finally checks for misspelled parameter names
         model_params.warn_unused()
-
-
-    def estimate_RAM_saving_factor(self):
-        est = super().estimate_RAM_saving_factor()
-        return self.options.get("RAM_saving_factor", est)
-
 
     @property
     def verbose(self):

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -43,6 +43,7 @@ __all__ = [
     'init_simulation_from_checkpoint',
     'resume_from_checkpoint',
     'run_seq_simulations',
+    'estimate_simulation_RAM',
     'output_filename_from_dict',
 ]
 
@@ -1415,6 +1416,8 @@ def estimate_simulation_RAM(*,
     Large-scale simulations need to be submitted to a simulation cluster, which often requires to
     give an estimate of the required RAM before actually running the simulation.
 
+    See also the model parameter :cfg:option:`Model.mem_saving_factor`.
+
     Parameters
     ----------
     suppress_non_RAM_output : bool
@@ -1432,6 +1435,10 @@ def estimate_simulation_RAM(*,
     unit : str
         Unit of the estimate
 
+    See also
+    --------
+    Simulation.estimate_RAM : Corresponding simulation method
+    tenpy.algorithms.algorithm.Algorithm.estimate_RAM : corresponding algorithm method.
     """
     offset_val, offset_unit = const_offset
     offset_MB, _ = convert_memory_units(offset_val, offset_unit, 'MB')

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -1460,8 +1460,8 @@ def estimate_simulation_RAM(*,
         estimate_MB = sim.estimate_RAM()
     total_MB = estimate_MB + offset_MB
 
-    est, est_unit = convert_memory_units(estimate_MB, 'MB', output_unit)
-    total, total_unit = convert_memory_units(total_MB, 'MB', output_unit)
+    est, est_unit = convert_memory_units(estimate_MB, 'MB', RAM_output_unit)
+    total, total_unit = convert_memory_units(total_MB, 'MB', RAM_output_unit)
     print(f"  {est:5.1f} {est_unit} estimated usage for tensors")
     print(f"+ {offset_val:5.1f} {offset_unit} constant offset for loading python etc")
     print(f"= {total:5.1f} {total_unit} total estimated RAM")

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -198,7 +198,7 @@ class Simulation:
         self.options = asConfig(self.options, self.__class__.__name__)
         self.options.touch('directory', 'output_filename', 'output_filename_params',
                            'overwrite_output', 'skip_if_output_exists', 'safe_write', 'log_params',
-                           'logging_params')
+                           'logging_params', 'estimate_RAM_const_offset')
         if cwd is not None:
             self.logger.info("change directory to %s", cwd)  # os.chdir(cwd) above
         self.logger.info("output filename: %s", self.output_filename)
@@ -1408,8 +1408,8 @@ def run_seq_simulations(sequential,
 
 def estimate_simulation_RAM(*,
                             suppress_non_RAM_output=True,
-                            output_unit=None,
-                            const_offset=(100, "MB"),
+                            RAM_output_unit=None,
+                            estimate_RAM_const_offset=(100, "MB"),
                             **simulation_params):
     """Pre-simulation RAM estimate.
 
@@ -1422,8 +1422,11 @@ def estimate_simulation_RAM(*,
     ----------
     suppress_non_RAM_output : bool
         If True (default), suppress all other output (except for error messages).
-    output_unit : None | str
+    RAM_output_unit : None | str
         Memory unit to be used for the output. ``None`` defaults to human-readable rounding.
+    estimate_RAM_const_offset : ``(int, str)``
+        Defaults to ``(100, "MB")`` which gets added to the scaling estimates.
+        This constant needs to account for loading python libraries etc.
     **simulation_params :
         Other simulation parameters as they would be pass to :func:`run_simulation` to run the
         simulation.
@@ -1431,7 +1434,7 @@ def estimate_simulation_RAM(*,
     Returns
     -------
     estimate : float
-        Estimated RAM requirements including the `const_offset`.
+        Estimated RAM requirements including the `estimate_RAM_const_offset`.
     unit : str
         Unit of the estimate
 
@@ -1440,7 +1443,7 @@ def estimate_simulation_RAM(*,
     Simulation.estimate_RAM : Corresponding simulation method
     tenpy.algorithms.algorithm.Algorithm.estimate_RAM : corresponding algorithm method.
     """
-    offset_val, offset_unit = const_offset
+    offset_val, offset_unit = estimate_RAM_const_offset
     offset_MB, _ = convert_memory_units(offset_val, offset_unit, 'MB')
     # suppress in this case undesired output
     if suppress_non_RAM_output:

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -28,7 +28,8 @@ from ..tools import hdf5_io
 from ..tools.cache import CacheFile
 from ..tools.params import asConfig
 from ..tools.events import EventHandler
-from ..tools.misc import find_subclass, update_recursive, get_recursive, set_recursive
+from ..tools.misc import find_subclass, convert_memory_units
+from ..tools.misc import update_recursive, get_recursive, set_recursive, merge_recursive
 from ..tools.misc import setup_logging as setup_logging_
 from .. import version
 from .measurement import (measurement_wrapper, _m_psi_method, _m_psi_method_wrapped,
@@ -255,6 +256,7 @@ class Simulation:
         """
         self.init_model()       # model, required for algorithm
         self.init_state()       # psi, required for algorithm
+        self.group_sites_for_algorithm()  # algorithm might only work if grouped
         self.init_algorithm()   # create engine (subclass of Algorithm)
 
         return self.engine.estimate_RAM()
@@ -1401,6 +1403,59 @@ def run_seq_simulations(sequential,
         return all_results
     else:
         return results
+
+
+def estimate_simulation_RAM(*,
+                            suppress_non_RAM_output=True,
+                            output_unit=None,
+                            const_offset=(100, "MB"),
+                            **simulation_params):
+    """Pre-simulation RAM estimate.
+
+    Large-scale simulations need to be submitted to a simulation cluster, which often requires to
+    give an estimate of the required RAM before actually running the simulation.
+
+    Parameters
+    ----------
+    suppress_non_RAM_output : bool
+        If True (default), suppress all other output (except for error messages).
+    output_unit : None | str
+        Memory unit to be used for the output. ``None`` defaults to human-readable rounding.
+    **simulation_params :
+        Other simulation parameters as they would be pass to :func:`run_simulation` to run the
+        simulation.
+
+    Returns
+    -------
+    estimate : float
+        Estimated RAM requirements including the `const_offset`.
+    unit : str
+        Unit of the estimate
+
+    """
+    offset_val, offset_unit = const_offset
+    offset_MB, _ = convert_memory_units(offset_val, offset_unit, 'MB')
+    # suppress in this case undesired output
+    if suppress_non_RAM_output:
+        for key in ['output_filename', 'output_filename_params']:  # ignore the output filename
+            if key in simulation_params:
+                del simulation_params[key]
+        overwrite = {'log_params': {'filename': None,
+                                    'to_stdout': 'ERROR'
+                                    # ERROR level suppresses unused parameters warning as well
+                                    }}
+        simulation_params = merge_recursive(simulation_params, overwrite, conflict='last')
+    # get simulation
+    with init_simulation(**simulation_params) as sim:
+        estimate_MB = sim.estimate_RAM()
+    total_MB = estimate_MB + offset_MB
+
+    est, est_unit = convert_memory_units(estimate_MB, 'MB', output_unit)
+    total, total_unit = convert_memory_units(total_MB, 'MB', output_unit)
+    print(f"  {est:5.1f} {est_unit} estimated usage for tensors")
+    print(f"+ {offset_val:5.1f} {offset_unit} constant offset for loading python etc")
+    print(f"= {total:5.1f} {total_unit} total estimated RAM")
+    return total, total_unit
 
 
 def output_filename_from_dict(options,

--- a/tenpy/tools/misc.py
+++ b/tenpy/tools/misc.py
@@ -21,6 +21,7 @@ __all__ = [
     'merge_recursive', 'flatten', 'setup_logging', 'build_initial_state', 'setup_executable'
 ]
 
+_not_set = object()  # sentinel
 
 def to_iterable(a):
     """If `a` is a not iterable or a string, return ``[a]``, else return ``a``."""
@@ -756,7 +757,7 @@ skip_logging_setup = False
 def setup_logging(options=None,
                   output_filename=None,
                   *,
-                  filename=None,
+                  filename=_not_set,
                   to_stdout="INFO",
                   to_file="INFO",
                   format="%(levelname)-8s: %(message)s",
@@ -830,7 +831,7 @@ def setup_logging(options=None,
             The filename is given by `filename`.
         filename : str
             Filename for the logfile.
-            It defaults  to `output_filename` with the extension replaced to ".log".
+            If not set, it defaults  to `output_filename` with the extension replaced to ".log".
             If ``None``, no log-file will be created, even with `to_file` set.
         logger_levels : dict(str, str)
             Set levels for certain loggers, e.g. ``{'tenpy.tools.params': 'WARNING'}`` to suppress
@@ -862,7 +863,7 @@ def setup_logging(options=None,
     if options is not None:
         warnings.warn("Give logging parameters directly as keyword arguments!", FutureWarning, 2)
         locals().update(**options)
-    if filename is None:
+    if filename is _not_set:
         if output_filename is not None:
             root, ext = os.path.splitext(output_filename)
             assert ext != '.log'

--- a/tenpy/tools/misc.py
+++ b/tenpy/tools/misc.py
@@ -1112,3 +1112,37 @@ def setup_executable(mod, run_defaults, identifier_list=None):
     })
 
     return model_par, sim_par, run_par, args
+
+
+def convert_memory_units(value, unit_from='bytes', unit_to=None):
+    """Convert between different memory units.
+
+    Parameters
+    ----------
+    value : float
+        The value to convert.
+    unit_from : ``'bytes'| 'KB'| 'MB'| 'GB'| 'TB'``
+        The unit to convert from.
+    unit_to : ``None | 'bytes'| 'KB'| 'MB'| 'GB'| 'TB'``
+        The unit to convert to.
+        The default ``None`` chooses a human-readable largest unit smaller than `value`.
+        In that case, the used `unit_to` is returned as well.
+
+    Returns
+    -------
+    value : float
+        The value in the unit `unit_to`.
+    unit_to : str
+        Only returned if the passed `unit_to` is ``None``.
+        The unit to which `value` was converted.
+    """
+    units = ['bytes', 'KB', 'MB', 'GB', 'TB']
+    factors = [1024**i for i in range(len(units))]
+    value = value * factors[units.index(unit_from)]  # first convert to bytes
+    if unit_to is None:
+        for f, unit_to in reversed(zip(factors, units)):
+            if value > f:
+                break
+        return value / f, unit_to
+    value = value / factors[units.index(unit_to)]  # now convert back to unit_to
+    return value

--- a/tenpy/tools/misc.py
+++ b/tenpy/tools/misc.py
@@ -18,7 +18,8 @@ __all__ = [
     'inverse_permutation', 'list_to_dict_list', 'atleast_2d_pad', 'transpose_list_list',
     'zero_if_close', 'pad', 'any_nonzero', 'add_with_None_0', 'chi_list', 'group_by_degeneracy',
     'get_close', 'find_subclass', 'get_recursive', 'set_recursive', 'update_recursive',
-    'merge_recursive', 'flatten', 'setup_logging', 'build_initial_state', 'setup_executable'
+    'merge_recursive', 'flatten', 'setup_logging', 'build_initial_state', 'setup_executable',
+    'convert_memory_units'
 ]
 
 _not_set = object()  # sentinel
@@ -1127,23 +1128,21 @@ def convert_memory_units(value, unit_from='bytes', unit_to=None):
     unit_to : ``None | 'bytes'| 'KB'| 'MB'| 'GB'| 'TB'``
         The unit to convert to.
         The default ``None`` chooses a human-readable largest unit smaller than `value`.
-        In that case, the used `unit_to` is returned as well.
 
     Returns
     -------
     value : float
         The value in the unit `unit_to`.
     unit_to : str
-        Only returned if the passed `unit_to` is ``None``.
         The unit to which `value` was converted.
     """
     units = ['bytes', 'KB', 'MB', 'GB', 'TB']
     factors = [1024**i for i in range(len(units))]
     value = value * factors[units.index(unit_from)]  # first convert to bytes
     if unit_to is None:
-        for f, unit_to in reversed(zip(factors, units)):
+        for f, unit_to in reversed(list(zip(factors, units))):
             if value > f:
                 break
         return value / f, unit_to
     value = value / factors[units.index(unit_to)]  # now convert back to unit_to
-    return value
+    return value, unit_to

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -302,10 +302,10 @@ def test_logging_setup(tmp_path):
 
 
 def test_convert_memory_units():
-    assert tools.misc.convert_memory_units(12.5*1024, 'bytes', 'bytes') == 12.5 * 1024
-    assert tools.misc.convert_memory_units(12.5*1024, 'KB', 'MB') == 12.5
-    assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == 12.5 * 1024**2
-    assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == 12.5 * 1024**2
+    assert tools.misc.convert_memory_units(12.5*1024, 'bytes', 'bytes') == (12.5 * 1024, 'bytes')
+    assert tools.misc.convert_memory_units(12.5*1024, 'KB', 'MB') == (12.5, 'MB')
+    assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == (12.5 * 1024**2, 'KB')
+    assert tools.misc.convert_memory_units(12.5*1024, 'MB', None) == (12.5, 'GB')
 
 if __name__ == "__main__":
     import tempfile

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -263,21 +263,27 @@ def test_merge_recursive():
 
 
 @pytest.mark.skip(reason="interferes with pytest logging setup")
-def test_logging_setup(tmp_path, capsys):
+def test_logging_setup(tmp_path):
+    from contextlib import redirect_stdout
     import logging.config
     logger = logging.getLogger('tenpy.test_logging')
     root = logging.getLogger()
-    output_filename = tmp_path / 'output.pkl'
     logging_params = {
+        'output_filename': tmp_path / 'output.pkl',
         'to_stdout': 'INFO',
         'to_file': 'WARNING',
         'skip_setup': False,
     }
-    tools.misc.setup_logging(logging_params, output_filename)
 
-    test_message = "test %s message 12345"
-    logger.info(test_message, 'info')
-    logger.warning(test_message, 'warning')
+
+    with open(tmp_path / 'stdout.txt', 'w') as stdout:
+        with redirect_stdout(stdout):
+            # example logging code
+            tools.misc.setup_logging(**logging_params)
+
+            test_message = "test %s message 12345"
+            logger.info(test_message, 'info')
+            logger.warning(test_message, 'warning')
 
     # clean up loggers -> close file handlers (?)
     logging.config.dictConfig({'version': 1, 'disable_existing_loggers': False})
@@ -288,10 +294,11 @@ def test_logging_setup(tmp_path, capsys):
     assert test_message % 'warning' in file_text
     assert test_message % 'info' not in file_text  # should have filtered that out
 
-    capture = capsys.readouterr()
-    stdout_text = capture.out
+    with open(tmp_path / 'stdout.txt', 'r') as stdout:
+        stdout_text = stdout.read()
     assert test_message % 'warning' in stdout_text
     assert test_message % 'info' in stdout_text
+    print("test_logging_setup() finished without errors")
 
 
 def test_convert_memory_units():
@@ -299,3 +306,9 @@ def test_convert_memory_units():
     assert tools.misc.convert_memory_units(12.5*1024, 'KB', 'MB') == 12.5
     assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == 12.5 * 1024**2
     assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == 12.5 * 1024**2
+
+if __name__ == "__main__":
+    import tempfile
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as tmp_path:
+        test_logging_setup(Path(tmp_path))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -292,3 +292,10 @@ def test_logging_setup(tmp_path, capsys):
     stdout_text = capture.out
     assert test_message % 'warning' in stdout_text
     assert test_message % 'info' in stdout_text
+
+
+def test_convert_memory_units():
+    assert tools.misc.convert_memory_units(12.5*1024, 'bytes', 'bytes') == 12.5 * 1024
+    assert tools.misc.convert_memory_units(12.5*1024, 'KB', 'MB') == 12.5
+    assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == 12.5 * 1024**2
+    assert tools.misc.convert_memory_units(12.5*1024, 'MB', 'KB') == 12.5 * 1024**2


### PR DESCRIPTION
This is an addition to #305 to fix minor issues.
I've restyled the code a little bit, in particular I've introduced a global function in the simulation class to just return the RAM estimate - this can then be used in tools like the cluster_jobs.py to read out the required memory.

I've also reverted the commits where Jan removed the extra simulation parameter again, because I think/hope that it is actually a useful knob to fine-tune the global pre-factor for the RAM requirements in case one gets bad estimates. Sorry that I didn't answer quickly enough to avoid the extra work of removing/adding it again.

@jangeiger if you have any more comments let me know. And a big THANKS again for implementing this feature! :+1: 