### PR TITLE
Minor fixes for safeguarding measurements in Simulation

### DIFF
--- a/examples/yaml/minimal_SpectralSimulation.yml
+++ b/examples/yaml/minimal_SpectralSimulation.yml
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S python -m tenpy
 # This can only run if there is an output `results/a_minimal_DMRG.h5`
 
-simulation_class : SpectralSimulation
+simulation_class: SpectralSimulation
 
-ground_state_filename : a_minimal_DMRG.h5
+ground_state_filename: a_minimal_DMRG.h5
 
 directory: results
-output_filename : a_minimal_SpectralSimulation.h5
+output_filename: a_minimal_SpectralSimulation.h5
 
 operator_t0:
     opname: Sz  # can also be a list
@@ -16,8 +16,6 @@ operator_t0:
 operator_t: Sz
 
 final_time: 1
-
-addJW: False  # default (no JW string needed (spin-model))
 
 algorithm_class: TEBDEngine
 algorithm_params:

--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -719,8 +719,8 @@ class Simulation:
         results = {}
         psi, model = self.get_measurement_psi_model(self.psi, self.model)
 
-        try: 
-            #
+        returned = []  # make sure list exists if try-clause fails
+        try:
             returned = self.measurement_event.emit(results=results,
                                                    psi=psi,
                                                    model=model,
@@ -728,7 +728,7 @@ class Simulation:
             # we safe-guard the measurements with try-except 
             # to avoid that mistakes in the measurement cause us to loose all our data, 
             # e.g. if we were running DMRG for days, and just have a stupid typo in a measurement function
-        except Exception as e:
+        except Exception:
             err_traceback = traceback.format_exc()
             self.errors_during_run.append(("measurement", "?", "?", err_traceback))
             max_errs = self.max_errors_before_abort
@@ -736,8 +736,7 @@ class Simulation:
                 tracebacks = [f"Error during {step} of {module_name} {module_func}\n{err_traceback}"
                         for (step, module_name, module_func, err_traceback) in self.errors_during_run]
                 raise RuntimeError('\n'.join(["Too many failed measurements \n"] + tracebacks))
-                
-            
+
         # check for returned values, although there shouldn't be any
         returned = [entry for entry in returned if entry is not None]
         if len(returned) > 0:


### PR DESCRIPTION
Safeguarding measurements in Simulations should now work as intended, since the `returned` list exists now also outside of the try-clause.
Furthermore dropping the config option `addJW` in the `example/minimal_SpectralSimulation.yml` after merging  #293