### PR TITLE
allow !py_eval python snippets when loading yaml files

### DIFF
--- a/doc/commandline-help.txt
+++ b/doc/commandline-help.txt
@@ -6,8 +6,10 @@ Command line interface to run a TeNPy simulation.
 
 positional arguments:
     parameters_file
-        Yaml (*.yml) file with the simulation parameters/options. Multiple files get merged
-        according to MERGE; see tenpy.tools.misc.merge_recursive for details.
+        Yaml (*.yml) file with the simulation parameters/options. We support an additional yaml
+        tag !py_eval: VALUE that gets initialized by python's ``eval(VALUE)`` with `np`, `scipy`
+        and `tenpy` defined. Multiple files get merged according to MERGE; see
+        tenpy.tools.misc.merge_recursive for details.
 
 options:
     -h, --help

--- a/doc/intro/options.rst
+++ b/doc/intro/options.rst
@@ -36,3 +36,22 @@ simulation, e.g., in the `sim_params` of the `results` returned by :meth:`~tenpy
 
     If you add extra options to your configuration that TeNPy doesn't read out by the end of the simulation, it will (usually) issue a warning.
     Getting such a warnings is an indicator for a typo in your configuration, or an option being in the wrong config dictionary.
+
+
+Python snippets in yaml files
+-----------------------------
+When defining the paremeters in the yaml file, you might want to evaluate small formulas e.g., set a parameter to a certain fraction of $\pi$,
+or expanding a long list ``[2**i for in range(5, 10)]`` without explicitly writing all the entries.
+For those cases, it can be convenient to have small python snippets inside the yaml file, which we allow by loading the
+yaml files with :func:`tenpy.tools.params.load_yaml_with_py_eval`.
+
+It defines an ``!py_eval`` yaml tag, which should be followed by a string of python code to be evaluated with python's ``eval()`` function.
+A good method to pass the python code is to use a literal string in yaml, as shown in the simple examples below.
+
+.. code :: yaml
+
+    a: !py_eval |
+        2**np.arange(6, 10)
+    b: !py_eval |
+        [10, 15] + list(range(20, 31, 2)) + [35, 40]
+    c: !py_eval "2*np.pi * 0.3"

--- a/doc/intro/simulations.rst
+++ b/doc/intro/simulations.rst
@@ -27,7 +27,7 @@ Of course, you can also directly run the simulation from inside python, the comm
     import tenpy
     import yaml
 
-    simulation_params = yaml.load("parameters.yml")
+    simulation_params = tenpy.load_yaml_with_py_eval("parameters.yml")
     # instead of using yaml, you can also define a usual python dictionary
     tenpy.run_simulation(**simulation_params)
 
@@ -86,8 +86,9 @@ returned by the simulation (or saved to file):
     from pprint import pprint
     import yaml
 
-    with open('parameters.yml', 'r') as f:
-        simulation_parameters = yaml.safe_load(f)
+    with open('parameters.yml', 'r') as stream:
+        simulation_parameters = yaml.safe_load(stream)
+    # alternative: simulation_parameters = tenpy.load_yaml_with_py_eval('parameters.yml')
     results = tenpy.run_simulation(simulation_parameters)
     pprint(results['simulation_parameters'])
 

--- a/tenpy/tools/params.py
+++ b/tenpy/tools/params.py
@@ -5,6 +5,7 @@ See the doc-string of :class:`Config` for details.
 # Copyright (C) TeNPy Developers, GNU GPLv3
 
 import warnings
+import numpy
 import numpy as np
 from collections.abc import MutableMapping
 import pprint
@@ -94,6 +95,8 @@ class Config(MutableMapping):
     def from_yaml(cls, filename, name=None):
         """Load a `Config` instance from a YAML file containing the :attr:`options`.
 
+        The yaml file can have additional ``!py_eval`` tags, see :func:`load_yaml_with_py_eval`.
+
         .. warning ::
             Like pickle, it is not safe to load a yaml file from an untrusted source! A malicious
             file can call any Python function and should thus be treated with extreme caution.
@@ -113,9 +116,7 @@ class Config(MutableMapping):
         """
         if name is None:
             name = os.path.basename(filename)
-        import yaml
-        with open(filename, 'r') as stream:
-            config = yaml.safe_load(stream)
+        config = load_yaml_with_py_eval(filename)
         return cls(config, name)
 
     def save_hdf5(self, hdf5_saver, h5gr, subpath):
@@ -423,3 +424,79 @@ def asConfig(config, name):
     if isinstance(config, Config):
         return config
     return Config(config, name)
+
+
+
+def _yaml_eval_construcor(loader, node):
+    """Yaml constructor to support `!py_eval` tag in yaml files."""
+    cmd = loader.construct_scalar(node)
+    if not isinstance(cmd, str):
+        raise ValueError("expect string argument to `!py_eval`")
+    try:
+        res = eval(cmd, loader.eval_context)
+    except:
+        print("\nError while yaml parsing the following !py_eval command:\n", cmd, "\n")
+        raise
+    return res
+
+
+try:
+    import yaml
+except ImportError:
+    pass
+else: # no ImportError
+    class YamlLoaderWithPyEval(yaml.FullLoader):
+        eval_context = {}
+
+    yaml.add_constructor("!py_eval", _yaml_eval_construcor, Loader=YamlLoaderWithPyEval)
+
+
+def load_yaml_with_py_eval(filename, context={'np': numpy}):
+    """Load a yaml file with support for an additional `!py_eval` tag.
+
+    When defining yaml parameter files, it's sometimes convenient to just have python snippets
+    in there, e.g. to get fractions of pi or expand last lists.
+
+    This function loads a yaml file supporting such (short) python snippets
+    that get evaluated by python's ``eval(snippet)``.
+
+    It expects one string of python code following the ``!py_eval`` tag.
+    The most reliable method to pass the python code is to use a literal
+    string in yaml, as shown in the example below.
+
+    .. code :: yaml
+
+        a: !py_eval |
+            2**np.arange(6, 10)
+        b: !py_eval |
+            [10, 15] + list(range(20, 31, 2)) + [35, 40]
+        c: !py_eval "2*np.pi * 0.3"
+
+    Note that a subsequent ``yaml.dump()`` might contain ugly parts if you construct
+    generic python objects, e.g., a numpy array scalar like ``np.arange(10)[0]``.
+    If you want to avoid this, you can explicitly convert back to lists before.
+
+
+    .. warning ::
+
+        Like pickle, it is not safe to load a yaml file from an untrusted source! A malicious
+        file can call any Python function and should thus be treated with extreme caution.
+
+    Parameters
+    ----------
+    filename : str
+        Filename of the file to load.
+    context : dict
+        The context of ``globals()`` passed to `eval`.
+
+    Returns
+    -------
+    config :
+        Data (typically nested dictionary) as defined in the yaml file.
+
+    """
+    YamlLoaderWithPyEval.eval_context = context
+
+    with open(filename, 'r') as stream:
+        config = yaml.load(stream, Loader=YamlLoaderWithPyEval)
+    return config


### PR DESCRIPTION
This allows to evaluate python snippets in yaml files while loading.

- [x] add py_eval tag
- [x] domument in options guides
- [ ] test on a small snippet