### PR TITLE
Fix error for RAM prediction for NearestNeighbor models

### DIFF
--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -282,7 +282,9 @@ class Model(Hdf5Exportable):
                 savings *= 1/4 # this is what we found empirically
             else:
                 savings *= 1/mod
-        return self.options.get("mem_saving_factor", savings)
+        if hasattr(self, 'options'):
+            savings = self.options.get("mem_saving_factor", savings)
+        return savings
 
 
 class NearestNeighborModel(Model):


### PR DESCRIPTION
A `NearestNeighbor` model might not have an attribute `options`. Therefore predicting the RAM might have failed when the model was not derived from a `MPOModel` or when sites are grouped in a Simulation.