### PR TITLE
V2 spaces refactor

### DIFF
--- a/examples/advanced/mpo_exponential_decay.py
+++ b/examples/advanced/mpo_exponential_decay.py
@@ -12,127 +12,127 @@ system in the thermodynamic limit.
 """
 # Copyright (C) TeNPy Developers, GNU GPLv3
 
+raise NotImplementedError
+# import numpy as np
+# import tenpy.linalg.np_conserved as npc
 
-import numpy as np
-import tenpy.linalg.np_conserved as npc
-
-from tenpy.networks.mpo import MPO
-from tenpy.networks.mps import MPS
-from tenpy.networks.site import SpinHalfSite
-from tenpy.models.model import MPOModel
-from tenpy.models.lattice import Chain
-from tenpy.algorithms import dmrg
-from tenpy.tools.params import asConfig
-
-
-class ExponentiallyDecayingHeisenberg(MPOModel):
-    r"""Spin-1/2 Heisenberg Chain with exponentially decaying interactions.
-
-    The Hamiltonian reads:
-
-    .. math ::
-
-        H = \sum_i \sum_{j>i} \exp(-\frac{|j-i-1|}{\mathtt{xi}}) (
-                  \mathtt{Jxx}/2 (S^{+}_i S^{-}_j + S^{-}_i S^{+}_j)
-                + \mathtt{Jz} S^z_i S^z_j                        ) \\
-            - \sum_i \mathtt{hz} S^z_i
-
-    All parameters are collected in a single dictionary `model_params`.
-
-    Parameters
-    ----------
-    L : int
-        Length of the chain.
-    Jxx, Jz, hz, xi: float
-        Coupling parameters as defined for the Hamiltonian above.
-    bc_MPS : {'finite' | 'infinte'}
-        MPS boundary conditions.
-    conserve : 'Sz' | 'parity' | None
-        What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
-    sort_charge : bool | None
-        Whether to sort by charges of physical legs.
-        See change comment in :class:`~tenpy.networks.site.Site`.
-    """
-    def __init__(self, model_params):
-        # model parameters
-        model_params = asConfig(model_params, "ExponentiallyDecayingHeisenberg")
-        L = model_params.get('L', 2)
-        xi = model_params.get('xi', 0.5)
-        Jxx = model_params.get('Jxx', 1.)
-        Jz = model_params.get('Jz', 1.5)
-        hz = model_params.get('hz', 0.)
-        conserve = model_params.get('conserve', 'Sz')
-        sort_charge = model_params.get('sort_charge', None)
-        if xi == 0.:
-            g = 0.
-        elif xi == np.inf:
-            g = 1.
-        else:
-            g = np.exp(-1 / (xi))
-
-        # Define the sites and the lattice, which in this case is a simple uniform chain
-        # of spin 1/2 sites
-        site = SpinHalfSite(conserve=conserve, sort_charge=sort_charge)
-        lat = Chain(L, site, bc_MPS='infinite', bc='periodic')
-
-        # The operators that appear in the Hamiltonian. Standard spin operators are
-        # already defined for the spin 1/2 site, but it is also possible to add new
-        # operators using the add_op method
-        Sz, Sp, Sm, Id = site.Sz, site.Sp, site.Sm, site.Id
-
-        # yapf:disable
-        # The grid (list of lists) that defines the MPO. It is possible to define the
-        # operators in the grid in the following ways:
-        # 1) NPC arrays, defined above:
-        grid = [[Id,   Sp,   Sm,   Sz,   -hz*Sz    ],
-                [None, g*Id, None, None, 0.5*Jxx*Sm],
-                [None, None, g*Id, None, 0.5*Jxx*Sp],
-                [None, None, None, g*Id, Jz*Sz     ],
-                [None, None, None, None, Id        ]]
-        # 2) In the form [("OpName", strength)], where "OpName" is the name of the
-        # operator (e.g. "Sm" for Sm) and "strength" is a number that multiplies it.
-        grid = [[[("Id", 1)], [("Sp",1)], [("Sm",1)], [("Sz",1)], [("Sz", -hz)]    ],
-                [None       , [("Id",g)], None      , None      , [("Sm", 0.5*Jxx)]],
-                [None       , None      , [("Id",g)], None      , [("Sp", 0.5*Jxx)]],
-                [None       , None      , None      , [("Id",g)], [("Sz",Jz)]      ],
-                [None       , None      , None      , None      , [("Id",1)]       ]]
-        # 3) It is also possible to write a single "OpName", equivalent to
-        # [("OpName", 1)].
-        grid = [["Id"       , "Sp"      , "Sm"      , "Sz"      , [("Sz", -hz)]    ],
-                [None       , [("Id",g)], None      , None      , [("Sm", 0.5*Jxx)]],
-                [None       , None      , [("Id",g)], None      , [("Sp", 0.5*Jxx)]],
-                [None       , None      , None      , [("Id",g)], [("Sz",Jz)]      ],
-                [None       , None      , None      , None      , "Id"             ]]
-        # yapf:enable
-        grids = [grid] * L
-
-        # Generate the MPO from the grid. Note that it is not necessary to specify
-        # the physical legs and their charges, since the from_grids method can extract
-        # this information from the position of the operators inside the grid.
-        H = MPO.from_grids(lat.mps_sites(), grids, bc='infinite', IdL=0, IdR=-1)
-        MPOModel.__init__(self, lat, H)
+# from tenpy.networks.mpo import MPO
+# from tenpy.networks.mps import MPS
+# from tenpy.networks.site import SpinHalfSite
+# from tenpy.models.model import MPOModel
+# from tenpy.models.lattice import Chain
+# from tenpy.algorithms import dmrg
+# from tenpy.tools.params import asConfig
 
 
-def example_run_dmrg():
-    """Use iDMRG to extract information about the ground state of the system."""
-    model_params = dict(L=2, Jxx=1, Jz=1.5, xi=0.8)
-    model = ExponentiallyDecayingHeisenberg(model_params)
-    psi = MPS.from_product_state(model.lat.mps_sites(), ["up", "down"], bc='infinite')
-    dmrg_params = {
-        'mixer': True,
-        'chi_list': {
-            0: 100
-        },
-        'trunc_params': {
-            'svd_min': 1.e-10
-        },
-    }
-    results = dmrg.run(psi, model, dmrg_params)
-    print("Energy per site: ", results['E'])
-    print("<Sz>: ", psi.expectation_value('Sz'))
+# class ExponentiallyDecayingHeisenberg(MPOModel):
+#     r"""Spin-1/2 Heisenberg Chain with exponentially decaying interactions.
+
+#     The Hamiltonian reads:
+
+#     .. math ::
+
+#         H = \sum_i \sum_{j>i} \exp(-\frac{|j-i-1|}{\mathtt{xi}}) (
+#                   \mathtt{Jxx}/2 (S^{+}_i S^{-}_j + S^{-}_i S^{+}_j)
+#                 + \mathtt{Jz} S^z_i S^z_j                        ) \\
+#             - \sum_i \mathtt{hz} S^z_i
+
+#     All parameters are collected in a single dictionary `model_params`.
+
+#     Parameters
+#     ----------
+#     L : int
+#         Length of the chain.
+#     Jxx, Jz, hz, xi: float
+#         Coupling parameters as defined for the Hamiltonian above.
+#     bc_MPS : {'finite' | 'infinte'}
+#         MPS boundary conditions.
+#     conserve : 'Sz' | 'parity' | None
+#         What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
+#     sort_charge : bool | None
+#         Whether to sort by charges of physical legs.
+#         See change comment in :class:`~tenpy.networks.site.Site`.
+#     """
+#     def __init__(self, model_params):
+#         # model parameters
+#         model_params = asConfig(model_params, "ExponentiallyDecayingHeisenberg")
+#         L = model_params.get('L', 2)
+#         xi = model_params.get('xi', 0.5)
+#         Jxx = model_params.get('Jxx', 1.)
+#         Jz = model_params.get('Jz', 1.5)
+#         hz = model_params.get('hz', 0.)
+#         conserve = model_params.get('conserve', 'Sz')
+#         sort_charge = model_params.get('sort_charge', None)
+#         if xi == 0.:
+#             g = 0.
+#         elif xi == np.inf:
+#             g = 1.
+#         else:
+#             g = np.exp(-1 / (xi))
+
+#         # Define the sites and the lattice, which in this case is a simple uniform chain
+#         # of spin 1/2 sites
+#         site = SpinHalfSite(conserve=conserve, sort_charge=sort_charge)
+#         lat = Chain(L, site, bc_MPS='infinite', bc='periodic')
+
+#         # The operators that appear in the Hamiltonian. Standard spin operators are
+#         # already defined for the spin 1/2 site, but it is also possible to add new
+#         # operators using the add_op method
+#         Sz, Sp, Sm, Id = site.Sz, site.Sp, site.Sm, site.Id
+
+#         # yapf:disable
+#         # The grid (list of lists) that defines the MPO. It is possible to define the
+#         # operators in the grid in the following ways:
+#         # 1) NPC arrays, defined above:
+#         grid = [[Id,   Sp,   Sm,   Sz,   -hz*Sz    ],
+#                 [None, g*Id, None, None, 0.5*Jxx*Sm],
+#                 [None, None, g*Id, None, 0.5*Jxx*Sp],
+#                 [None, None, None, g*Id, Jz*Sz     ],
+#                 [None, None, None, None, Id        ]]
+#         # 2) In the form [("OpName", strength)], where "OpName" is the name of the
+#         # operator (e.g. "Sm" for Sm) and "strength" is a number that multiplies it.
+#         grid = [[[("Id", 1)], [("Sp",1)], [("Sm",1)], [("Sz",1)], [("Sz", -hz)]    ],
+#                 [None       , [("Id",g)], None      , None      , [("Sm", 0.5*Jxx)]],
+#                 [None       , None      , [("Id",g)], None      , [("Sp", 0.5*Jxx)]],
+#                 [None       , None      , None      , [("Id",g)], [("Sz",Jz)]      ],
+#                 [None       , None      , None      , None      , [("Id",1)]       ]]
+#         # 3) It is also possible to write a single "OpName", equivalent to
+#         # [("OpName", 1)].
+#         grid = [["Id"       , "Sp"      , "Sm"      , "Sz"      , [("Sz", -hz)]    ],
+#                 [None       , [("Id",g)], None      , None      , [("Sm", 0.5*Jxx)]],
+#                 [None       , None      , [("Id",g)], None      , [("Sp", 0.5*Jxx)]],
+#                 [None       , None      , None      , [("Id",g)], [("Sz",Jz)]      ],
+#                 [None       , None      , None      , None      , "Id"             ]]
+#         # yapf:enable
+#         grids = [grid] * L
+
+#         # Generate the MPO from the grid. Note that it is not necessary to specify
+#         # the physical legs and their charges, since the from_grids method can extract
+#         # this information from the position of the operators inside the grid.
+#         H = MPO.from_grids(lat.mps_sites(), grids, bc='infinite', IdL=0, IdR=-1)
+#         MPOModel.__init__(self, lat, H)
 
 
-if __name__ == "__main__":
-    import logging
-    logging.basicConfig(level=logging.INFO)
-    example_run_dmrg()
+# def example_run_dmrg():
+#     """Use iDMRG to extract information about the ground state of the system."""
+#     model_params = dict(L=2, Jxx=1, Jz=1.5, xi=0.8)
+#     model = ExponentiallyDecayingHeisenberg(model_params)
+#     psi = MPS.from_product_state(model.lat.mps_sites(), ["up", "down"], bc='infinite')
+#     dmrg_params = {
+#         'mixer': True,
+#         'chi_list': {
+#             0: 100
+#         },
+#         'trunc_params': {
+#             'svd_min': 1.e-10
+#         },
+#     }
+#     results = dmrg.run(psi, model, dmrg_params)
+#     print("Energy per site: ", results['E'])
+#     print("<Sz>: ", psi.expectation_value('Sz'))
+
+
+# if __name__ == "__main__":
+#     import logging
+#     logging.basicConfig(level=logging.INFO)
+#     example_run_dmrg()

--- a/examples/e_tdvp.py
+++ b/examples/e_tdvp.py
@@ -5,90 +5,93 @@ difference is that we can run one-site TDVP or two-site TDVP. In the former, the
 not grow; the latter allows to grow the bond dimension and hence requires a truncation.
 """
 # Copyright (C) TeNPy Developers, GNU GPLv3
-import numpy as np
-import tenpy.linalg.np_conserved as npc
-import tenpy
-from tenpy.networks import mps
-from tenpy.networks import site
-from tenpy.algorithms import tdvp
-from tenpy.networks.mps import MPS
+
+raise NotImplementedError
+
+# import numpy as np
+# import tenpy.linalg.np_conserved as npc
+# import tenpy
+# from tenpy.networks import mps
+# from tenpy.networks import site
+# from tenpy.algorithms import tdvp
+# from tenpy.networks.mps import MPS
 
 
-def example_TDVP():
-    L = 14
-    chi = 20  # exemplary strong truncation!
-    delta_t = 0.1
-    model_params = {
-        'L': L,
-        'S': 0.5,
-        'conserve': 'Sz',
-        'Jz': 1.0,
-        'Jy': 1.0,
-        'Jx': 1.0,
-        'hx': 0.0,
-        'hy': 0.0,
-        'hz': 0.0,
-        'muJ': 0.0,
-        'bc_MPS': 'finite',
-    }
+# def example_TDVP():
+#     L = 14
+#     chi = 20  # exemplary strong truncation!
+#     delta_t = 0.1
+#     model_params = {
+#         'L': L,
+#         'S': 0.5,
+#         'conserve': 'Sz',
+#         'Jz': 1.0,
+#         'Jy': 1.0,
+#         'Jx': 1.0,
+#         'hx': 0.0,
+#         'hy': 0.0,
+#         'hz': 0.0,
+#         'muJ': 0.0,
+#         'bc_MPS': 'finite',
+#     }
 
-    heisenberg = tenpy.models.spins.SpinChain(model_params)
-    product_state = ["up", "down"] * (L // 2)
-    # starting from a Neel product state which is not an eigenstate of the Heisenberg model
-    psi = MPS.from_product_state(heisenberg.lat.mps_sites(),
-                                 product_state,
-                                 bc=heisenberg.lat.bc_MPS,
-                                 form='B')
+#     heisenberg = tenpy.models.spins.SpinChain(model_params)
+#     product_state = ["up", "down"] * (L // 2)
+#     # starting from a Neel product state which is not an eigenstate of the Heisenberg model
+#     psi = MPS.from_product_state(heisenberg.lat.mps_sites(),
+#                                  product_state,
+#                                  bc=heisenberg.lat.bc_MPS,
+#                                  form='B')
 
-    tdvp_params = {
-        'start_time': 0,
-        'dt': delta_t,
-        'N_steps': 1,
-        'trunc_params': {
-            'chi_max': chi,
-            'svd_min': 1.e-10,
-            'trunc_cut': None
-        }
-    }
-    tdvp_engine = tdvp.TwoSiteTDVPEngine(psi, heisenberg, tdvp_params)
-    times = []
-    S_mid = []
-    Es = []
-    def measure():
-        times.append(tdvp_engine.evolved_time)
-        S_mid.append(psi.entanglement_entropy(bonds=[L // 2])[0])
-        Es.append(heisenberg.H_MPO.expectation_value(psi))
+#     tdvp_params = {
+#         'start_time': 0,
+#         'dt': delta_t,
+#         'N_steps': 1,
+#         'trunc_params': {
+#             'chi_max': chi,
+#             'svd_min': 1.e-10,
+#             'trunc_cut': None
+#         }
+#     }
+#     tdvp_engine = tdvp.TwoSiteTDVPEngine(psi, heisenberg, tdvp_params)
+#     times = []
+#     S_mid = []
+#     Es = []
+#     def measure():
+#         times.append(tdvp_engine.evolved_time)
+#         S_mid.append(psi.entanglement_entropy(bonds=[L // 2])[0])
+#         Es.append(heisenberg.H_MPO.expectation_value(psi))
 
-    measure()
-    for i in range(30):
-        tdvp_engine.run()
-        measure()
+#     measure()
+#     for i in range(30):
+#         tdvp_engine.run()
+#         measure()
 
-    tdvp_engine = tdvp.SingleSiteTDVPEngine.switch_engine(tdvp_engine)
-    for i in range(30):
-        tdvp_engine.run()
-        measure()
+#     tdvp_engine = tdvp.SingleSiteTDVPEngine.switch_engine(tdvp_engine)
+#     for i in range(30):
+#         tdvp_engine.run()
+#         measure()
 
-    return times, S_mid, Es
-
-
-def plot_example_TDVP(times, S_mid, Es):
-    import matplotlib.pyplot as plt
-    fig, axes = plt.subplots(2, 1, sharex=True, figsize=(7,7))
-    axes[0].plot(times, S_mid)
-    axes[0].set_ylabel('entroy $S$ at center bond')
-    axes[1].plot(times, np.array(Es) - Es[0])
-    axes[1].set_ylabel('energy $E - E(t=0)$')
-    axes[1].set_xlabel('time $t$')
-    for ax in axes:
-        ax.axvline(x=3.01, color='red')
-    axes[0].text(2.9, 0.0000015, "Two-site update", ha='right')
-    axes[0].text(3.1, 0.0000015, "One-site update, strict TDVP")
-    plt.show()
+#     return times, S_mid, Es
 
 
-if __name__ == "__main__":
-    import logging
-    logging.basicConfig(level=logging.INFO)
-    measure = example_TDVP()
-    plot_example_TDVP(*measure)
+# def plot_example_TDVP(times, S_mid, Es):
+#     import matplotlib.pyplot as plt
+#     fig, axes = plt.subplots(2, 1, sharex=True, figsize=(7,7))
+#     axes[0].plot(times, S_mid)
+#     axes[0].set_ylabel('entroy $S$ at center bond')
+#     axes[1].plot(times, np.array(Es) - Es[0])
+#     axes[1].set_ylabel('energy $E - E(t=0)$')
+#     axes[1].set_xlabel('time $t$')
+#     for ax in axes:
+#         ax.axvline(x=3.01, color='red')
+#     axes[0].text(2.9, 0.0000015, "Two-site update", ha='right')
+#     axes[0].text(3.1, 0.0000015, "One-site update, strict TDVP")
+#     plt.show()
+
+
+# if __name__ == "__main__":
+#     import logging
+#     logging.basicConfig(level=logging.INFO)
+#     measure = example_TDVP()
+#     plot_example_TDVP(*measure)

--- a/examples/model_custom.py
+++ b/examples/model_custom.py
@@ -1,68 +1,67 @@
 """This file ``/examples/model_custom.py`` illustrates customization code for simulations.
 
-Put this file somewhere where it can be importet by python, i.e. either in the working directory
+Put this file somewhere where it can be imported by python, i.e. either in the working directory
 or somewhere in the ``PYTHON_PATH``. Then you can use it with the parameters file
 ``/examples/model_custom.yml`` from the terminal like this::
 
     tenpy-run -i model_custom simulation_custom.yml
 """
 
-import tenpy
-from tenpy.networks.site import SpinSite
-from tenpy.networks.mps import TransferMatrix
-from tenpy.models.model import CouplingMPOModel, NearestNeighborModel
-from tenpy.models.lattice import Chain
-from tenpy.linalg import np_conserved as npc
-import numpy as np
+# from tenpy.networks.site import SpinSite
+# from tenpy.networks.mps import TransferMatrix
+# from tenpy.models.model import CouplingMPOModel, NearestNeighborModel
+# from tenpy.models.lattice import Chain
+# from tenpy.linalg import np_conserved as npc
+# import numpy as np
 
 
-class AnisotropicSpin1Chain(CouplingMPOModel, NearestNeighborModel):
-    r"""An example for a custom model, implementing the Hamiltonian of :arxiv:`1204.0704`.
+# class AnisotropicSpin1Chain(CouplingMPOModel, NearestNeighborModel):
+#     r"""An example for a custom model, implementing the Hamiltonian of :arxiv:`1204.0704`.
 
-    .. math ::
-        H = J \sum_i \vec{S}_i \cdot \vec{S}_{i+1} + B \sum_i S^x_i + D \sum_i (S^z_i)^2
-    """
-    default_lattice = Chain
-    force_default_lattice = True
+#     .. math ::
+#         H = J \sum_i \vec{S}_i \cdot \vec{S}_{i+1} + B \sum_i S^x_i + D \sum_i (S^z_i)^2
+#     """
+#     default_lattice = Chain
+#     force_default_lattice = True
 
-    def init_sites(self, model_params):
-        B = model_params.get('B', 0.)
-        conserve = model_params.get('conserve', 'best')
-        if conserve == 'best':
-            conserve = 'Sz' if not model_params.any_nonzero(['B']) else None
-            self.logger.info("%s: set conserve to %s", self.name, conserve)
-        sort_charge = model_params.get('sort_charge', True)
-        return SpinSite(S=1., conserve=None, sort_charge=sort_charge)
+#     def init_sites(self, model_params):
+#         B = model_params.get('B', 0.)
+#         conserve = model_params.get('conserve', 'best')
+#         if conserve == 'best':
+#             conserve = 'Sz' if not model_params.any_nonzero(['B']) else None
+#             self.logger.info("%s: set conserve to %s", self.name, conserve)
+#         sort_charge = model_params.get('sort_charge', True)
+#         return SpinSite(S=1., conserve=None, sort_charge=sort_charge)
 
-    def init_terms(self, model_params):
-        J = model_params.get('J', 1.)
-        B = model_params.get('B', 0.)
-        D = model_params.get('D', 0.)
+#     def init_terms(self, model_params):
+#         J = model_params.get('J', 1.)
+#         B = model_params.get('B', 0.)
+#         D = model_params.get('D', 0.)
 
-        for u1, u2, dx in self.lat.pairs['nearest_neighbors']:
-            self.add_coupling(J / 2., u1, 'Sp', u2, 'Sm', dx, plus_hc=True)
-            self.add_coupling(J, u1, 'Sz', u2, 'Sz', dx)
+#         for u1, u2, dx in self.lat.pairs['nearest_neighbors']:
+#             self.add_coupling(J / 2., u1, 'Sp', u2, 'Sm', dx, plus_hc=True)
+#             self.add_coupling(J, u1, 'Sz', u2, 'Sz', dx)
 
-        for u in range(len(self.lat.unit_cell)):
-            self.add_onsite(B, u, 'Sx')
-            self.add_onsite(D, u, 'Sz Sz')
+#         for u in range(len(self.lat.unit_cell)):
+#             self.add_onsite(B, u, 'Sx')
+#             self.add_onsite(D, u, 'Sz Sz')
 
 
-def m_pollmann_turner_inversion(results, psi, model, simulation, tol=0.01):
-    """Measurement function for equation 15 of :arxiv:`1204.0704`.
+# def m_pollmann_turner_inversion(results, psi, model, simulation, tol=0.01):
+#     """Measurement function for equation 15 of :arxiv:`1204.0704`.
 
-    See :func:`~tenpy.simulations.measurement.measurement_index` for the call structure.
-    """
-    psi2 = psi.copy()
-    psi2.spatial_inversion()
-    mixed_TM = TransferMatrix(psi, psi2, transpose=False, charge_sector=0, form='B')
-    evals, evecs = mixed_TM.eigenvectors(which='LM', num_ev=1)
-    results['pollmann_turner_inversion_eta'] = eta = evals[0]
-    U_I = evecs[0].split_legs().transpose().conj()
-    U_I *= np.sqrt(U_I.shape[0])  # previously normalized to npc.norm(U_I) = 1, need unitary
-    results['pollmann_turner_inversion_U_I'] = U_I
-    if abs(eta) < 1. - tol:
-        O_I = 0.
-    else:
-        O_I = npc.inner(U_I, U_I.conj(), axes=[[0, 1], [1, 0]]) / U_I.shape[0]
-    results['pollmann_turner_inversion'] = O_I
+#     See :func:`~tenpy.simulations.measurement.measurement_index` for the call structure.
+#     """
+#     psi2 = psi.copy()
+#     psi2.spatial_inversion()
+#     mixed_TM = TransferMatrix(psi, psi2, transpose=False, charge_sector=0, form='B')
+#     evals, evecs = mixed_TM.eigenvectors(which='LM', num_ev=1)
+#     results['pollmann_turner_inversion_eta'] = eta = evals[0]
+#     U_I = evecs[0].split_legs().transpose().conj()
+#     U_I *= np.sqrt(U_I.shape[0])  # previously normalized to npc.norm(U_I) = 1, need unitary
+#     results['pollmann_turner_inversion_U_I'] = U_I
+#     if abs(eta) < 1. - tol:
+#         O_I = 0.
+#     else:
+#         O_I = npc.inner(U_I, U_I.conj(), axes=[[0, 1], [1, 0]]) / U_I.shape[0]
+#     results['pollmann_turner_inversion'] = O_I

--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,1104 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
+rootdir: /Users/jakobunfried/tenpy/v2_development
+configfile: pyproject.toml
+testpaths: tests
+collected 262 items / 244 deselected / 4 skipped / 18 selected
+
+tests/linalg/test_spaces.py ......                                       [ 33%]
+tests/linalg/test_tensors.py ............                                [100%]
+
+==================================== PASSES ====================================
+____________________________ test_str_repr[NoSymm] _____________________________
+----------------------------- Captured stdout call -----------------------------
+----------------------
+ElementarySpace.__repr__()
+----------------------
+ElementarySpace(
+  NoSymmetry(),
+  sectors=[0],
+  multiplicities=[3],
+  basis_perm=[2, 0, 1],
+  is_dual=False,
+)
+
+
+----------------------
+ElementarySpace.__str__() 
+----------------------
+ElementarySpace(
+  NoSymmetry(),
+  sectors=[0],
+  multiplicities=[3],
+  basis_perm=[2, 0, 1],
+  is_dual=False,
+)
+
+
+-----------------------
+ProductSpace.__repr__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=NoSymmetry(),
+  ElementarySpace(
+    sectors=[0],
+    multiplicities=[4],
+    basis_perm=[0, 2, 3, 1],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[0],
+    multiplicities=[4],
+    basis_perm=[0, 3, 2, 1],
+    is_dual=True,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__str__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=NoSymmetry(),
+  ElementarySpace(
+    sectors=[0],
+    multiplicities=[4],
+    basis_perm=[0, 2, 3, 1],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[0],
+    multiplicities=[4],
+    basis_perm=[0, 3, 2, 1],
+    is_dual=True,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__repr__()  3 spaces
+-----------------------
+<ProductSpace symmetry=NoSymmetry() 3 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  3 spaces
+-----------------------
+<ProductSpace symmetry=NoSymmetry() 3 spaces >
+
+
+-----------------------
+ProductSpace.__repr__()  4 spaces
+-----------------------
+<ProductSpace symmetry=NoSymmetry() 4 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  4 spaces
+-----------------------
+<ProductSpace symmetry=NoSymmetry() 4 spaces >
+______________________________ test_str_repr[U1] _______________________________
+----------------------------- Captured stdout call -----------------------------
+----------------------
+ElementarySpace.__repr__()
+----------------------
+<ElementarySpace: U(1) 14 sectors basis_perm=[...] is_dual=True >
+
+
+----------------------
+ElementarySpace.__str__() 
+----------------------
+<ElementarySpace: U(1) 14 sectors basis_perm=[...] is_dual=True >
+
+
+-----------------------
+ProductSpace.__repr__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=U1Symmetry(),
+  ElementarySpace(
+    sectors=[-1, 2],
+    multiplicities=[4, 3],
+    basis_perm=[4, 0, 3, 6, 5, 2, 1],
+    is_dual=True,
+  ),
+  ElementarySpace(
+    sectors=[-123],
+    multiplicities=[4],
+    basis_perm=[2, 1, 3, 0],
+    is_dual=True,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__str__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=U1Symmetry(),
+  ElementarySpace(
+    sectors=[-1, 2],
+    multiplicities=[4, 3],
+    basis_perm=[4, 0, 3, 6, 5, 2, 1],
+    is_dual=True,
+  ),
+  ElementarySpace(
+    sectors=[-123],
+    multiplicities=[4],
+    basis_perm=[2, 1, 3, 0],
+    is_dual=True,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__repr__()  3 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() 3 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  3 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() 3 spaces >
+
+
+-----------------------
+ProductSpace.__repr__()  4 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() 4 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  4 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() 4 spaces >
+______________________________ test_str_repr[Z2] _______________________________
+----------------------------- Captured stdout call -----------------------------
+----------------------
+ElementarySpace.__repr__()
+----------------------
+ElementarySpace(
+  ZNSymmetry(2),
+  sectors=[0, 1],
+  multiplicities=[5, 3],
+  basis_perm=None,
+  is_dual=False,
+)
+
+
+----------------------
+ElementarySpace.__str__() 
+----------------------
+ElementarySpace(
+  ZNSymmetry(2),
+  sectors=[0, 1],
+  multiplicities=[5, 3],
+  basis_perm=None,
+  is_dual=False,
+)
+
+
+-----------------------
+ProductSpace.__repr__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=ZNSymmetry(2),
+  ElementarySpace(
+    sectors=[0, 1],
+    multiplicities=[5, 3],
+    basis_perm=[0, 2, 6, 3, 1, 5, 4, 7],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[0, 1],
+    multiplicities=[2, 3],
+    basis_perm=None,
+    is_dual=False,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__str__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=ZNSymmetry(2),
+  ElementarySpace(
+    sectors=[0, 1],
+    multiplicities=[5, 3],
+    basis_perm=[0, 2, 6, 3, 1, 5, 4, 7],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[0, 1],
+    multiplicities=[2, 3],
+    basis_perm=None,
+    is_dual=False,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__repr__()  3 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(2) 3 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  3 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(2) 3 spaces >
+
+
+-----------------------
+ProductSpace.__repr__()  4 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(2) 4 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  4 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(2) 4 spaces >
+___________________________ test_str_repr[Z4_named] ____________________________
+----------------------------- Captured stdout call -----------------------------
+----------------------
+ElementarySpace.__repr__()
+----------------------
+ElementarySpace(
+  ZNSymmetry(4, "My_Z4_symmetry"),
+  sectors=[0, 1, 2, 3],
+  multiplicities=[2, 4, 4, 4],
+  basis_perm=[8, 0, 4, 1, 7, 3, 13, 9, 5, 12, 6, 2, 10, 11],
+  is_dual=True,
+)
+
+
+----------------------
+ElementarySpace.__str__() 
+----------------------
+ElementarySpace(
+  ZNSymmetry(4, "My_Z4_symmetry"),
+  sectors=[0, 1, 2, 3],
+  multiplicities=[2, 4, 4, 4],
+  basis_perm=[8, 0, 4, 1, 7, 3, 13, 9, 5, 12, 6, 2, 10, 11],
+  is_dual=True,
+)
+
+
+-----------------------
+ProductSpace.__repr__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=ZNSymmetry(4, "My_Z4_symmetry"),
+  ElementarySpace(
+    sectors=[0, 2, 3],
+    multiplicities=[1, 2, 1],
+    basis_perm=[0, 2, 3, 1],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[1],
+    multiplicities=[3],
+    basis_perm=[2, 0, 1],
+    is_dual=False,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__str__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=ZNSymmetry(4, "My_Z4_symmetry"),
+  ElementarySpace(
+    sectors=[0, 2, 3],
+    multiplicities=[1, 2, 1],
+    basis_perm=[0, 2, 3, 1],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[1],
+    multiplicities=[3],
+    basis_perm=[2, 0, 1],
+    is_dual=False,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__repr__()  3 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(4, "My_Z4_symmetry") 3 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  3 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(4, "My_Z4_symmetry") 3 spaces >
+
+
+-----------------------
+ProductSpace.__repr__()  4 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(4, "My_Z4_symmetry") 4 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  4 spaces
+-----------------------
+<ProductSpace symmetry=ZNSymmetry(4, "My_Z4_symmetry") 4 spaces >
+_____________________________ test_str_repr[U1xZ3] _____________________________
+----------------------------- Captured stdout call -----------------------------
+----------------------
+ElementarySpace.__repr__()
+----------------------
+<ElementarySpace: U(1) ⨉ ℤ₃ 14 sectors basis_perm=[...] is_dual=False >
+
+
+----------------------
+ElementarySpace.__str__() 
+----------------------
+<ElementarySpace: U(1) ⨉ ℤ₃ 14 sectors basis_perm=[...] is_dual=False >
+
+
+-----------------------
+ProductSpace.__repr__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=U1Symmetry() * ZNSymmetry(3),
+  ElementarySpace(
+    sectors=[[0, 0], [2, 2]],
+    multiplicities=[3, 4],
+    basis_perm=[2, 0, 4, 5, 1, 3, 6],
+    is_dual=True,
+  ),
+  ElementarySpace(
+    sectors=[[2, 1]],
+    multiplicities=[4],
+    basis_perm=[1, 0, 2, 3],
+    is_dual=True,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__str__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=U1Symmetry() * ZNSymmetry(3),
+  ElementarySpace(
+    sectors=[[0, 0], [2, 2]],
+    multiplicities=[3, 4],
+    basis_perm=[2, 0, 4, 5, 1, 3, 6],
+    is_dual=True,
+  ),
+  ElementarySpace(
+    sectors=[[2, 1]],
+    multiplicities=[4],
+    basis_perm=[1, 0, 2, 3],
+    is_dual=True,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__repr__()  3 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() * ZNSymmetry(3) 3 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  3 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() * ZNSymmetry(3) 3 spaces >
+
+
+-----------------------
+ProductSpace.__repr__()  4 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() * ZNSymmetry(3) 4 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  4 spaces
+-----------------------
+<ProductSpace symmetry=U1Symmetry() * ZNSymmetry(3) 4 spaces >
+______________________________ test_str_repr[SU2] ______________________________
+----------------------------- Captured stdout call -----------------------------
+----------------------
+ElementarySpace.__repr__()
+----------------------
+<ElementarySpace: SU(2) 14 sectors basis_perm=[...] is_dual=False >
+
+
+----------------------
+ElementarySpace.__str__() 
+----------------------
+<ElementarySpace: SU(2) 14 sectors basis_perm=[...] is_dual=False >
+
+
+-----------------------
+ProductSpace.__repr__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=SU2Symmetry(),
+  ElementarySpace(
+    sectors=[0 (J=0), 1 (J=1/2)],
+    multiplicities=[3, 4],
+    basis_perm=[9, 2, 1, 3, 7, 10, 4, 8, 0, 6, 5],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[0 (J=0), 1 (J=1/2)],
+    multiplicities=[4, 5],
+    basis_perm=[4, 8, 3, 6, 11, 10, 2, 0, 13, 12, 1, 7, 5, 9],
+    is_dual=False,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__str__()  2 spaces
+-----------------------
+ProductSpace(
+  symmetry=SU2Symmetry(),
+  ElementarySpace(
+    sectors=[0 (J=0), 1 (J=1/2)],
+    multiplicities=[3, 4],
+    basis_perm=[9, 2, 1, 3, 7, 10, 4, 8, 0, 6, 5],
+    is_dual=False,
+  ),
+  ElementarySpace(
+    sectors=[0 (J=0), 1 (J=1/2)],
+    multiplicities=[4, 5],
+    basis_perm=[4, 8, 3, 6, 11, 10, 2, 0, 13, 12, 1, 7, 5, 9],
+    is_dual=False,
+  ),
+)
+
+
+-----------------------
+ProductSpace.__repr__()  3 spaces
+-----------------------
+<ProductSpace symmetry=SU2Symmetry() 3 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  3 spaces
+-----------------------
+<ProductSpace symmetry=SU2Symmetry() 3 spaces >
+
+
+-----------------------
+ProductSpace.__repr__()  4 spaces
+-----------------------
+<ProductSpace symmetry=SU2Symmetry() 4 spaces >
+
+
+-----------------------
+ProductSpace.__str__()  4 spaces
+-----------------------
+<ProductSpace symmetry=SU2Symmetry() 4 spaces >
+_______________________ test_str_repr[numpy-NoSymmetry] ________________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: NoSymmetryNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (3, 5, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: NoSymmetryNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (3, 5, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: NoSymmetryNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['p', 'p*']
+  * Shape: (5, 5)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: NoSymmetryNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['p', 'p*']
+  * Shape: (5, 5)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+__________________ test_str_repr[numpy-AbelianBackend-NoSymm] __________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (3, 5, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (3, 5, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['p', 'p*']
+  * Shape: (5, 5)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['p', 'p*']
+  * Shape: (5, 5)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+________________ test_str_repr[numpy-FusionTreeBackend-NoSymm] _________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (3, 5, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (3, 5, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['p', 'p*']
+  * Shape: (5, 5)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: no_symmetry
+  * Labels: ['p', 'p*']
+  * Shape: (5, 5)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+____________________ test_str_repr[numpy-AbelianBackend-U1] ____________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 25, 11)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 25, 11)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['p', 'p*']
+  * Shape: (11, 11)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['p', 'p*']
+  * Shape: (11, 11)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+__________________ test_str_repr[numpy-FusionTreeBackend-U1] ___________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 25, 11)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 25, 11)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['p', 'p*']
+  * Shape: (10, 10)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1)
+  * Labels: ['p', 'p*']
+  * Shape: (10, 10)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+____________________ test_str_repr[numpy-AbelianBackend-Z2] ____________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (8, 10, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (8, 10, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['p', 'p*']
+  * Shape: (6, 6)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['p', 'p*']
+  * Shape: (6, 6)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+__________________ test_str_repr[numpy-FusionTreeBackend-Z2] ___________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (8, 10, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (8, 10, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['p', 'p*']
+  * Shape: (6, 6)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₂
+  * Labels: ['p', 'p*']
+  * Shape: (6, 6)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+_________________ test_str_repr[numpy-AbelianBackend-Z4_named] _________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 20, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 20, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['p', 'p*']
+  * Shape: (8, 8)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['p', 'p*']
+  * Shape: (8, 8)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+_______________ test_str_repr[numpy-FusionTreeBackend-Z4_named] ________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 20, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (14, 20, 8)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['p', 'p*']
+  * Shape: (7, 7)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: ℤ₄("My_Z4_symmetry")
+  * Labels: ['p', 'p*']
+  * Shape: (7, 7)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+__________________ test_str_repr[numpy-AbelianBackend-U1xZ3] ___________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (11, 15, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (11, 15, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['p', 'p*']
+  * Shape: (12, 12)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: AbelianNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['p', 'p*']
+  * Shape: (12, 12)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+_________________ test_str_repr[numpy-FusionTreeBackend-U1xZ3] _________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (11, 14, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (11, 14, 4)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['p', 'p*']
+  * Shape: (4, 4)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: U(1) ⨉ ℤ₃
+  * Labels: ['p', 'p*']
+  * Shape: (4, 4)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+__________________ test_str_repr[numpy-FusionTreeBackend-SU2] __________________
+----------------------------- Captured stdout call -----------------------------
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: SU(2)
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (34, 55, 3)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: SU(2)
+  * Labels: ['vL', 'p', 'vR']
+  * Shape: (34, 55, 3)
+  * Domain -> Codomain: ['vR', 'p'] -> ['vL']
+>
+
+
+----------------------
+__repr__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: SU(2)
+  * Labels: ['p', 'p*']
+  * Shape: (61, 61)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+
+
+----------------------
+__str__()
+----------------------
+<SymmetricTensor
+  * Backend: FusionTreeNumpyBackend
+  * Symmetry: SU(2)
+  * Labels: ['p', 'p*']
+  * Shape: (61, 61)
+  * Domain -> Codomain: ['p*'] -> ['p']
+>
+================ 18 passed, 4 skipped, 244 deselected in 0.08s =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 [project.optional-dependencies]
 plot = ["matplotlib"]
 io = ["h5py", "pyyaml"]
-test = ["pytest>=6.0"]
+test = ["pytest>=6.0", "sympy"]
 extra = ["bottleneck", "yapf==0.28.0", "docformatter==1.3.1"]
 docbuild = [
     "Sphinx", 

--- a/tenpy/__init__.py
+++ b/tenpy/__init__.py
@@ -3,7 +3,7 @@
 TeNPy is a library for algorithms working with tensor networks,
 e.g., matrix product states and -operators,
 designed to study the physics of strongly correlated quantum systems.
-The code is intended to be accessible for newcommers
+The code is intended to be accessible for newcomers
 and yet powerful enough for day-to-day research.
 """
 # Copyright (C) TeNPy Developers, GNU GPLv3

--- a/tenpy/__main__.py
+++ b/tenpy/__main__.py
@@ -4,5 +4,4 @@
 import tenpy
 
 if __name__ == "__main__":
-    import sys
     raise SystemExit(tenpy.console_main())

--- a/tenpy/linalg/_su2data.py
+++ b/tenpy/linalg/_su2data.py
@@ -3,8 +3,7 @@
 
 from __future__ import annotations
 import numpy as np
-import typing
-from functools import lru_cache, wraps
+from functools import lru_cache
 
 try:
     from sympy import S as sympy_S

--- a/tenpy/linalg/backends/abelian.py
+++ b/tenpy/linalg/backends/abelian.py
@@ -1663,7 +1663,7 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
             block_inds=np.array([[bi, 0]])
         )
 
-    def inv_part_to_flat_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
         raise NotImplementedError  # TODO not yet reviewed
         # TODO dont use legs! use conventional_leg_order / domain / codomain
         num_blocks = len(tensor.data.blocks)
@@ -1682,7 +1682,7 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
             dim = tensor.legs[0].multiplicities[bi]
             # no need to consider basis_perm, since its all 0 anyway
             return self.zero_block(shape=[dim], dtype=tensor.data.dtype)
-        raise ValueError  # should have been caught by input checks in ChargedTensor.to_flat_block_single_sector
+        raise ValueError  # should have been caught by input checks in ChargedTensor.to_dense_block_single_sector
 
     def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
                          flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:

--- a/tenpy/linalg/backends/abelian.py
+++ b/tenpy/linalg/backends/abelian.py
@@ -220,6 +220,1227 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
             assert self.block_sum_all(block) == small_leg.multiplicities[bi_small]
             assert self.block_dtype(block) == Dtype.bool
 
+    # ABSTRACT METHODS
+
+    def act_block_diagonal_square_matrix(self, a: SymmetricTensor,
+                                         block_method: Callable[[Block], Block]) -> Data:
+        leg = a.domain.spaces[0]
+        a_block_inds = a.data.block_inds
+        all_block_inds = np.repeat(np.arange(leg.num_sectors)[:, None], 2, axis=1)
+        res_blocks = []
+        for i, j in iter_common_noncommon_sorted_arrays(a_block_inds, all_block_inds):
+            if i is None:
+                # use that all_block_inds is just ascending -> all_block_inds[j, 0] == j
+                block = self.zero_block(shape=[leg.multiplicities[j]] * 2, dtype=a.dtype)
+            else:
+                block = a.data.blocks[i]
+            res_blocks.append(block_method(block))
+        dtype = Dtype.common(*(self.block_dtype(block) for block in res_blocks))
+        res_blocks = [self.block_to_dtype(block, dtype) for block in res_blocks]
+        return AbelianBackendData(dtype, res_blocks, all_block_inds, is_sorted=True)
+
+    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        a_blocks = a.data.blocks
+        b_blocks = b.data.blocks
+        a_block_inds = a.data.block_inds
+        b_block_inds = b.data.block_inds
+        # ensure common dtypes
+        common_dtype = a.dtype.common(b.dtype)
+        if a.data.dtype != common_dtype:
+            a_blocks = [self.block_to_dtype(T, common_dtype) for T in a_blocks]
+        if b.data.dtype != common_dtype:
+            b_blocks = [self.block_to_dtype(T, common_dtype) for T in b_blocks]
+        res_blocks = []
+        res_block_inds = []
+        for i, j in iter_common_noncommon_sorted_arrays(a_block_inds, b_block_inds):
+            if j is None:
+                res_blocks.append(a_blocks[i])
+                res_block_inds.append(a_block_inds[i])
+            elif i is None:
+                res_blocks.append(b_blocks[j])
+                res_block_inds.append(b_block_inds[j])
+            else:
+                res_blocks.append(self.block_add(a_blocks[i], b_blocks[j]))
+                res_block_inds.append(a_block_inds[i])
+        if len(res_block_inds) > 0:
+            res_block_inds = np.array(res_block_inds)
+        else:
+            res_block_inds = np.zeros((0, a.num_legs), int)
+        return AbelianBackendData(common_dtype, res_blocks, res_block_inds, is_sorted=True)
+
+    def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
+                        co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
+                        ) -> Data:
+        blocks = [self.block_add_axis(block, legs_pos) for block in a.data.blocks]
+        block_inds = np.insert(a.data.block_inds, legs_pos, 0, axis=1)
+        # since the new column is constant, block_inds are still sorted.
+        return AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=True)
+
+    def almost_equal(self, a: SymmetricTensor, b: SymmetricTensor, rtol: float, atol: float) -> bool:
+        a_blocks = a.data.blocks
+        b_blocks = b.data.blocks
+        for i, j in iter_common_noncommon_sorted_arrays(a.data.block_inds, b.data.block_inds):
+            if j is None:
+                if self.block_max_abs(a_blocks[i]) > atol:
+                    return False
+            elif i is None:
+                if self.block_max_abs(b_blocks[j]) > atol:
+                    return False
+            else:
+                if not self.block_allclose(a_blocks[i], b_blocks[j], rtol=rtol, atol=atol):
+                    return False
+        return True
+
+    def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
+        raise NotImplementedError  # TODO not yet reviewed
+        tensor_blocks = tensor.data.blocks
+        mask_blocks = mask.data.blocks
+        tensor_block_inds_cont = tensor.data.block_inds[:, :1]  # since tensor is Diagonal, this is sorted
+        mask_block_inds = mask.data.block_inds
+        mask_block_inds_cont = mask_block_inds[:, :1]
+        sort = np.lexsort(mask_block_inds_cont.T)
+        mask_blocks = [mask_blocks[i] for i in sort]
+        mask_block_inds = mask_block_inds[sort]
+        mask_block_inds_cont = mask_block_inds_cont[sort]
+        
+        res_blocks = []
+        res_block_inds = []  # gather only the entries of the first column in this list, repeat later
+        for i, j in iter_common_sorted_arrays(tensor_block_inds_cont, mask_block_inds_cont):
+            res_blocks.append(self.apply_mask_to_block(block=tensor_blocks[i], mask=mask_blocks[j], ax=0))
+            res_block_inds.append(mask_block_inds[j, 1])
+        if len(res_block_inds) > 0:
+            res_block_inds = np.repeat(np.array(res_block_inds)[:, None], 2, axis=1)
+        else:
+            res_block_inds = np.zeros((0, 2), int)
+        return AbelianBackendData(tensor.dtype, res_blocks, res_block_inds, is_sorted=True)
+
+    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        # implementation similar to scale_axis, see notes there
+        tensor_blocks = tensor.data.blocks
+        mask_blocks = mask.data.blocks
+        tensor_block_inds = tensor.data.block_inds
+        tensor_block_inds_cont = tensor_block_inds[:, leg_idx:leg_idx + 1]
+        if leg_idx != tensor.num_legs - 1:
+            # due to np.lexsort(tensor_block_inds.T), only tensor_block_inds[:, -1] is sorted
+            sort = np.lexsort(tensor_block_inds_cont.T)
+            tensor_blocks = [tensor_blocks[i] for i in sort]
+            tensor_block_inds = tensor_block_inds[sort]
+            tensor_block_inds_cont = tensor_block_inds_cont[sort]
+        mask_block_inds = mask.data.block_inds
+        mask_block_inds_cont = mask_block_inds[:, 0:1]
+        sort = np.lexsort(mask_block_inds_cont.T)
+        mask_blocks = [mask_blocks[i] for i in sort]
+        mask_block_inds = mask_block_inds[sort]
+        mask_block_inds_cont = mask_block_inds_cont[sort]
+
+        res_blocks = []
+        res_block_inds = []
+        # need only common blocks : zeros masks to zero, and a missing mask block means all False
+        for i, j in iter_common_nonstrict_sorted_arrays(tensor_block_inds_cont, mask_block_inds_cont):
+            res_blocks.append(self.apply_mask_to_block(block=tensor_blocks[i], mask=mask_blocks[j], ax=leg_idx))
+            block_inds = tensor_block_inds[i].copy()
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            # tensor_block_inds[i] refer to mask.legs[0]._sectors
+            # need to adjust to refer to mask.legs[1]._sectors
+            block_inds[leg_idx] = mask_block_inds[j, 1]
+            res_block_inds.append(block_inds)
+        if len(res_block_inds) > 0:
+            res_block_inds = np.array(res_block_inds)
+        else:
+            res_block_inds = np.zeros((0, tensor.num_legs), int)
+        # OPTIMIZE (JU) block_inds might actually be sorted but i am not sure right now
+        return AbelianBackendData(tensor.dtype, res_blocks, res_block_inds, is_sorted=False)
+
+    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int], product_spaces: list[ProductSpace],
+                     new_axes: list[int], final_legs: list[Space]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        res_dtype = a.data.dtype
+        old_block_inds = a.data.block_inds
+        # first, find block indices of the final array to which we map
+        map_inds = [self.product_space_map_incoming_block_inds(product_space, old_block_inds[:, b:e])
+                    for product_space, (b,e) in zip(product_spaces, combine_slices)]
+        old_block_inds = a.data.block_inds
+        old_blocks = a.data.blocks
+        res_block_inds = np.empty((len(old_block_inds), len(final_legs)), dtype=int)
+        last_e = 0
+        last_i = -1
+        for i, (b, e), product_space, map_ind in zip(new_axes, combine_slices, product_spaces, map_inds):
+            res_block_inds[:, last_i + 1:i] = old_block_inds[:, last_e:b]
+            block_ind_map = product_space.get_metadata('_block_ind_map', backend=self)
+            res_block_inds[:, i] = block_ind_map[map_ind, -1]
+            last_e = e
+            last_i = i
+        res_block_inds[:, last_i + 1:] = old_block_inds[:, last_e:]
+
+        # now we have probably many duplicate rows in res_block_inds, since many combinations of
+        # non-combined block indices map to the same block index in product space
+        # -> find unique entries by sorting res_block_inds
+        sort = np.lexsort(res_block_inds.T)
+        res_block_inds = res_block_inds[sort]
+        old_blocks = [old_blocks[i] for i in sort]
+        map_inds = [map_[sort] for map_ in map_inds]
+
+        # determine slices in the new blocks
+        block_slices = np.zeros((len(old_blocks), len(final_legs), 2), int)
+        block_shape = np.empty((len(old_blocks), len(final_legs)), int)
+        for i, leg in enumerate(final_legs):  # legs not in new_axes
+            if i not in new_axes:
+                # block_slices[:, i, 0] = 0
+                block_slices[:, i, 1] = block_shape[:, i] = leg.multiplicities[res_block_inds[:, i]]
+        for i, product_space, map_ind in zip(new_axes, product_spaces, map_inds):  # legs in new_axes
+            block_ind_map = product_space.get_metadata('_block_ind_map', backend=self)
+            slices = block_ind_map[map_ind, :2]
+            block_slices[:, i, :] = slices
+            block_shape[:, i] = slices[:, 1] - slices[:, 0]
+
+        # split res_block_inds into parts, which give a unique new blocks
+        diffs = find_row_differences(res_block_inds, include_len=True)  # including 0 and len to have slices later
+        res_num_blocks = len(diffs) - 1
+        res_block_inds = res_block_inds[diffs[:res_num_blocks], :]
+        res_block_shapes = np.empty((res_num_blocks, len(final_legs)), int)
+        for i, leg in enumerate(final_legs):
+            res_block_shapes[:, i] = leg.multiplicities[res_block_inds[:, i]]
+
+        # now the hard part: map data
+        res_blocks = []
+        # iterate over ranges of equal qindices in qdata
+        for res_block_shape, beg, end in zip(res_block_shapes, diffs[:-1], diffs[1:]):
+            new_block = self.zero_block(res_block_shape, dtype=res_dtype)
+            for old_row in range(beg, end):  # copy blocks
+                shape = block_shape[old_row]  # this has multiplied dimensions for combined legs
+                old_block = self.block_reshape(old_blocks[old_row], shape)
+                new_slices = tuple(slice(b, e) for b, e in block_slices[old_row])
+
+                new_block[new_slices] = old_block  # actual data copy
+
+            res_blocks.append(new_block)
+
+        # we lexsort( .T)-ed res_block_inds while it still had duplicates, and then indexed by diffs,
+        # which is sorted and thus preserves lexsort( .T)-ing of res_block_inds
+        return AbelianBackendData(res_dtype, res_blocks, res_block_inds, is_sorted=True)
+
+    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
+        raise NotImplementedError  # TODO not yet reviewed. duality of legs changes!!
+        blocks = [self.block_conj(b) for b in a.data.blocks]
+        return AbelianBackendData(a.data.dtype, blocks, a.data.block_inds, is_sorted=True)
+
+    def copy_data(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
+        blocks = [self.block_copy(b) for b in self.blocks]
+        return AbelianBackendData(a.data.dtype, blocks, a.data.block_inds.copy(), is_sorted=True)
+
+    def data_item(self, a: Data | DiagonalData) -> float | complex:
+        if len(a.blocks) > 1:
+            raise ValueError("More than 1 block!")
+        if len(a.blocks) == 0:
+            return a.dtype.zero_scalar
+        return self.block_item(a.blocks[0])
+
+    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int, max_lines: int):
+        raise NotImplementedError  # TODO not yet reviewed
+        from ..dummy_config import printoptions
+        from ..misc import join_as_many_as_possible
+        
+        data = a.data
+        if len(data.blocks) == 0:
+            return [f'{indent}* Data : no non-zero blocks']
+        if max_lines <= 1:
+            return [f'{indent}* Data : Showing none of {len(data.blocks):d} blocks']
+
+        line_start = f'{indent}* Data for sectors '
+
+        if not printoptions.summarize_blocks:
+            # try showing all blocks
+            lines = []
+            for block, block_inds in zip(data.blocks, data.block_inds):
+                sectors = join_as_many_as_possible(
+                    # TODO dont use legs! use conventional_leg_order
+                    [a.symmetry.sector_str(leg.sectors[i]) for leg, i in zip(a.legs, block_inds)],
+                    separator=', ', max_len=printoptions.linewidth - len(line_start) - 1
+                )
+                lines.append(f'{line_start}[{sectors}]:')
+                lines.extend(self._block_repr_lines(block,
+                                                    indent=indent + printoptions.indent * ' ',
+                                                    max_width=max_width,
+                                                    max_lines=max_lines))
+                if len(lines) > max_lines:
+                    break
+            else:  # (no break ocurred)
+                return lines
+            
+
+        # try showing shapes of all blocks
+        lines = []
+        for block, block_inds in zip(data.blocks, data.block_inds):
+            sectors = join_as_many_as_possible(
+                # TODO dont use legs! use conventional_leg_order
+                [a.symmetry.sector_str(leg.sectors[i]) for leg, i in zip(a.legs, block_inds)],
+                separator=', ', max_len=printoptions.linewidth - len(line_start) - 1
+            )
+            shape = str(self.block_shape(block))
+            if len(line_start) + len(sectors) + 10 + len(shape) <= printoptions.linewidth:
+                lines.append(f'{line_start}[{sectors}]: shape {shape}')
+            else:
+                lines.append(f'{line_start}[{sectors}]: shape {shape}')
+                lines.append(f'{indent}    shape {shape}')
+            if len(lines) > max_lines:
+                break
+        else:  # (no break ocurred)
+            return lines
+
+        # only show shapes of largest blocks
+        lines = []
+        sizes = np.prod([self.block_shape(block) for block in data.blocks], axis=1)
+        missing_blocks = len(a.data.blocks)
+        for j in np.argsort(sizes):
+            sectors = join_as_many_as_possible(
+                [a.symmetry.sector_str(leg.sectors[i])
+                 # TODO dont use legs! use conventional_leg_order
+                 for leg, i in zip(a.legs, a.data.block_inds[j])],
+                separator=', ', max_len=printoptions.linewidth - len(line_start) - 1
+            )
+            shape = str(self.block_shape(a.data.blocks[j]))
+            if len(line_start) + len(sectors) + 10 + len(shape) <= printoptions.linewidth:
+                new_lines = [f'{line_start}[{sectors}]: shape {shape}']
+            else:
+                new_lines = [f'{line_start}[{sectors}]: shape {shape}',
+                             f'{indent}    shape {shape}']
+            if len(lines) + len(new_lines) >= max_lines:
+                lines.append(f'{indent}* Data for {missing_blocks} smaller blocks not shown')
+                return lines
+            lines.extend(new_lines)
+            missing_blocks -= 1
+
+        raise ValueError  # the above return should have triggered
+
+    def diagonal_all(self, a: DiagonalTensor) -> bool:
+        if len(a.data.block_inds) < a.leg.num_sectors:
+            # missing blocks are filled with False
+            return False
+        # now it is enough to check that all existing blocks are all-True
+        return all(self.block_all(b) for b in a.data.blocks)
+
+    def diagonal_any(self, a: DiagonalTensor) -> bool:
+        return any(self.block_any(b) for b in a.data.blocks)
+
+    def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
+                                    func_kwargs, partial_zero_is_zero: bool
+                                    ) -> DiagonalData:
+        a_blocks = a.data.blocks
+        b_blocks = b.data.blocks
+        a_block_inds = a.data.block_inds
+        b_block_inds = b.data.block_inds
+        a_mults = a.leg.multiplicities
+        b_mults = b.leg.multiplicities
+        
+        blocks = []
+        block_inds = []
+        if partial_zero_is_zero:
+            for i, j in iter_common_sorted_arrays(a_block_inds, b_block_inds):
+                blocks.append(func(a_blocks[i], b_blocks[j], **func_kwargs))
+                block_inds.append(a_block_inds[i])
+        else:
+            for i, j in iter_common_noncommon_sorted_arrays(a_block_inds, b_block_inds):
+                if i is None:
+                    a_block = self.zero_block([b_mults[b_block_inds[j, 0]]], dtype=a.dtype)
+                    b_block = b_blocks[j]
+                    block_inds.append(b_block_inds[j])
+                elif j is None:
+                    a_block = a_blocks[i]
+                    b_block = self.zero_block([a_mults[a_block_inds[i, 0]]], dtype=b.dtype)
+                    block_inds.append(a_block_inds[i])
+                else:
+                    a_block = a_blocks[i]
+                    b_block = b_blocks[j]
+                    block_inds.append(a_block_inds[i])
+                blocks.append(func(a_block, b_block, **func_kwargs))
+        block_inds = np.array(block_inds)
+
+        if len(blocks) == 0:
+            block = func(self.ones_block([1], dtype=a.dtype), self.ones_block([1], dtype=b.dtype))
+            dtype = self.block_dtype(block)
+        else:
+            dtype = self.block_dtype(blocks[0])
+            
+        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
+
+    def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs, maps_zero_to_zero: bool
+                                   ) -> DiagonalData:
+        a_blocks = a.data.blocks
+        if maps_zero_to_zero:
+            blocks = [func(block, **func_kwargs) for block in a.data.blocks]
+            block_inds = a.data.block_inds
+        else:
+            a_block_inds = a.data.block_inds
+            block_inds = np.repeat(np.arange(a.leg.num_sectors)[:, None], 2, axis=1)
+            blocks = []
+            for i, j in iter_common_noncommon_sorted_arrays(block_inds, a_block_inds):
+                if j is None:
+                    # use that block_inds is just arange -> block_inds[i, 0] == i
+                    block = self.zero_block([a.leg.multiplicities[i]], dtype=a.dtype)
+                else:
+                    block = a_blocks[j]
+                blocks.append(func(block, **func_kwargs))
+        if len(blocks) == 0:
+            dtype = self.block_dtype(func(self.zero_block([1], dtype=a.dtype)))
+        else:
+            dtype = self.block_dtype(blocks[0])
+        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
+
+    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
+        leg = co_domain.spaces[0]
+        a = self.apply_basis_perm(a, co_domain.spaces)
+        dtype = self.block_dtype(a)
+        block_inds = np.repeat(np.arange(co_domain.num_sectors)[:, None], 2, axis=1)
+        blocks = [a[slice(*leg.slices[i])] for i in block_inds[:, 0]]
+        return AbelianBackendData(dtype, blocks, block_inds, is_sorted=True)
+
+    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
+        leg = co_domain.spaces[0]
+        block_inds = np.repeat(np.arange(leg.num_sectors)[:, None], 2, axis=1)
+        blocks = [func((mult,), coupled)
+                  for coupled, mult in zip(leg.sectors, leg.multiplicities)]
+        if len(blocks) == 0:
+            sample_block = func((1,), co_domain.symmetry.trivial_sector)
+        else:
+            sample_block = blocks[0]
+        dtype = self.block_dtype(sample_block)
+        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
+
+    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
+        blocks = [self.block_get_diagonal(block, check_offdiagonal) for block in a.data.blocks]
+        return AbelianBackendData(a.dtype, blocks, a.data.block_inds, is_sorted=True)
+
+    def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
+        total_sum = a.data.dtype.zero_scalar
+        for block in a.data.blocks:
+            total_sum += self.block_sum_all(block)
+        return total_sum
+
+    def diagonal_tensor_to_block(self, a: DiagonalTensor) -> Block:
+        res = self.zero_block([a.leg.dim], a.dtype)
+        for block, b_i_0 in zip(a.data.blocks, a.data.block_inds[:, 0]):
+            res[slice(*a.leg.slices[b_i_0])] = block
+        return self.apply_basis_perm(res, [a.leg], inv=True)
+
+    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
+        # TODO block_inds needs to be (potentially) modified
+        raise NotImplementedError  # TODO
+
+    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
+        raise NotImplementedError  # TODO not yet reviewed. interface may change.
+        # for missing blocks, i.e. a zero block, the eigenvalues are zero, so we can just skip adding
+        # that block to the eigenvalues.
+        # for the eigenvectors, we choose the computational basis vectors, i.e. the matrix
+        # representation within that block is the identity matrix.
+        # we initialize all blocks to eye and override those where a has blocks.
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        eigvects_data = self.eye_data(legs=a.legs[0:1], dtype=a.dtype)
+        eigvals_blocks = []
+        for block, bi in zip(a.data.blocks, a.data.block_inds):
+            vals, vects = self.block_eigh(block, sort=sort)
+            eigvals_blocks.append(vals)
+            assert bi[0] == bi[1]  # TODO remove this check
+            eigvects_data.blocks[bi[0]] = vects
+        eigvals_data = AbelianBackendData(dtype=a.dtype.to_real, blocks=eigvals_blocks,
+                                          block_inds=a.data.block_inds, is_sorted=True)
+        return eigvals_data, eigvects_data
+
+    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> Data:
+        # Note: the identity has the same matrix elements in all ONB, so ne need to consider
+        #       the basis perms.
+        # results[i1,...im,jm,...,j1] = delta_{i1,j1} ... delta{im,jm}
+        # need exactly the "diagonal" blocks, where sector of i1 matches the one of j1 etc.
+        # to guarantee sorting later, it is easier to generate the block inds of the domain
+        domain_dims = [leg.num_sectors for leg in reversed(co_domain.spaces)]
+        domain_block_inds = np.indices(domain_dims).T.reshape(-1, co_domain.num_spaces)
+        block_inds = np.hstack([domain_block_inds[:, ::-1], domain_block_inds])
+        # domain_block_inds is by construction np.lexsort( .T)-ed.
+        # since the last co_domain.num_spaces columns of block_inds are already unique, the first
+        # columns are not relevant to np.lexsort( .T)-ing, thus the block_inds above is sorted.
+        blocks = []
+        for b_i in block_inds:
+            shape = [leg.multiplicities[i] for leg, i in zip(co_domain.spaces, b_i)]
+            blocks.append(self.eye_block(shape, dtype))
+        return AbelianBackendData(dtype, blocks, block_inds, is_sorted=True)
+
+    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
+                         flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        block_inds = np.copy(tensor.data.block_inds)
+        for i, perm in zip(which_legs, perms):
+            # old_sector_idx = perm[new_sector_idx]
+            block_inds[:, i] = inverse_permutation(perm)[block_inds[:, i]]
+        return AbelianBackendData(dtype=tensor.data.dtype, blocks=tensor.data.blocks,
+                                  block_inds=block_inds, is_sorted=False)
+
+    def from_dense_block(self, a: Block, codomain: ProductSpace, domain: ProductSpace, tol: float
+                         ) -> AbelianBackendData:
+        a = self.apply_basis_perm(a, list(conventional_leg_order(codomain, domain)))
+        dtype = self.block_dtype(a)
+        projected = self.zero_block(self.block_shape(a), dtype=dtype)
+        block_inds = _valid_block_inds(codomain, domain)
+        blocks = []
+        for b_i in block_inds:
+            slices = tuple(slice(*leg.slices[i])
+                           for i, leg in zip(b_i, conventional_leg_order(codomain, domain)))
+            block = a[slices]
+            blocks.append(block)
+            projected[slices] = block
+        if tol is not None:
+            if self.block_norm(a - projected) > tol * self.block_norm(a):
+                raise ValueError('Block is not symmetric up to tolerance.')
+        return AbelianBackendData(dtype, blocks, block_inds, is_sorted=True)
+ 
+    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
+        # need to consider basis_perm. see comment in to_dense_block_trivial_sector.
+        # here we need the inverse though
+        bi = leg.sectors_where(leg.symmetry.trivial_sector)
+        if leg.basis_perm is not None:
+            perm = np.argsort(leg.basis_perm[slice(*leg.slices[bi])])
+            block = self.apply_leg_permutations(block, [inverse_permutation(perm)])
+        return AbelianBackendData(
+            dtype=self.block_dtype(block), blocks=[block],
+            block_inds=np.array([[bi]]),
+            is_sorted=True
+        )
+
+    def from_random_normal(self, codomain: ProductSpace, domain: ProductSpace, sigma: float,
+                           dtype: Dtype) -> Data:
+        return self.from_sector_block_func(
+            func=lambda shape, coupled: self.block_random_normal(shape, dtype, sigma),
+            codomain=codomain, domain=domain
+        )
+
+    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> Data:
+        """Generate tensor data from a function ``func(shape: tuple[int], coupled: Sector) -> Block``."""
+        block_inds = _valid_block_inds(codomain=codomain, domain=domain)
+        M = codomain.num_spaces
+        blocks = []
+        for b_i in block_inds:
+            shape = [leg.multiplicities[i]
+                     for i, leg in zip(b_i, conventional_leg_order(codomain, domain))]
+            coupled = codomain.symmetry.multiple_fusion(
+                *(leg.sectors[i] for i, leg in zip(b_i, codomain.spaces))
+            )
+            blocks.append(func(shape, coupled))
+        if len(blocks) == 0:
+            sample_block = func((1,) * (M + domain.num_spaces), codomain.symmetry.trivial_sector)
+        else:
+            sample_block = blocks[0]
+        dtype = self.block_dtype(sample_block)
+        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
+
+    def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
+        blocks = [self.block_from_diagonal(block) for block in a.data.blocks]
+        return AbelianBackendData(a.dtype, blocks, a.data.block_inds, is_sorted=True)
+
+    def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
+        blocks = [self.block_from_mask(block, dtype) for block in a.data.blocks]
+        return AbelianBackendData(dtype, blocks, a.data.block_inds, is_sorted=True)
+
+    def get_dtype_from_data(self, a: Data) -> Dtype:
+        return a.dtype
+
+    def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        pos = np.array([l.parse_index(idx) for l, idx in zip(a.legs, idcs)])
+        block = a.data.get_block(pos[:, 0])
+        if block is None:
+            return a.dtype.zero_scalar
+        return self.get_block_element(block, pos[:, 1])
+
+    def get_element_diagonal(self, a: DiagonalTensor, idx: int) -> complex | float | bool:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        block_idx, idx_within = a.legs[0].parse_index(idx)
+        block = a.data.get_block(np.array([block_idx]))
+        if block is None:
+            return a.dtype.zero_scalar
+        return self.get_block_element(block, [idx_within])
+        
+    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False
+                  ) -> ElementarySpace:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO how to handle ChargedTensor vs Tensor?
+        #  JU: dont need to consider ChargedTensor here.
+        #      When e.g. a ChargedTensor classmethod wants to infer the charge, it should add a
+        #      one-dimensional axis to the block. then, this block is "uncharged", i.e. it will
+        #      become the ``invariant_part: Tensor`` of the ChargedTensor.
+        #      The "qtotal" is then the charge of the "artificial"/"dummy" leg.
+        
+        #  def detect_qtotal(flat_array, legcharges):
+        #      inds_max = np.unravel_index(np.argmax(np.abs(flat_array)), flat_array.shape)
+        #      val_max = abs(flat_array[inds_max])
+
+        #      test_array = zeros(legcharges)  # Array prototype with correct charges
+        #      qindices = [leg.get_qindex(i)[0] for leg, i in zip(legcharges, inds_max)]
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        #      q = np.sum([l.get_charge(qi) for l, qi in zip(self.legs, qindices)], axis=0)
+        #      return make_valid(q)  # TODO: leg.get_qindex, leg.get_charge
+    
+    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool, axs2: list[int] | None) -> complex:
+        raise NotImplementedError  # TODO not yet reviewed
+        # a.legs[i] to be contracted with b.legs[axs2[i]]
+        a_blocks = a.data.blocks
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        stride = make_stride([l.num_sectors for l in a.legs], cstyle=False)
+        a_block_inds = np.sum(a.data.block_inds * stride, axis=1)
+        if axs2 is not None:
+            # permute strides to match the label order on b:
+            # strides_for_a[i] == strides_for_b[axs2[i]]
+            stride[axs2] = stride.copy()
+        b_blocks = b.data.blocks
+        b_block_inds = np.sum(b.data.block_inds * stride, axis=1)
+        if axs2 is not None:
+            # we permuted the strides, so b_block_inds is no longer sorted
+            sort = np.argsort(b_block_inds)
+            b_block_inds = b_block_inds[sort]
+            b_blocks = [b_blocks[i] for i in sort]
+        res = [self.block_inner(a_blocks[i], b_blocks[j], do_conj=do_conj, axs2=axs2)
+               for i, j in iter_common_sorted(a_block_inds, b_block_inds)]
+        return np.sum(res)
+
+    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
+                                                charge_leg: ElementarySpace) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        assert charge_leg.num_sectors == 1
+        bi = leg.sectors_where(leg.symmetry.dual_sector(charge_leg.sectors[0]))
+        assert bi is not None
+        assert self.block_shape(block) == (leg.multiplicities[bi],)
+        if leg.basis_perm is not None:
+            # see comment in to_dense_block_trivial_sector. here we need the inverse of that.
+            perm = np.argsort(leg.basis_perm[slice(*leg.slices[bi])])
+            block = self.apply_leg_permutations(block, [inverse_permutation(perm)])
+        return AbelianBackendData(
+            dtype=self.block_dtype(block),
+            blocks=[self.block_add_axis(block, pos=1)],
+            block_inds=np.array([[bi, 0]])
+        )
+
+    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        num_blocks = len(tensor.data.blocks)
+        assert tensor.legs[1].num_sectors == 1
+        # find the block-index that the single allowed block has (or would have)
+        sector = tensor.legs[1].sectors[0]
+        bi = tensor.legs[0].sectors_where(tensor.symmetry.dual_sector(sector))
+        if num_blocks == 1:
+            res = tensor.data.blocks[0][:, 0]
+            if tensor.legs[0].basis_perm is not None:
+                # see comment in to_dense_block_trivial_sector
+                perm = np.argsort(tensor.legs[0].basis_perm[slice(*tensor.legs[0].slices[bi])])
+                res = self.apply_leg_permutations(res, [perm])
+            return res
+        elif num_blocks == 0:
+            dim = tensor.legs[0].multiplicities[bi]
+            # no need to consider basis_perm, since its all 0 anyway
+            return self.zero_block(shape=[dim], dtype=tensor.data.dtype)
+        raise ValueError  # should have been caught by input checks in ChargedTensor.to_dense_block_single_sector
+
+    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+
+    def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace
+                        ) -> DiagonalData:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO thoroughly test this!
+        a = self.apply_basis_perm(a, [large_leg])
+        blocks = []
+        block_inds = []
+        bi_small = 0
+        for bi_large, slc in enumerate(large_leg.slices):
+            block = a[slice(*slc)]
+            if self.block_sum_all(block) == 0:
+                continue
+            # TODO remove this check after testing
+            assert all(large_leg.sectors[bi_large] == small_leg.sectors[bi_small])
+            blocks.append(block)
+            block_inds.append([bi_large, bi_small])
+            bi_small += 1
+        if len(block_inds) == 0:
+            block_inds = np.zeros(shape=(0, 2), dtype=int)
+        else:
+            block_inds = np.array(block_inds, dtype=int)
+
+        # TODO remove this check after testing
+        if len(block_inds) > 0:
+            perm = np.lexsort(block_inds.T)
+            assert np.all(perm == np.arange(len(perm)))
+
+        return AbelianBackendData(dtype=Dtype.bool, blocks=blocks, block_inds=block_inds,
+                                  is_sorted=True)
+
+    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+        
+    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
+        if a == 0.:
+            return self.zero_data(b.codomain, b.domain, b.dtype)
+        blocks = [self.block_mul(a, T) for T in b.data.blocks]
+        if len(blocks) == 0:
+            if isinstance(a, float):
+                dtype = b.data.dtype
+            else:
+                dtype = b.data.dtype.to_complex
+        else:
+            dtype = self.block_dtype(blocks[0])
+        return AbelianBackendData(dtype, blocks, b.data.block_inds, is_sorted=True)
+
+    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
+        block_norms = [self.block_norm(b, order=2) for b in a.data.blocks]
+        return np.linalg.norm(block_norms, ord=2)
+
+    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        res_dtype = a.data.dtype.common(b.data.dtype)
+        a_blocks = a.data.blocks
+        b_blocks = b.data.blocks
+        if a.data.dtype != res_dtype:
+            a_blocks = [self.block_to_dtype(T, res_dtype) for T in a_blocks]
+        if b.data.dtype != res_dtype:
+            b_blocks = [self.block_to_dtype(T, res_dtype) for T in b_blocks]
+        a_block_inds = a.data.block_inds
+        b_block_inds = b.data.block_inds
+        l_a, num_legs_a = a_block_inds.shape
+        l_b, num_legs_b = b_block_inds.shape
+        grid = np.indices([len(a_block_inds), len(b_block_inds)]).T.reshape(-1, 2)
+        # grid is lexsorted, with rows as all combinations of a/b block indices.
+        res_block_inds = np.empty((l_a * l_b, num_legs_a + num_legs_b), dtype=int)
+        res_block_inds[:, :num_legs_a] = a_block_inds[grid[:, 0]]
+        res_block_inds[:, num_legs_a:] = b_block_inds[grid[:, 1]]
+
+        res_blocks = [self.block_outer(a_blocks[i], b_blocks[j]) for i, j in grid]
+
+        # TODO (JU) are the block_inds actually sorted?
+        #  if yes: add comment explaining why, adjust argument below
+        return AbelianBackendData(res_dtype, res_blocks, res_block_inds, is_sorted=False)
+
+    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
+        # TODO decide signature of backend function
+        raise NotImplementedError  # TODO not yet reviewed
+        if permutation is None:
+            return a.data  # TODO copy?
+        blocks = a.data.blocks
+        blocks = [self.block_permute_axes(block, permutation) for block in a.data.blocks]
+        block_inds = a.data.block_inds[:, permutation]
+        data = AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=False)
+        return data
+
+    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        q_leg_0, r_leg_1 = a.legs
+        q_blocks = []
+        r_blocks = []
+        for block in a.data.blocks:
+            q, r = self.matrix_qr(block, full=full)
+            q_blocks.append(q)
+            r_blocks.append(r)
+        sym = a.symmetry
+        if full:
+            new_leg = q_leg_0.as_ElementarySpace()
+            if new_leg.is_dual != new_r_leg_dual:
+                # taking the dual leaves _non_sorted_dual_sectors unaffected and
+                # thus we dont need to adjust anything else
+                new_leg = new_leg.dual
+            # sort q_blocks
+            q_blocks_full = [None] * q_leg_0.num_sectors
+            for i, q in zip(a.data.block_inds[:, 0], q_blocks):
+                q_blocks_full[i] = q
+            if len(q_blocks) < q_leg_0.num_sectors:
+                # there is a block-column in `a` that is completely 0 and not in a.data.blocks
+                # so we need to add corresponding identity blocks in q to ensure q is unitary!
+                dtype = a.data.dtype
+                for i, q in enumerate(q_blocks_full):
+                    if q is None:
+                        q_blocks_full[i] = self.eye_block([q_leg_0.multiplicities[i]], dtype)
+            q_block_inds = np.repeat(np.arange(q_leg_0.num_sectors, dtype=int)[:, None], 2, axis=1)  # sorted
+            r_block_inds = a.data.block_inds.copy() # is already sorted...
+
+            q_data = AbelianBackendData(a.data.dtype, q_blocks_full, q_block_inds, is_sorted=True)
+            r_data = AbelianBackendData(a.data.dtype, r_blocks, r_block_inds, is_sorted=True)
+        else:
+            keep = a.data.block_inds[:, 0]
+
+            # fix the order of sectors on the new leg: by order of appearance in q_leg_0
+            keep_perm = np.argsort(keep)
+            keep_sorted = keep[keep_perm]  # this fixes the order! "by order of appearance in q_leg_0"
+
+            new_leg_sectors = q_leg_0.sectors[keep_sorted, :]  # this is lexsort(x.T)-ed
+            new_leg_mults = np.array([self.block_shape(q)[1] for q in q_blocks], int)[keep_perm]
+            raise NotImplementedError  # TODO review this. duality.
+            new_leg = ElementarySpace(sym, new_leg_sectors, new_leg_mults, is_real=q_leg_0.is_real,
+                                      _is_dual=new_r_leg_dual)
+
+            # determine block_inds for the new leg:
+            # for q_blocks[i], the relevant sector is the same as the sector on the 0 leg:
+            # q_leg_0.sectors[a.data.block_inds[i, 0]]
+            #  == q_leg_0.sectors[keep[i]]
+            #  == q_leg_0.sectors[keep_sorted[inv_keep_perm[i]]]
+            #  == new_leg_sectors[inv_keep_perm[i]]
+            #  == new_leg.sectors[inv_keep_perm[i]]
+            # Thus we have
+            new_block_inds = inverse_permutation(keep_perm)
+            
+            q_block_inds = np.hstack([keep[:, None], new_block_inds[:, None]])  # not sorted.
+            r_block_inds = np.hstack([new_block_inds[:, None], a.data.block_inds[:, 1:2]])  # lexsorted.
+            assert np.all(np.lexsort(r_block_inds.T) == np.arange(len(r_block_inds)))  # TODO remove test
+            q_data = AbelianBackendData(a.dtype, q_blocks, q_block_inds, is_sorted=False)
+            r_data = AbelianBackendData(a.dtype, r_blocks, r_block_inds, is_sorted=True)
+
+        return q_data, r_data, new_leg
+
+    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        a_blocks = a.data.blocks
+        b_blocks = b.data.blocks
+
+        a_block_inds = a.data.block_inds
+        a_block_inds_cont = a_block_inds[:, leg:leg+1]
+        if leg == a.num_legs - 1:
+            # due to lexsort(a_block_inds.T), a_block_inds_cont is sorted in this case
+            pass
+        else:
+            sort = np.lexsort(a_block_inds_cont.T)
+            a_blocks = [a_blocks[i] for i in sort]
+            a_block_inds = a_block_inds[sort, :]
+            a_block_inds_cont = a_block_inds_cont[sort, :]
+        b_block_inds = b.data.block_inds
+        
+        # ensure common dtypes
+        common_dtype = a.dtype.common(b.dtype)
+        if a.data.dtype != common_dtype:
+            a_blocks = [self.block_to_dtype(block, common_dtype) for block in a_blocks]
+        if b.data.dtype != common_dtype:
+            b_blocks = [self.block_to_dtype(block, common_dtype) for block in b_blocks]
+        
+        res_blocks = []
+        res_block_inds = []
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        # can assume that a.legs[leg] and b.legs[0] have same _sectors.
+        # only need to iterate over common blocks, the non-common multiply to 0.
+        # note: unlike the tdot implementation, we do not combine and reshape here.
+        #       this is because we know the result will have the same block-structure as `a`, and
+        #       we only need to scale the blocks on one axis, not perform a general tensordot.
+        #       but this also means that we may encounter duplicates in a_block_inds_cont,
+        #       i.e. multiple blocks of `a` which have the same sector on the leg to be scaled.
+        #       -> use iter_common_nonstrict_sorted_arrays instead of iter_common_sorted_arrays
+        for i, j in iter_common_nonstrict_sorted_arrays(a_block_inds_cont, b_block_inds[:, :1]):
+            res_blocks.append(self.block_scale_axis(a_blocks[i], b_blocks[j], axis=leg))
+            res_block_inds.append(a_block_inds[i])
+        if len(res_block_inds) > 0:
+            res_block_inds = np.array(res_block_inds)
+        else:
+            res_block_inds = np.zeros((0, a.num_legs), int)
+        
+        return AbelianBackendData(common_dtype, res_blocks, res_block_inds, is_sorted=True)
+   
+    def set_element(self, a: SymmetricTensor, idcs: list[int], value: complex | float) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        pos = np.array([l.parse_index(idx) for l, idx in zip(a.legs, idcs)])
+        n = a.data.get_block_num(pos[:, 0])
+        if n is None:
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            shape = [leg.multiplicities[sector_idx] for leg, sector_idx in zip(a.legs, pos[:, 0])]
+            block = self.zero_block(shape, dtype=a.dtype)
+        else:
+            block = a.data.blocks[n]
+        blocks = a.data.blocks[:]
+        blocks[n] = self.set_block_element(block, pos[:, 1], value)
+        return AbelianBackendData(dtype=a.data.dtype, blocks=blocks, block_inds=a.data.blocks_inds,
+                                  is_sorted=True)
+
+    def set_element_diagonal(self, a: DiagonalTensor, idx: int, value: complex | float | bool
+                             ) -> DiagonalData:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        block_idx, idx_within = a.legs[0].parse_index(idx)
+        n = a.data.get_block_num(np.array([block_idx]))
+        if n is None:
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            block = self.zero_block(shape=[a.legs[0].multiplicities[block_idx]], dtype=a.dtype)
+        else:
+            block = a.data.blocks[n]
+        blocks = a.data.blocks[:]
+        blocks[n] = self.set_block_element(block, [idx_within], value)
+        return AbelianBackendData(dtype=a.data.dtype, blocks=blocks, block_inds=a.data.blocks_inds,
+                                  is_sorted=True)
+
+    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int], final_legs: list[Space]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        # TODO (JH) below, we implement it by first generating the block_inds of the splitted tensor and
+        # then extract subblocks from the original one.
+        # Why not go the other way around and implement
+        # block_views = self.block_split(block, block_sizes, axis) similar as np.array_split()
+        # and call that for each axis to be split for each block?
+        # we do a lot of numpy index tricks below, but does that really save time for splitting?
+        # block_split should just be views anyways, not data copies?
+
+        if len(a.data.blocks) == 0:
+            return self.zero_data(final_legs, a.data.dtype)
+        n_split = len(leg_idcs)
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        product_spaces = [a.legs[i] for i in leg_idcs]
+        res_num_legs = len(final_legs)
+
+        old_blocks = a.data.blocks
+        old_block_inds = a.data.block_inds
+
+        map_slices_beg = np.zeros((len(old_blocks), n_split), int)
+        map_slices_shape = np.zeros((len(old_blocks), n_split), int)  # = end - beg
+        for j, product_space in enumerate(product_spaces):
+            block_inds_j = old_block_inds[:, leg_idcs[j]]
+            block_ind_map_slices = product_space.get_metadata('_block_ind_map_slices', backend=self)
+            map_slices_beg[:, j] = block_ind_map_slices[block_inds_j]
+            sizes = block_ind_map_slices[1:] - block_ind_map_slices[:-1]
+            map_slices_shape[:, j] = sizes[block_inds_j]
+        new_data_blocks_per_old_block = np.prod(map_slices_shape, axis=1)
+
+        old_rows = np.concatenate([np.full((s,), i, int) for i, s in enumerate(new_data_blocks_per_old_block)])
+        res_num_blocks = len(old_rows)
+
+        map_rows = []
+        for beg, shape in zip(map_slices_beg, map_slices_shape):
+            map_rows.append(np.indices(shape, int).reshape(n_split, -1).T + beg[np.newaxis, :])
+        map_rows = np.concatenate(map_rows, axis=0)  # shape (res_num_blocks, n_split)
+
+        # generate new block_inds and figure out slices within old blocks to be extracted
+        new_block_inds = np.empty((res_num_blocks, res_num_legs), dtype=int)
+        old_block_beg = np.zeros((res_num_blocks, a.num_legs), dtype=int)
+        old_block_shapes = np.empty((res_num_blocks, a.num_legs), dtype=int)
+        shift = 0  #  = i - k for indices below
+        j = 0  # index within product_spaces
+        for i in range(a.num_legs):  # i = index in old tensor
+            if i in leg_idcs:
+                product_space = product_spaces[j]  # = a.legs[i]
+                k = i + shift  # = index where split legs begin in new tensor
+                k2 = k + len(product_space.spaces)  # = until where spaces go in new tensor
+                _block_ind_map = product_space.get_metadata('_block_ind_map', backend=self)[map_rows[:, j], :]
+                new_block_inds[:, k:k2] = _block_ind_map[:, 2:-1]
+                old_block_beg[:, i] = _block_ind_map[:, 0]
+                old_block_shapes[:, i] = _block_ind_map[:, 1] - _block_ind_map[:, 0]
+                shift += len(product_space.spaces) - 1
+                j += 1
+            else:
+                new_block_inds[:, i + shift] = nbi = old_block_inds[old_rows, i]
+                # TODO dont use legs! use conventional_leg_order / domain / codomain
+                old_block_shapes[:, i] = a.legs[i].multiplicities[nbi]
+        # sort new_block_inds
+        # OPTIMIZE (JU) could also skip sorting here and put is_sorted=False in AbelianBackendData(..) below?
+        sort = np.lexsort(new_block_inds.T)
+        new_block_inds = new_block_inds[sort, :]
+        old_block_beg = old_block_beg[sort]
+        old_block_shapes = old_block_shapes[sort]
+        old_rows = old_rows[sort]
+
+        new_block_shapes = np.empty((res_num_blocks, res_num_legs), dtype=int)
+        for i, leg in enumerate(final_legs):
+            new_block_shapes[:, i] = leg.multiplicities[new_block_inds[:, i]]
+
+        # the actual loop to split the blocks
+        new_blocks = []
+        for i in range(res_num_blocks):
+            old_block = old_blocks[old_rows[i]]
+            slices = tuple(slice(b, b + s) for b, s in zip(old_block_beg[i], old_block_shapes[i]))
+            new_block = old_block[slices]
+            new_blocks.append(self.block_reshape(new_block, new_block_shapes[i]))
+
+        return AbelianBackendData(a.data.dtype, new_blocks, new_block_inds, is_sorted=True)
+
+    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        n_legs = a.num_legs
+        if len(a.data.blocks) == 0:
+            block_inds = np.zeros([0, n_legs - len(idcs)], dtype=int)
+            return AbelianBackendData(a.data.dtype, [], block_inds, is_sorted=True)
+        blocks = [self.block_squeeze_legs(b, idcs) for b in a.data.blocks]
+        block_inds = a.data.block_inds
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        symmetry = a.legs[0].symmetry
+        sector = symmetry.trivial_sector
+        for i in idcs:
+            bi = block_inds[0, i]
+            assert np.all(block_inds[:, i] == bi)
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            sector = symmetry.fusion_outcomes(sector, a.legs[i].sector(bi))[0]
+        if not np.all(sector == symmetry.trivial_sector):
+            # TODO return corresponding ChargedTensor instead in this case?
+            raise ValueError("Squeezing legs drops non-trivial charges, would give ChargedTensor.")
+        keep = np.ones(n_legs, dtype=bool)
+        keep[idcs] = False
+        block_inds = block_inds[:, keep]
+        return AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=True)
+
+    def supports_symmetry(self, symmetry: Symmetry) -> bool:
+        return symmetry.is_abelian and symmetry.braiding_style == BraidingStyle.bosonic
+
+    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None, compute_u: bool,
+            compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
+        raise NotImplementedError  # TODO not yet reviewed
+        u_blocks = []
+        s_blocks = []
+        vh_blocks = []
+        for block in a.data.blocks:
+            u, s, vh = self.matrix_svd(block, algorithm=algorithm, compute_u=compute_u, compute_vh=compute_vh)
+            u_blocks.append(u)
+            s_blocks.append(s)
+            assert len(s) > 0
+            vh_blocks.append(vh)
+
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        leg_L, leg_R = a.legs
+        symmetry = a.legs[0].symmetry
+        block_inds_L, block_inds_R = a.data.block_inds.T  # columns of block_inds
+        # due to lexsort(a.data.block_inds.T), block_inds_R is sorted, but block_inds_L not.
+
+        # build new leg: add sectors in the order given by block_inds_R, which is sorted
+        leg_C_sectors = leg_R.sectors[block_inds_R]
+        # economic SVD (aka full_matrices=False) : len(s) = min(block.shape)
+        leg_C_mults = np.minimum(leg_L.multiplicities[block_inds_L], leg_R.multiplicities[block_inds_R])
+        block_inds_C = np.arange(len(s_blocks), dtype=int)
+        raise NotImplementedError  # TODO revise. duality.
+        # if new_vh_leg_dual != leg_R.is_dual:
+        #     # opposite dual flag in legs of vH => same _sectors
+        #     new_leg = Vector_Space(symmetry, leg_C_sectors, leg_C_mults, is_real=leg_R.is_real, _is_dual=new_vh_leg_dual)
+        # else:  # new_vh_leg_dual == leg_R.is_dual
+        #     # same dual flag in legs of vH => opposite _sectors => opposite sorting!!!
+        #     leg_C_sectors = symmetry.dual_sectors(leg_C_sectors)  # not sorted
+        #     sort = np.lexsort(leg_C_sectors.T)
+        #     block_inds_C = block_inds_C[sort]
+        #     new_leg = Vector_Space(symmetry, leg_C_sectors[sort], leg_C_mults[sort], is_real=leg_R.is_real, _is_dual=new_vh_leg_dual)
+            
+        u_block_inds = np.column_stack([block_inds_L, block_inds_C])
+        s_block_inds = np.repeat(block_inds_C[:, None], 2, axis=1)
+        vh_block_inds = np.column_stack([block_inds_C, block_inds_R])
+        if new_vh_leg_dual == leg_R.is_dual:
+            # need to sort u_block_inds and s_block_inds
+            # since we lexsort with last column changing slowest, we need to sort block_inds_C only
+            sort = np.argsort(block_inds_C)
+            u_block_inds = u_block_inds[sort, :]
+            s_block_inds = s_block_inds[sort, :]
+            u_blocks = [u_blocks[i] for i in sort]
+            s_blocks = [s_blocks[i] for i in sort]
+        dtype = a.data.dtype
+        if compute_u:
+            u_data = AbelianBackendData(dtype, u_blocks, u_block_inds, is_sorted=True)
+        else:
+            u_data = None
+        s_data = AbelianBackendData(dtype.to_real, s_blocks, s_block_inds, is_sorted=True)
+        if compute_vh:
+            vh_data = AbelianBackendData(dtype, vh_blocks, vh_block_inds, is_sorted=True)
+        else:
+            vh_data = None
+        return u_data, s_data, vh_data, new_leg
+
+    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int], axs_b: list[int]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        #  Looking at the source of numpy's tensordot (which is just 62 lines of python code),
+        #  you will find that it has the following strategy:
+
+        #  1. Transpose `a` and `b` such that the axes to sum over are in the end of `a` and front of `b`.
+        #  2. Combine the legs `axes`-legs and other legs with a `np.reshape`,
+        #  such that `a` and `b` are matrices.
+        #  3. Perform a matrix product with `np.dot`.
+        #  4. Split the remaining axes with another `np.reshape` to obtain the correct shape.
+
+        #  The main work is done by `np.dot`, which calls LAPACK to perform the simple matrix product.
+        #  [This matrix multiplication of a ``NxK`` times ``KxM`` matrix is actually faster
+        #  than the O(N*K*M) needed by a naive implementation looping over the indices.]
+
+        #  We follow the same overall strategy data block entries.
+        #  Step 1) is performed by :meth:`_tdot_transpose_axes`
+
+        #  The steps 2) and 4) could be implemented with `combine_legs` and `split_legs`.
+        #  However, that would actually be an overkill: we're not interested
+        #  in the full charge data of the combined legs (which would be generated in the LegPipes).
+        #  Instead, we just need to track the block_inds of a and b carefully.
+
+        #  Our step 2) is implemented in :meth:`_tdot_pre_worker`:
+        #  We split `a.data.block_inds` into `a_block_inds_keep` and `a_block_inds_contr`, and similar for `b`.
+        #  Then, view `a` is a matrix :math:`A_{i,k1}` and `b` as :math:`B_{k2,j}`, where
+        #  `i` can be any row of `a_block_inds_keep`, `j` can be any row of `b_block_inds_keep`.
+        #  The `k1` and `k2` are rows/columns of `a/b_block_inds_contr`, which come from compatible dual legs.
+        #  In our storage scheme, `a.data.blocks[s]` then contains the block :math:`A_{i,k1}` for
+        #  ``j = a_block_inds_keep[s]`` and ``k1 = a_block_inds_contr[s]``.
+        #  To identify the different indices `i` and `j`, it is easiest to lexsort in the `s`.
+        #  Note that we give priority to the `{a,b}_block_inds_keep` over the `_contr`, such that
+        #  equal rows of `i` are contiguous in `a_block_inds_keep`.
+        #  Then, they are identified with :func:`find_row_differences`.
+
+        #  Now, the goal is to calculate the sums :math:`C_{i,j} = sum_k A_{i,k} B_{k,j}`,
+        #  analogous to step 3) above. This is implemented directly in this function.
+        #  It is done 'naively' by explicit loops over ``i``, ``j`` and ``k``.
+        #  However, this is not as bad as it sounds:
+        #  First, we loop only over existent ``i`` and ``j``
+        #  (in the sense that there is at least some non-zero block with these ``i`` and ``j``).
+        #  Second, if the ``i`` and ``j`` are not compatible with the new total charge,
+        #  we know that ``C_{i,j}`` will be zero.
+        #  Third, given ``i`` and ``j``, the sum over ``k`` runs only over
+        #  ``k1`` with nonzero :math:`A_{i,k1}`, and ``k2` with nonzero :math:`B_{k2,j}`.
+
+        #  How many multiplications :math:`A_{i,k} B_{k,j}` we actually have to perform
+        #  depends on the sparseness. If ``k`` comes from a single leg, it is completely sorted
+        #  by charges, so the 'sum' over ``k`` will contain at most one term!
+
+        # note: tensor.tdot() checks special-cases inner and outer, so it's at least a mat-vec
+        open_axs_a = [idx for idx in range(a.num_legs) if idx not in axs_a]
+        open_axs_b = [idx for idx in range(b.num_legs) if idx not in axs_b]
+        assert len(open_axs_a) > 0 or len(open_axs_b) > 0, "special case inner() in tensor.tdot()"
+        assert len(axs_a) > 0, "special case outer() in tensor.tdot()"
+
+        if len(a.data.blocks) == 0 or len(b.data.blocks) == 0:
+            dtype = a.data.dtype.common(b.data.dtype)
+            # TODO dont use legs! use conventional_leg_order
+            return self.zero_data([a.legs[i] for i in open_axs_a] + [b.legs[i] for i in open_axs_b], dtype, num_domain_legs=-666)
+
+        # for details on the implementation, see _tensordot_worker.
+        # Step 1: transpose if necessary:
+        a, b, contr_axes = self._tdot_transpose_axes(a, b, open_axs_a, axs_a, axs_b, open_axs_b)
+        # now we need to contract the last `contr_axes` of a with the first `contr_axes` of b
+
+        # Step 2:
+        cut_a = a.num_legs - contr_axes
+        cut_b = contr_axes
+        a_pre_result, b_pre_result, res_dtype = self._tdot_pre_worker(a, b, cut_a, cut_b)
+        a_blocks, a_block_inds_contr, a_block_inds_keep, a_shape_keep = a_pre_result
+        b_blocks, b_block_inds_contr, b_block_inds_keep, b_shape_keep = b_pre_result
+
+        # Step 3) loop over column/row of the result
+        # TODO dont use legs! use conventional_leg_order / domain / codomain
+        sym = a.legs[0].symmetry
+        if cut_a > 0:
+            a_charges_keep = sym.multiple_fusion_broadcast(
+                # TODO dont use legs! use conventional_leg_order / domain / codomain
+                *(leg.sectors[i] for leg, i in zip(a.legs[:cut_a], a_block_inds_keep.T))
+            )
+        else:
+            a_charges_keep = np.zeros((len(a_block_inds_keep), sym.sector_ind_len), int)
+        if cut_b < b.num_legs:
+            b_charges_keep_dual = sym.multiple_fusion_broadcast(
+                # TODO dont use legs! use conventional_leg_order / domain / codomain
+                *(leg.dual.sectors[i] for leg, i in zip(b.legs[cut_b:], b_block_inds_keep.T))
+            )
+        else:
+            b_charges_keep_dual = np.zeros((len(b_block_inds_keep), sym.sector_ind_len), int)
+        # dual such that b_charges_keep_dual must match a_charges_keep
+        a_lookup_charges = list_to_dict_list(a_charges_keep)  # lookup table ``charge -> [row_a]``
+
+        # (rows_a changes faster than cols_b, such that the resulting array is qdata lex-sorted)
+        # determine output qdata
+        res_blocks = []
+        res_block_inds_a = []
+        res_block_inds_b = []
+        for col_b, charge_match in enumerate(b_charges_keep_dual):
+            b_blocks_in_col = b_blocks[col_b]
+            rows_a = a_lookup_charges.get(tuple(charge_match), [])  # empty list if no match
+            for row_a in rows_a:
+                ks = iter_common_sorted(a_block_inds_contr[row_a], b_block_inds_contr[col_b])
+                if len(ks) == 0:
+                    continue
+                a_blocks_in_row = a_blocks[row_a]
+                k1, k2 = ks[0]
+                block_contr = self.matrix_dot(a_blocks_in_row[k1], b_blocks_in_col[k2])
+                for k1, k2 in ks[1:]:
+                    block_contr = block_contr + self.matrix_dot(a_blocks_in_row[k1],
+                                                                b_blocks_in_col[k2])
+
+                # Step 4) reshape back to tensors
+                block_contr = self.block_reshape(block_contr, a_shape_keep[row_a] + b_shape_keep[col_b])
+                res_blocks.append(block_contr)
+                res_block_inds_a.append(a_block_inds_keep[row_a])
+                res_block_inds_b.append(b_block_inds_keep[col_b])
+        if len(res_blocks) == 0:
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            return self.zero_data(a.legs[:cut_a] + b.legs[cut_b:], num_domain_legs=-666, dtype=res_dtype)
+        block_inds = np.hstack((res_block_inds_a, res_block_inds_b))
+        return AbelianBackendData(res_dtype, res_blocks, block_inds, is_sorted=True)
+
+    def to_dense_block(self, a: SymmetricTensor) -> Block:
+        res = self.zero_block(a.shape, a.data.dtype)
+        for block, b_i in zip(a.data.blocks, a.data.block_inds):
+            slices = tuple(slice(*leg.slices[i]) for i, leg in zip(b_i, conventional_leg_order(a)))
+            res[slices] = block
+        return self.apply_basis_perm(res, conventional_leg_order(a), inv=True)
+
+    def to_dense_block_trivial_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError  # TODO not yet reviewed
+        num_blocks = len(tensor.data.blocks)
+        if num_blocks == 1:
+            res = tensor.data.blocks[0]
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            if tensor.legs[0].basis_perm is not None:
+                # we need to find the permutation perm such that res[perm] == dense_data[some_mask]
+                # so far we have
+                # res == internal_data[slice] == dense_data[basis_perm][slice] == dense_data[basis_perm[slice]]
+                # thus dense_data[some_mask] == res[perm] == dense_data[basis_perm[slice][perm]]
+                # i.e. perm needs to sort basis_perm[slice]
+                # TODO dont use legs! use conventional_leg_order / domain / codomain
+                bi = tensor.legs[0].sectors_where(tensor.legs[0].symmetry.trivial_sector)
+                perm = np.argsort(tensor.legs[0].basis_perm[slice(*tensor.legs[0].slices[bi])])
+                res = self.apply_leg_permutations(res, [perm])
+            return res
+        elif num_blocks == 0:
+            dim = tensor.legs[0]._non_dual_sector_multiplicity(tensor.symmetry.trivial_sector)
+            # no need to consider basis_perm, since its all 0 anyway
+            return self.zero_block(shape=[dim], dtype=tensor.data.dtype)
+        raise ValueError  # this should not happen for single-leg tensors
+
+    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> Data:
+        # shallow copy if dtype stays same
+        blocks = [self.block_to_dtype(block, dtype) for block in a.data.blocks]
+        return AbelianBackendData(dtype, blocks, a.data.block_inds, is_sorted=True)
+
+    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]) -> float | complex:
+        raise NotImplementedError  # TODO not yet reviewed
+        a_blocks = a.data.blocks
+        a_block_inds_1 = a.data.block_inds[:, idcs1]
+        a_block_inds_2 = a.data.block_inds[:, idcs2]
+        total_sum = a.data.dtype.zero_scalar
+        for block, i1, i2 in zip(a_blocks, a_block_inds_1, a_block_inds_2):
+            # if len(idcs1) == 1, i1==i2 due to charge conservation,
+            # but for multi-dimensional indices not clear
+            if np.all(i1 == i2):
+                total_sum += self.block_trace_full(block, idcs1, idcs2)
+        return total_sum
+
+    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int], remaining_idcs: list[int]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
+        a_blocks = a.data.blocks
+        a_block_inds_1 = a.data.block_inds[:, idcs1]
+        a_block_inds_2 = a.data.block_inds[:, idcs2]
+        a_block_inds_rem = a.data.block_inds[:, remaining_idcs]
+        res_data = {}  # dictionary res_block_inds_row -> Block
+        for block, i1, i2, ir in zip(a_blocks, a_block_inds_1, a_block_inds_2, a_block_inds_rem):
+            if not np.all(i1 == i2):
+                continue
+            ir = tuple(ir)
+            block = self.block_trace_partial(block, idcs1, idcs2, remaining_idcs)
+            add_block = res_data.get(ir, None)
+            if add_block is not None:
+                block = block + add_block
+            res_data[ir] = block
+        res_blocks = list(res_data.values())
+        if len(res_blocks) == 0:
+            # TODO dont use legs! use conventional_leg_order / domain / codomain
+            return self.zero_data([a.legs[i] for i in remaining_idcs], dtype=a.data.dtype, num_domain_legs=-666)
+        res_block_inds = np.array(list(res_data.keys()), dtype=int)
+        return AbelianBackendData(a.data.dtype, res_blocks, res_block_inds, is_sorted=False)
+
+    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype
+                  ) -> AbelianBackendData:
+        block_inds = np.zeros((0, codomain.num_spaces + domain.num_spaces), dtype=int)
+        return AbelianBackendData(dtype, blocks=[], block_inds=block_inds, is_sorted=True)
+
+    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
+        return AbelianBackendData(dtype, blocks=[], block_inds=np.zeros((0, 2), dtype=int),
+                                  is_sorted=True)
+
+    # OPTIONAL OVERRIDES
+    
     def _fuse_spaces(self, symmetry: Symmetry, spaces: list[Space]
                      ) -> tuple[SectorArray, ndarray, dict]:
         r"""
@@ -365,375 +1586,35 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
             _, _, metadata = self._fuse_spaces(symmetry=leg.symmetry, spaces=leg.spaces)
             return metadata
         return {}
-            
-    def get_dtype_from_data(self, a: Data) -> Dtype:
-        return a.dtype
-
-    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> Data:
-        # shallow copy if dtype stays same
-        blocks = [self.block_to_dtype(block, dtype) for block in a.data.blocks]
-        return AbelianBackendData(dtype, blocks, a.data.block_inds, is_sorted=True)
-
-    def supports_symmetry(self, symmetry: Symmetry) -> bool:
-        return symmetry.is_abelian and symmetry.braiding_style == BraidingStyle.bosonic
-
-    def data_item(self, a: Data | DiagonalData) -> float | complex:
-        if len(a.blocks) > 1:
-            raise ValueError("More than 1 block!")
-        if len(a.blocks) == 0:
-            return a.dtype.zero_scalar
-        return self.block_item(a.blocks[0])
-
-    def to_dense_block(self, a: SymmetricTensor) -> Block:
-        res = self.zero_block(a.shape, a.data.dtype)
-        for block, b_i in zip(a.data.blocks, a.data.block_inds):
-            slices = tuple(slice(*leg.slices[i]) for i, leg in zip(b_i, conventional_leg_order(a)))
-            res[slices] = block
-        return self.apply_basis_perm(res, conventional_leg_order(a), inv=True)
-
-    def diagonal_to_block(self, a: DiagonalTensor) -> Block:
-        res = self.zero_block([a.leg.dim], a.dtype)
-        for block, b_i_0 in zip(a.data.blocks, a.data.block_inds[:, 0]):
-            res[slice(*a.leg.slices[b_i_0])] = block
-        return self.apply_basis_perm(res, [a.leg], inv=True)
-
-    def from_dense_block(self, a: Block, codomain: ProductSpace, domain: ProductSpace, tol: float
-                         ) -> AbelianBackendData:
-        a = self.apply_basis_perm(a, list(conventional_leg_order(codomain, domain)))
-        dtype = self.block_dtype(a)
-        projected = self.zero_block(self.block_shape(a), dtype=dtype)
-        block_inds = _valid_block_inds(codomain, domain)
-        blocks = []
-        for b_i in block_inds:
-            slices = tuple(slice(*leg.slices[i])
-                           for i, leg in zip(b_i, conventional_leg_order(codomain, domain)))
-            block = a[slices]
-            blocks.append(block)
-            projected[slices] = block
-        if tol is not None:
-            if self.block_norm(a - projected) > tol * self.block_norm(a):
-                raise ValueError('Block is not symmetric up to tolerance.')
-        return AbelianBackendData(dtype, blocks, block_inds, is_sorted=True)
-
-    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
-        leg = co_domain.spaces[0]
-        a = self.apply_basis_perm(a, co_domain.spaces)
-        dtype = self.block_dtype(a)
-        block_inds = np.repeat(np.arange(co_domain.num_sectors)[:, None], 2, axis=1)
-        blocks = [a[slice(*leg.slices[i])] for i in block_inds[:, 0]]
-        return AbelianBackendData(dtype, blocks, block_inds, is_sorted=True)
-
-    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
-        leg = co_domain.spaces[0]
-        block_inds = np.repeat(np.arange(leg.num_sectors)[:, None], 2, axis=1)
-        blocks = [func((mult,), coupled)
-                  for coupled, mult in zip(leg.sectors, leg.multiplicities)]
-        if len(blocks) == 0:
-            sample_block = func((1,), co_domain.symmetry.trivial_sector)
-        else:
-            sample_block = blocks[0]
-        dtype = self.block_dtype(sample_block)
-        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
-
-    def diagonal_all(self, a: DiagonalTensor) -> bool:
-        raise NotImplementedError
-
-    def diagonal_any(self, a: DiagonalTensor) -> bool:
-        raise NotImplementedError
-
-    def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace
-                        ) -> DiagonalData:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO thoroughly test this!
-        a = self.block_to_dtype(a, Dtype.bool)
-        a = self.apply_basis_perm(a, [large_leg])
-        blocks = []
-        block_inds = []
-        bi_small = 0
-        for bi_large, slc in enumerate(large_leg.slices):
-            block = a[slice(*slc)]
-            if self.block_sum_all(block) == 0:
-                continue
-            # TODO remove this check after testing
-            assert all(large_leg.sectors[bi_large] == small_leg.sectors[bi_small])
-            blocks.append(block)
-            block_inds.append([bi_large, bi_small])
-            bi_small += 1
-        if len(block_inds) == 0:
-            block_inds = np.zeros(shape=(0, 2), dtype=int)
-        else:
-            block_inds = np.array(block_inds, dtype=int)
-
-        # TODO remove this check after testing
-        if len(block_inds) > 0:
-            perm = np.lexsort(block_inds.T)
-            assert np.all(perm == np.arange(len(perm)))
-
-        return AbelianBackendData(dtype=Dtype.bool, blocks=blocks, block_inds=block_inds,
-                                  is_sorted=True)
-
-    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
         
-    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
+    # INTERNAL HELPERS
+    
+    def product_space_map_incoming_block_inds(self, space: ProductSpace, incoming_block_inds):
+        """Map incoming block indices to indices of :attr:`_block_ind_map`.
 
-    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError  # TODO
+        Needed for `combine_legs`.
 
-    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> Data:
-        """Generate tensor data from a function ``func(shape: tuple[int], coupled: Sector) -> Block``."""
-        block_inds = _valid_block_inds(codomain=codomain, domain=domain)
-        M = codomain.num_spaces
-        blocks = []
-        for b_i in block_inds:
-            shape = [leg.multiplicities[i]
-                     for i, leg in zip(b_i, conventional_leg_order(codomain, domain))]
-            coupled = codomain.symmetry.multiple_fusion(
-                *(leg.sectors[i] for i, leg in zip(b_i, codomain.spaces))
-            )
-            blocks.append(func(shape, coupled))
-        if len(blocks) == 0:
-            sample_block = func((1,) * (M + domain.num_spaces), codomain.symmetry.trivial_sector)
-        else:
-            sample_block = blocks[0]
-        dtype = self.block_dtype(sample_block)
-        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
+        Parameters
+        ----------
+        space : ProductSpace
+            The ProductSpace which indices are to be mapped
+        incoming_block_inds : 2D array
+            Rows are block indices :math:`(i_1, i_2, ... i_{nlegs})` for incoming legs.
 
-    def from_random_normal(self, codomain: ProductSpace, domain: ProductSpace, sigma: float,
-                           dtype: Dtype) -> Data:
-        raise NotImplementedError  # TODO
-
-    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype
-                  ) -> AbelianBackendData:
-        block_inds = np.zeros((0, codomain.num_spaces + domain.num_spaces), dtype=int)
-        return AbelianBackendData(dtype, blocks=[], block_inds=block_inds, is_sorted=True)
-
-    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
-        return AbelianBackendData(dtype, blocks=[], block_inds=np.zeros((0, 2), dtype=int),
-                                  is_sorted=True)
-
-    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> Data:
-        # Note: the identity has the same matrix elements in all ONB, so ne need to consider
-        #       the basis perms.
-        # results[i1,...im,jm,...,j1] = delta_{i1,j1} ... delta{im,jm}
-        # need exactly the "diagonal" blocks, where sector of i1 matches the one of j1 etc.
-        # to guarantee sorting later, it is easier to generate the block inds of the domain
-        domain_dims = [leg.num_sectors for leg in reversed(co_domain.spaces)]
-        domain_block_inds = np.indices(domain_dims).T.reshape(-1, co_domain.num_spaces)
-        block_inds = np.hstack([domain_block_inds[:, ::-1], domain_block_inds])
-        # domain_block_inds is by construction np.lexsort( .T)-ed.
-        # since the last co_domain.num_spaces columns of block_inds are already unique, the first
-        # columns are not relevant to np.lexsort( .T)-ing, thus the block_inds above is sorted.
-        blocks = []
-        for b_i in block_inds:
-            shape = [leg.multiplicities[i] for leg, i in zip(co_domain.spaces, b_i)]
-            blocks.append(self.eye_block(shape, dtype))
-        return AbelianBackendData(dtype, blocks, block_inds, is_sorted=True)
-
-    def copy_data(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
-        blocks = [self.block_copy(b) for b in self.blocks]
-        return AbelianBackendData(a.data.dtype, blocks, a.data.block_inds.copy(), is_sorted=True)
-
-    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int, max_lines: int):
+        Returns
+        -------
+        block_inds: 1D array
+            For each row j of `incoming_block_inds` an index `J` such that
+            ``self.metadata['_block_ind_map'][J, 2:-1] == block_inds[j]``.
+        """
         raise NotImplementedError  # TODO not yet reviewed
-        from ..dummy_config import printoptions
-        from ..misc import join_as_many_as_possible
-        
-        data = a.data
-        if len(data.blocks) == 0:
-            return [f'{indent}* Data : no non-zero blocks']
-        if max_lines <= 1:
-            return [f'{indent}* Data : Showing none of {len(data.blocks):d} blocks']
-
-        line_start = f'{indent}* Data for sectors '
-
-        if not printoptions.summarize_blocks:
-            # try showing all blocks
-            lines = []
-            for block, block_inds in zip(data.blocks, data.block_inds):
-                sectors = join_as_many_as_possible(
-                    # TODO dont use legs! use conventional_leg_order
-                    [a.symmetry.sector_str(leg.sectors[i]) for leg, i in zip(a.legs, block_inds)],
-                    separator=', ', max_len=printoptions.linewidth - len(line_start) - 1
-                )
-                lines.append(f'{line_start}[{sectors}]:')
-                lines.extend(self._block_repr_lines(block,
-                                                    indent=indent + printoptions.indent * ' ',
-                                                    max_width=max_width,
-                                                    max_lines=max_lines))
-                if len(lines) > max_lines:
-                    break
-            else:  # (no break ocurred)
-                return lines
-            
-
-        # try showing shapes of all blocks
-        lines = []
-        for block, block_inds in zip(data.blocks, data.block_inds):
-            sectors = join_as_many_as_possible(
-                # TODO dont use legs! use conventional_leg_order
-                [a.symmetry.sector_str(leg.sectors[i]) for leg, i in zip(a.legs, block_inds)],
-                separator=', ', max_len=printoptions.linewidth - len(line_start) - 1
-            )
-            shape = str(self.block_shape(block))
-            if len(line_start) + len(sectors) + 10 + len(shape) <= printoptions.linewidth:
-                lines.append(f'{line_start}[{sectors}]: shape {shape}')
-            else:
-                lines.append(f'{line_start}[{sectors}]: shape {shape}')
-                lines.append(f'{indent}    shape {shape}')
-            if len(lines) > max_lines:
-                break
-        else:  # (no break ocurred)
-            return lines
-
-        # only show shapes of largest blocks
-        lines = []
-        sizes = np.prod([self.block_shape(block) for block in data.blocks], axis=1)
-        missing_blocks = len(a.data.blocks)
-        for j in np.argsort(sizes):
-            sectors = join_as_many_as_possible(
-                [a.symmetry.sector_str(leg.sectors[i])
-                 # TODO dont use legs! use conventional_leg_order
-                 for leg, i in zip(a.legs, a.data.block_inds[j])],
-                separator=', ', max_len=printoptions.linewidth - len(line_start) - 1
-            )
-            shape = str(self.block_shape(a.data.blocks[j]))
-            if len(line_start) + len(sectors) + 10 + len(shape) <= printoptions.linewidth:
-                new_lines = [f'{line_start}[{sectors}]: shape {shape}']
-            else:
-                new_lines = [f'{line_start}[{sectors}]: shape {shape}',
-                             f'{indent}    shape {shape}']
-            if len(lines) + len(new_lines) >= max_lines:
-                lines.append(f'{indent}* Data for {missing_blocks} smaller blocks not shown')
-                return lines
-            lines.extend(new_lines)
-            missing_blocks -= 1
-
-        raise ValueError  # the above return should have triggered
-
-    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int], axs_b: list[int]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        #  Looking at the source of numpy's tensordot (which is just 62 lines of python code),
-        #  you will find that it has the following strategy:
-
-        #  1. Transpose `a` and `b` such that the axes to sum over are in the end of `a` and front of `b`.
-        #  2. Combine the legs `axes`-legs and other legs with a `np.reshape`,
-        #  such that `a` and `b` are matrices.
-        #  3. Perform a matrix product with `np.dot`.
-        #  4. Split the remaining axes with another `np.reshape` to obtain the correct shape.
-
-        #  The main work is done by `np.dot`, which calls LAPACK to perform the simple matrix product.
-        #  [This matrix multiplication of a ``NxK`` times ``KxM`` matrix is actually faster
-        #  than the O(N*K*M) needed by a naive implementation looping over the indices.]
-
-        #  We follow the same overall strategy data block entries.
-        #  Step 1) is performed by :meth:`_tdot_transpose_axes`
-
-        #  The steps 2) and 4) could be implemented with `combine_legs` and `split_legs`.
-        #  However, that would actually be an overkill: we're not interested
-        #  in the full charge data of the combined legs (which would be generated in the LegPipes).
-        #  Instead, we just need to track the block_inds of a and b carefully.
-
-        #  Our step 2) is implemented in :meth:`_tdot_pre_worker`:
-        #  We split `a.data.block_inds` into `a_block_inds_keep` and `a_block_inds_contr`, and similar for `b`.
-        #  Then, view `a` is a matrix :math:`A_{i,k1}` and `b` as :math:`B_{k2,j}`, where
-        #  `i` can be any row of `a_block_inds_keep`, `j` can be any row of `b_block_inds_keep`.
-        #  The `k1` and `k2` are rows/columns of `a/b_block_inds_contr`, which come from compatible dual legs.
-        #  In our storage scheme, `a.data.blocks[s]` then contains the block :math:`A_{i,k1}` for
-        #  ``j = a_block_inds_keep[s]`` and ``k1 = a_block_inds_contr[s]``.
-        #  To identify the different indices `i` and `j`, it is easiest to lexsort in the `s`.
-        #  Note that we give priority to the `{a,b}_block_inds_keep` over the `_contr`, such that
-        #  equal rows of `i` are contiguous in `a_block_inds_keep`.
-        #  Then, they are identified with :func:`find_row_differences`.
-
-        #  Now, the goal is to calculate the sums :math:`C_{i,j} = sum_k A_{i,k} B_{k,j}`,
-        #  analogous to step 3) above. This is implemented directly in this function.
-        #  It is done 'naively' by explicit loops over ``i``, ``j`` and ``k``.
-        #  However, this is not as bad as it sounds:
-        #  First, we loop only over existent ``i`` and ``j``
-        #  (in the sense that there is at least some non-zero block with these ``i`` and ``j``).
-        #  Second, if the ``i`` and ``j`` are not compatible with the new total charge,
-        #  we know that ``C_{i,j}`` will be zero.
-        #  Third, given ``i`` and ``j``, the sum over ``k`` runs only over
-        #  ``k1`` with nonzero :math:`A_{i,k1}`, and ``k2` with nonzero :math:`B_{k2,j}`.
-
-        #  How many multiplications :math:`A_{i,k} B_{k,j}` we actually have to perform
-        #  depends on the sparseness. If ``k`` comes from a single leg, it is completely sorted
-        #  by charges, so the 'sum' over ``k`` will contain at most one term!
-
-        # note: tensor.tdot() checks special-cases inner and outer, so it's at least a mat-vec
-        open_axs_a = [idx for idx in range(a.num_legs) if idx not in axs_a]
-        open_axs_b = [idx for idx in range(b.num_legs) if idx not in axs_b]
-        assert len(open_axs_a) > 0 or len(open_axs_b) > 0, "special case inner() in tensor.tdot()"
-        assert len(axs_a) > 0, "special case outer() in tensor.tdot()"
-
-        if len(a.data.blocks) == 0 or len(b.data.blocks) == 0:
-            dtype = a.data.dtype.common(b.data.dtype)
-            # TODO dont use legs! use conventional_leg_order
-            return self.zero_data([a.legs[i] for i in open_axs_a] + [b.legs[i] for i in open_axs_b], dtype, num_domain_legs=-666)
-
-        # for details on the implementation, see _tensordot_worker.
-        # Step 1: transpose if necessary:
-        a, b, contr_axes = self._tdot_transpose_axes(a, b, open_axs_a, axs_a, axs_b, open_axs_b)
-        # now we need to contract the last `contr_axes` of a with the first `contr_axes` of b
-
-        # Step 2:
-        cut_a = a.num_legs - contr_axes
-        cut_b = contr_axes
-        a_pre_result, b_pre_result, res_dtype = self._tdot_pre_worker(a, b, cut_a, cut_b)
-        a_blocks, a_block_inds_contr, a_block_inds_keep, a_shape_keep = a_pre_result
-        b_blocks, b_block_inds_contr, b_block_inds_keep, b_shape_keep = b_pre_result
-
-        # Step 3) loop over column/row of the result
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        sym = a.legs[0].symmetry
-        if cut_a > 0:
-            a_charges_keep = sym.multiple_fusion_broadcast(
-                # TODO dont use legs! use conventional_leg_order / domain / codomain
-                *(leg.sectors[i] for leg, i in zip(a.legs[:cut_a], a_block_inds_keep.T))
-            )
-        else:
-            a_charges_keep = np.zeros((len(a_block_inds_keep), sym.sector_ind_len), int)
-        if cut_b < b.num_legs:
-            b_charges_keep_dual = sym.multiple_fusion_broadcast(
-                # TODO dont use legs! use conventional_leg_order / domain / codomain
-                *(leg.dual.sectors[i] for leg, i in zip(b.legs[cut_b:], b_block_inds_keep.T))
-            )
-        else:
-            b_charges_keep_dual = np.zeros((len(b_block_inds_keep), sym.sector_ind_len), int)
-        # dual such that b_charges_keep_dual must match a_charges_keep
-        a_lookup_charges = list_to_dict_list(a_charges_keep)  # lookup table ``charge -> [row_a]``
-
-        # (rows_a changes faster than cols_b, such that the resulting array is qdata lex-sorted)
-        # determine output qdata
-        res_blocks = []
-        res_block_inds_a = []
-        res_block_inds_b = []
-        for col_b, charge_match in enumerate(b_charges_keep_dual):
-            b_blocks_in_col = b_blocks[col_b]
-            rows_a = a_lookup_charges.get(tuple(charge_match), [])  # empty list if no match
-            for row_a in rows_a:
-                ks = iter_common_sorted(a_block_inds_contr[row_a], b_block_inds_contr[col_b])
-                if len(ks) == 0:
-                    continue
-                a_blocks_in_row = a_blocks[row_a]
-                k1, k2 = ks[0]
-                block_contr = self.matrix_dot(a_blocks_in_row[k1], b_blocks_in_col[k2])
-                for k1, k2 in ks[1:]:
-                    block_contr = block_contr + self.matrix_dot(a_blocks_in_row[k1],
-                                                                b_blocks_in_col[k2])
-
-                # Step 4) reshape back to tensors
-                block_contr = self.block_reshape(block_contr, a_shape_keep[row_a] + b_shape_keep[col_b])
-                res_blocks.append(block_contr)
-                res_block_inds_a.append(a_block_inds_keep[row_a])
-                res_block_inds_b.append(b_block_inds_keep[col_b])
-        if len(res_blocks) == 0:
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            return self.zero_data(a.legs[:cut_a] + b.legs[cut_b:], num_domain_legs=-666, dtype=res_dtype)
-        block_inds = np.hstack((res_block_inds_a, res_block_inds_b))
-        return AbelianBackendData(res_dtype, res_blocks, block_inds, is_sorted=True)
+        # TODO move this back to ProductSpace?
+        assert incoming_block_inds.shape[1] == len(space.spaces)
+        # calculate indices of _block_ind_map by using the appropriate strides
+        strides = space.get_metadata('_strides', backend=self)
+        inds_before_perm = np.sum(incoming_block_inds * strides[np.newaxis, :], axis=1)
+        # now permute them to indices in _block_ind_map
+        return inverse_permutation(space.fusion_outcomes_sort)[inds_before_perm]
 
     def _tdot_transpose_axes(self, a: SymmetricTensor, b: SymmetricTensor, open_axs_a, axs_a, axs_b, open_axs_b):
         contr_axes = len(axs_a)
@@ -837,885 +1718,3 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
         res = [[self.block_reshape(T, (np.prod(self.block_shape(T)[:cut]), -1)) for T in blocks]
                 for blocks in blocks_list]
         return res
-
-    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None, compute_u: bool,
-            compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
-        raise NotImplementedError  # TODO not yet reviewed
-        u_blocks = []
-        s_blocks = []
-        vh_blocks = []
-        for block in a.data.blocks:
-            u, s, vh = self.matrix_svd(block, algorithm=algorithm, compute_u=compute_u, compute_vh=compute_vh)
-            u_blocks.append(u)
-            s_blocks.append(s)
-            assert len(s) > 0
-            vh_blocks.append(vh)
-
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        leg_L, leg_R = a.legs
-        symmetry = a.legs[0].symmetry
-        block_inds_L, block_inds_R = a.data.block_inds.T  # columns of block_inds
-        # due to lexsort(a.data.block_inds.T), block_inds_R is sorted, but block_inds_L not.
-
-        # build new leg: add sectors in the order given by block_inds_R, which is sorted
-        leg_C_sectors = leg_R.sectors[block_inds_R]
-        # economic SVD (aka full_matrices=False) : len(s) = min(block.shape)
-        leg_C_mults = np.minimum(leg_L.multiplicities[block_inds_L], leg_R.multiplicities[block_inds_R])
-        block_inds_C = np.arange(len(s_blocks), dtype=int)
-        raise NotImplementedError  # TODO revise. duality.
-        # if new_vh_leg_dual != leg_R.is_dual:
-        #     # opposite dual flag in legs of vH => same _sectors
-        #     new_leg = Vector_Space(symmetry, leg_C_sectors, leg_C_mults, is_real=leg_R.is_real, _is_dual=new_vh_leg_dual)
-        # else:  # new_vh_leg_dual == leg_R.is_dual
-        #     # same dual flag in legs of vH => opposite _sectors => opposite sorting!!!
-        #     leg_C_sectors = symmetry.dual_sectors(leg_C_sectors)  # not sorted
-        #     sort = np.lexsort(leg_C_sectors.T)
-        #     block_inds_C = block_inds_C[sort]
-        #     new_leg = Vector_Space(symmetry, leg_C_sectors[sort], leg_C_mults[sort], is_real=leg_R.is_real, _is_dual=new_vh_leg_dual)
-            
-        u_block_inds = np.column_stack([block_inds_L, block_inds_C])
-        s_block_inds = np.repeat(block_inds_C[:, None], 2, axis=1)
-        vh_block_inds = np.column_stack([block_inds_C, block_inds_R])
-        if new_vh_leg_dual == leg_R.is_dual:
-            # need to sort u_block_inds and s_block_inds
-            # since we lexsort with last column changing slowest, we need to sort block_inds_C only
-            sort = np.argsort(block_inds_C)
-            u_block_inds = u_block_inds[sort, :]
-            s_block_inds = s_block_inds[sort, :]
-            u_blocks = [u_blocks[i] for i in sort]
-            s_blocks = [s_blocks[i] for i in sort]
-        dtype = a.data.dtype
-        if compute_u:
-            u_data = AbelianBackendData(dtype, u_blocks, u_block_inds, is_sorted=True)
-        else:
-            u_data = None
-        s_data = AbelianBackendData(dtype.to_real, s_blocks, s_block_inds, is_sorted=True)
-        if compute_vh:
-            vh_data = AbelianBackendData(dtype, vh_blocks, vh_block_inds, is_sorted=True)
-        else:
-            vh_data = None
-        return u_data, s_data, vh_data, new_leg
-
-    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        q_leg_0, r_leg_1 = a.legs
-        q_blocks = []
-        r_blocks = []
-        for block in a.data.blocks:
-            q, r = self.matrix_qr(block, full=full)
-            q_blocks.append(q)
-            r_blocks.append(r)
-        sym = a.symmetry
-        if full:
-            new_leg = q_leg_0.as_ElementarySpace()
-            if new_leg.is_dual != new_r_leg_dual:
-                # taking the dual leaves _non_sorted_dual_sectors unaffected and
-                # thus we dont need to adjust anything else
-                new_leg = new_leg.dual
-            # sort q_blocks
-            q_blocks_full = [None] * q_leg_0.num_sectors
-            for i, q in zip(a.data.block_inds[:, 0], q_blocks):
-                q_blocks_full[i] = q
-            if len(q_blocks) < q_leg_0.num_sectors:
-                # there is a block-column in `a` that is completely 0 and not in a.data.blocks
-                # so we need to add corresponding identity blocks in q to ensure q is unitary!
-                dtype = a.data.dtype
-                for i, q in enumerate(q_blocks_full):
-                    if q is None:
-                        q_blocks_full[i] = self.eye_block([q_leg_0.multiplicities[i]], dtype)
-            q_block_inds = np.repeat(np.arange(q_leg_0.num_sectors, dtype=int)[:, None], 2, axis=1)  # sorted
-            r_block_inds = a.data.block_inds.copy() # is already sorted...
-
-            q_data = AbelianBackendData(a.data.dtype, q_blocks_full, q_block_inds, is_sorted=True)
-            r_data = AbelianBackendData(a.data.dtype, r_blocks, r_block_inds, is_sorted=True)
-        else:
-            keep = a.data.block_inds[:, 0]
-
-            # fix the order of sectors on the new leg: by order of appearance in q_leg_0
-            keep_perm = np.argsort(keep)
-            keep_sorted = keep[keep_perm]  # this fixes the order! "by order of appearance in q_leg_0"
-
-            new_leg_sectors = q_leg_0.sectors[keep_sorted, :]  # this is lexsort(x.T)-ed
-            new_leg_mults = np.array([self.block_shape(q)[1] for q in q_blocks], int)[keep_perm]
-            raise NotImplementedError  # TODO review this. duality.
-            new_leg = ElementarySpace(sym, new_leg_sectors, new_leg_mults, is_real=q_leg_0.is_real,
-                                      _is_dual=new_r_leg_dual)
-
-            # determine block_inds for the new leg:
-            # for q_blocks[i], the relevant sector is the same as the sector on the 0 leg:
-            # q_leg_0.sectors[a.data.block_inds[i, 0]]
-            #  == q_leg_0.sectors[keep[i]]
-            #  == q_leg_0.sectors[keep_sorted[inv_keep_perm[i]]]
-            #  == new_leg_sectors[inv_keep_perm[i]]
-            #  == new_leg.sectors[inv_keep_perm[i]]
-            # Thus we have
-            new_block_inds = inverse_permutation(keep_perm)
-            
-            q_block_inds = np.hstack([keep[:, None], new_block_inds[:, None]])  # not sorted.
-            r_block_inds = np.hstack([new_block_inds[:, None], a.data.block_inds[:, 1:2]])  # lexsorted.
-            assert np.all(np.lexsort(r_block_inds.T) == np.arange(len(r_block_inds)))  # TODO remove test
-            q_data = AbelianBackendData(a.dtype, q_blocks, q_block_inds, is_sorted=False)
-            r_data = AbelianBackendData(a.dtype, r_blocks, r_block_inds, is_sorted=True)
-
-        return q_data, r_data, new_leg
-
-    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        res_dtype = a.data.dtype.common(b.data.dtype)
-        a_blocks = a.data.blocks
-        b_blocks = b.data.blocks
-        if a.data.dtype != res_dtype:
-            a_blocks = [self.block_to_dtype(T, res_dtype) for T in a_blocks]
-        if b.data.dtype != res_dtype:
-            b_blocks = [self.block_to_dtype(T, res_dtype) for T in b_blocks]
-        a_block_inds = a.data.block_inds
-        b_block_inds = b.data.block_inds
-        l_a, num_legs_a = a_block_inds.shape
-        l_b, num_legs_b = b_block_inds.shape
-        grid = np.indices([len(a_block_inds), len(b_block_inds)]).T.reshape(-1, 2)
-        # grid is lexsorted, with rows as all combinations of a/b block indices.
-        res_block_inds = np.empty((l_a * l_b, num_legs_a + num_legs_b), dtype=int)
-        res_block_inds[:, :num_legs_a] = a_block_inds[grid[:, 0]]
-        res_block_inds[:, num_legs_a:] = b_block_inds[grid[:, 1]]
-
-        res_blocks = [self.block_outer(a_blocks[i], b_blocks[j]) for i, j in grid]
-
-        # TODO (JU) are the block_inds actually sorted?
-        #  if yes: add comment explaining why, adjust argument below
-        return AbelianBackendData(res_dtype, res_blocks, res_block_inds, is_sorted=False)
-
-    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool, axs2: list[int] | None) -> complex:
-        raise NotImplementedError  # TODO not yet reviewed
-        # a.legs[i] to be contracted with b.legs[axs2[i]]
-        a_blocks = a.data.blocks
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        stride = make_stride([l.num_sectors for l in a.legs], cstyle=False)
-        a_block_inds = np.sum(a.data.block_inds * stride, axis=1)
-        if axs2 is not None:
-            # permute strides to match the label order on b:
-            # strides_for_a[i] == strides_for_b[axs2[i]]
-            stride[axs2] = stride.copy()
-        b_blocks = b.data.blocks
-        b_block_inds = np.sum(b.data.block_inds * stride, axis=1)
-        if axs2 is not None:
-            # we permuted the strides, so b_block_inds is no longer sorted
-            sort = np.argsort(b_block_inds)
-            b_block_inds = b_block_inds[sort]
-            b_blocks = [b_blocks[i] for i in sort]
-        res = [self.block_inner(a_blocks[i], b_blocks[j], do_conj=do_conj, axs2=axs2)
-               for i, j in iter_common_sorted(a_block_inds, b_block_inds)]
-        return np.sum(res)
-
-    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
-        # TODO decide signature of backend function
-        raise NotImplementedError  # TODO not yet reviewed
-        if permutation is None:
-            return a.data  # TODO copy?
-        blocks = a.data.blocks
-        blocks = [self.block_permute_axes(block, permutation) for block in a.data.blocks]
-        block_inds = a.data.block_inds[:, permutation]
-        data = AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=False)
-        return data
-
-    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]) -> float | complex:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_blocks = a.data.blocks
-        a_block_inds_1 = a.data.block_inds[:, idcs1]
-        a_block_inds_2 = a.data.block_inds[:, idcs2]
-        total_sum = a.data.dtype.zero_scalar
-        for block, i1, i2 in zip(a_blocks, a_block_inds_1, a_block_inds_2):
-            # if len(idcs1) == 1, i1==i2 due to charge conservation,
-            # but for multi-dimensional indices not clear
-            if np.all(i1 == i2):
-                total_sum += self.block_trace_full(block, idcs1, idcs2)
-        return total_sum
-
-    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int], remaining_idcs: list[int]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_blocks = a.data.blocks
-        a_block_inds_1 = a.data.block_inds[:, idcs1]
-        a_block_inds_2 = a.data.block_inds[:, idcs2]
-        a_block_inds_rem = a.data.block_inds[:, remaining_idcs]
-        res_data = {}  # dictionary res_block_inds_row -> Block
-        for block, i1, i2, ir in zip(a_blocks, a_block_inds_1, a_block_inds_2, a_block_inds_rem):
-            if not np.all(i1 == i2):
-                continue
-            ir = tuple(ir)
-            block = self.block_trace_partial(block, idcs1, idcs2, remaining_idcs)
-            add_block = res_data.get(ir, None)
-            if add_block is not None:
-                block = block + add_block
-            res_data[ir] = block
-        res_blocks = list(res_data.values())
-        if len(res_blocks) == 0:
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            return self.zero_data([a.legs[i] for i in remaining_idcs], dtype=a.data.dtype, num_domain_legs=-666)
-        res_block_inds = np.array(list(res_data.keys()), dtype=int)
-        return AbelianBackendData(a.data.dtype, res_blocks, res_block_inds, is_sorted=False)
-
-    def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_blocks = a.data.blocks
-        total_sum = a.data.dtype.zero_scalar
-        for block in a_blocks:
-            total_sum += self.block_sum_all(block)
-        return total_sum
-
-    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
-        raise NotImplementedError  # TODO not yet reviewed
-        blocks = [self.block_conj(b) for b in a.data.blocks]
-        return AbelianBackendData(a.data.dtype, blocks, a.data.block_inds, is_sorted=True)
-
-    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int], product_spaces: list[ProductSpace],
-                     new_axes: list[int], final_legs: list[Space]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        res_dtype = a.data.dtype
-        old_block_inds = a.data.block_inds
-        # first, find block indices of the final array to which we map
-        map_inds = [self.product_space_map_incoming_block_inds(product_space, old_block_inds[:, b:e])
-                    for product_space, (b,e) in zip(product_spaces, combine_slices)]
-        old_block_inds = a.data.block_inds
-        old_blocks = a.data.blocks
-        res_block_inds = np.empty((len(old_block_inds), len(final_legs)), dtype=int)
-        last_e = 0
-        last_i = -1
-        for i, (b, e), product_space, map_ind in zip(new_axes, combine_slices, product_spaces, map_inds):
-            res_block_inds[:, last_i + 1:i] = old_block_inds[:, last_e:b]
-            block_ind_map = product_space.get_metadata('_block_ind_map', backend=self)
-            res_block_inds[:, i] = block_ind_map[map_ind, -1]
-            last_e = e
-            last_i = i
-        res_block_inds[:, last_i + 1:] = old_block_inds[:, last_e:]
-
-        # now we have probably many duplicate rows in res_block_inds, since many combinations of
-        # non-combined block indices map to the same block index in product space
-        # -> find unique entries by sorting res_block_inds
-        sort = np.lexsort(res_block_inds.T)
-        res_block_inds = res_block_inds[sort]
-        old_blocks = [old_blocks[i] for i in sort]
-        map_inds = [map_[sort] for map_ in map_inds]
-
-        # determine slices in the new blocks
-        block_slices = np.zeros((len(old_blocks), len(final_legs), 2), int)
-        block_shape = np.empty((len(old_blocks), len(final_legs)), int)
-        for i, leg in enumerate(final_legs):  # legs not in new_axes
-            if i not in new_axes:
-                # block_slices[:, i, 0] = 0
-                block_slices[:, i, 1] = block_shape[:, i] = leg.multiplicities[res_block_inds[:, i]]
-        for i, product_space, map_ind in zip(new_axes, product_spaces, map_inds):  # legs in new_axes
-            block_ind_map = product_space.get_metadata('_block_ind_map', backend=self)
-            slices = block_ind_map[map_ind, :2]
-            block_slices[:, i, :] = slices
-            block_shape[:, i] = slices[:, 1] - slices[:, 0]
-
-        # split res_block_inds into parts, which give a unique new blocks
-        diffs = find_row_differences(res_block_inds, include_len=True)  # including 0 and len to have slices later
-        res_num_blocks = len(diffs) - 1
-        res_block_inds = res_block_inds[diffs[:res_num_blocks], :]
-        res_block_shapes = np.empty((res_num_blocks, len(final_legs)), int)
-        for i, leg in enumerate(final_legs):
-            res_block_shapes[:, i] = leg.multiplicities[res_block_inds[:, i]]
-
-        # now the hard part: map data
-        res_blocks = []
-        # iterate over ranges of equal qindices in qdata
-        for res_block_shape, beg, end in zip(res_block_shapes, diffs[:-1], diffs[1:]):
-            new_block = self.zero_block(res_block_shape, dtype=res_dtype)
-            for old_row in range(beg, end):  # copy blocks
-                shape = block_shape[old_row]  # this has multiplied dimensions for combined legs
-                old_block = self.block_reshape(old_blocks[old_row], shape)
-                new_slices = tuple(slice(b, e) for b, e in block_slices[old_row])
-
-                new_block[new_slices] = old_block  # actual data copy
-
-            res_blocks.append(new_block)
-
-        # we lexsort( .T)-ed res_block_inds while it still had duplicates, and then indexed by diffs,
-        # which is sorted and thus preserves lexsort( .T)-ing of res_block_inds
-        return AbelianBackendData(res_dtype, res_blocks, res_block_inds, is_sorted=True)
-
-    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int], final_legs: list[Space]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO (JH) below, we implement it by first generating the block_inds of the splitted tensor and
-        # then extract subblocks from the original one.
-        # Why not go the other way around and implement
-        # block_views = self.block_split(block, block_sizes, axis) similar as np.array_split()
-        # and call that for each axis to be split for each block?
-        # we do a lot of numpy index tricks below, but does that really save time for splitting?
-        # block_split should just be views anyways, not data copies?
-
-        if len(a.data.blocks) == 0:
-            return self.zero_data(final_legs, a.data.dtype)
-        n_split = len(leg_idcs)
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        product_spaces = [a.legs[i] for i in leg_idcs]
-        res_num_legs = len(final_legs)
-
-        old_blocks = a.data.blocks
-        old_block_inds = a.data.block_inds
-
-        map_slices_beg = np.zeros((len(old_blocks), n_split), int)
-        map_slices_shape = np.zeros((len(old_blocks), n_split), int)  # = end - beg
-        for j, product_space in enumerate(product_spaces):
-            block_inds_j = old_block_inds[:, leg_idcs[j]]
-            block_ind_map_slices = product_space.get_metadata('_block_ind_map_slices', backend=self)
-            map_slices_beg[:, j] = block_ind_map_slices[block_inds_j]
-            sizes = block_ind_map_slices[1:] - block_ind_map_slices[:-1]
-            map_slices_shape[:, j] = sizes[block_inds_j]
-        new_data_blocks_per_old_block = np.prod(map_slices_shape, axis=1)
-
-        old_rows = np.concatenate([np.full((s,), i, int) for i, s in enumerate(new_data_blocks_per_old_block)])
-        res_num_blocks = len(old_rows)
-
-        map_rows = []
-        for beg, shape in zip(map_slices_beg, map_slices_shape):
-            map_rows.append(np.indices(shape, int).reshape(n_split, -1).T + beg[np.newaxis, :])
-        map_rows = np.concatenate(map_rows, axis=0)  # shape (res_num_blocks, n_split)
-
-        # generate new block_inds and figure out slices within old blocks to be extracted
-        new_block_inds = np.empty((res_num_blocks, res_num_legs), dtype=int)
-        old_block_beg = np.zeros((res_num_blocks, a.num_legs), dtype=int)
-        old_block_shapes = np.empty((res_num_blocks, a.num_legs), dtype=int)
-        shift = 0  #  = i - k for indices below
-        j = 0  # index within product_spaces
-        for i in range(a.num_legs):  # i = index in old tensor
-            if i in leg_idcs:
-                product_space = product_spaces[j]  # = a.legs[i]
-                k = i + shift  # = index where split legs begin in new tensor
-                k2 = k + len(product_space.spaces)  # = until where spaces go in new tensor
-                _block_ind_map = product_space.get_metadata('_block_ind_map', backend=self)[map_rows[:, j], :]
-                new_block_inds[:, k:k2] = _block_ind_map[:, 2:-1]
-                old_block_beg[:, i] = _block_ind_map[:, 0]
-                old_block_shapes[:, i] = _block_ind_map[:, 1] - _block_ind_map[:, 0]
-                shift += len(product_space.spaces) - 1
-                j += 1
-            else:
-                new_block_inds[:, i + shift] = nbi = old_block_inds[old_rows, i]
-                # TODO dont use legs! use conventional_leg_order / domain / codomain
-                old_block_shapes[:, i] = a.legs[i].multiplicities[nbi]
-        # sort new_block_inds
-        # OPTIMIZE (JU) could also skip sorting here and put is_sorted=False in AbelianBackendData(..) below?
-        sort = np.lexsort(new_block_inds.T)
-        new_block_inds = new_block_inds[sort, :]
-        old_block_beg = old_block_beg[sort]
-        old_block_shapes = old_block_shapes[sort]
-        old_rows = old_rows[sort]
-
-        new_block_shapes = np.empty((res_num_blocks, res_num_legs), dtype=int)
-        for i, leg in enumerate(final_legs):
-            new_block_shapes[:, i] = leg.multiplicities[new_block_inds[:, i]]
-
-        # the actual loop to split the blocks
-        new_blocks = []
-        for i in range(res_num_blocks):
-            old_block = old_blocks[old_rows[i]]
-            slices = tuple(slice(b, b + s) for b, s in zip(old_block_beg[i], old_block_shapes[i]))
-            new_block = old_block[slices]
-            new_blocks.append(self.block_reshape(new_block, new_block_shapes[i]))
-
-        return AbelianBackendData(a.data.dtype, new_blocks, new_block_inds, is_sorted=True)
-
-    def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
-                        co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
-                        ) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        blocks = [self.block_add_axis(block, pos) for block in a.data.blocks]
-        block_inds = np.insert(a.data.block_inds, pos, 0, axis=1)
-        # since the new column is constant, block_inds are still sorted.
-        return AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=True)
-
-    def almost_equal(self, a: SymmetricTensor, b: SymmetricTensor, rtol: float, atol: float) -> bool:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_blocks = a.data.blocks
-        b_blocks = b.data.blocks
-        for i, j in iter_common_noncommon_sorted_arrays(a.data.block_inds, b.data.block_inds):
-            if j is None:
-                if self.block_max_abs(a_blocks[i]) > atol:
-                    return False
-            elif i is None:
-                if self.block_max_abs(b_blocks[j]) > atol:
-                    return False
-            else:
-                if not self.block_allclose(a_blocks[i], b_blocks[j], rtol=rtol, atol=atol):
-                    return False
-        return True
-
-    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        n_legs = a.num_legs
-        if len(a.data.blocks) == 0:
-            block_inds = np.zeros([0, n_legs - len(idcs)], dtype=int)
-            return AbelianBackendData(a.data.dtype, [], block_inds, is_sorted=True)
-        blocks = [self.block_squeeze_legs(b, idcs) for b in a.data.blocks]
-        block_inds = a.data.block_inds
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        symmetry = a.legs[0].symmetry
-        sector = symmetry.trivial_sector
-        for i in idcs:
-            bi = block_inds[0, i]
-            assert np.all(block_inds[:, i] == bi)
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            sector = symmetry.fusion_outcomes(sector, a.legs[i].sector(bi))[0]
-        if not np.all(sector == symmetry.trivial_sector):
-            # TODO return corresponding ChargedTensor instead in this case?
-            raise ValueError("Squeezing legs drops non-trivial charges, would give ChargedTensor.")
-        keep = np.ones(n_legs, dtype=bool)
-        keep[idcs] = False
-        block_inds = block_inds[:, keep]
-        return AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=True)
-
-    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
-        block_norms = [self.block_norm(b, order=2) for b in a.data.blocks]
-        return np.linalg.norm(block_norms, ord=2)
-
-    def act_block_diagonal_square_matrix(self, a: SymmetricTensor, block_method: Callable[[Block], Block]
-                                         ) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_block_inds = a.data.block_inds
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        all_block_inds = np.repeat(np.arange(a.legs[0].num_sectors)[:, None], 2, axis=1)  # [[0, 0], [1, 1], ...]
-        res_blocks = []
-        for i, j in iter_common_noncommon_sorted_arrays(a_block_inds, all_block_inds):
-            if i is None:
-                # use that all_block_inds is just ascending -> all_block_inds[j, 0] == j
-                # TODO dont use legs! use conventional_leg_order / domain / codomain
-                block = self.zero_block(shape=[a.legs[0].multiplicities[j]] * 2, dtype=a.dtype)
-            else:
-                block = a.data.blocks[i]
-            res_blocks.append(block_method(block))
-        dtype = Dtype.common(*(self.block_dtype(block) for block in res_blocks))
-        res_blocks = [self.block_to_dtype(block, dtype) for block in res_blocks]
-        return AbelianBackendData(dtype, res_blocks, all_block_inds, is_sorted=True)
-
-    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_blocks = a.data.blocks
-        b_blocks = b.data.blocks
-        a_block_inds = a.data.block_inds
-        b_block_inds = b.data.block_inds
-        # ensure common dtypes
-        common_dtype = a.dtype.common(b.dtype)
-        if a.data.dtype != common_dtype:
-            a_blocks = [self.block_to_dtype(T, common_dtype) for T in a_blocks]
-        if b.data.dtype != common_dtype:
-            b_blocks = [self.block_to_dtype(T, common_dtype) for T in b_blocks]
-        res_blocks = []
-        res_block_inds = []
-        for i, j in iter_common_noncommon_sorted_arrays(a_block_inds, b_block_inds):
-            if j is None:
-                res_blocks.append(a_blocks[i])
-                res_block_inds.append(a_block_inds[i])
-            elif i is None:
-                res_blocks.append(b_blocks[j])
-                res_block_inds.append(b_block_inds[j])
-            else:
-                res_blocks.append(self.block_add(a_blocks[i], b_blocks[j]))
-                res_block_inds.append(a_block_inds[i])
-        if len(res_block_inds) > 0:
-            res_block_inds = np.array(res_block_inds)
-        else:
-            res_block_inds = np.zeros((0, a.num_legs), int)
-        return AbelianBackendData(common_dtype, res_blocks, res_block_inds, is_sorted=True)
-
-    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        if a == 0.:
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            return self.zero_data(b.legs, b.data.dtype, b.num_domain_legs)
-        blocks = [self.block_mul(a, T) for T in b.data.blocks]
-        if len(blocks) == 0:
-            if isinstance(a, float):
-                dtype = b.data.dtype
-            else:
-                dtype = b.data.dtype.to_complex
-        else:
-            dtype = self.block_dtype(blocks[0])
-        return AbelianBackendData(dtype, blocks, b.data.block_inds, is_sorted=True)
-
-    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False
-                  ) -> ElementarySpace:
-        raise NotImplementedError  # TODO not yet reviewed
-        raise NotImplementedError  # TODO
-        # TODO how to handle ChargedTensor vs Tensor?
-        #  JU: dont need to consider ChargedTensor here.
-        #      When e.g. a ChargedTensor classmethod wants to infer the charge, it should add a
-        #      one-dimensional axis to the block. then, this block is "uncharged", i.e. it will
-        #      become the ``invariant_part: Tensor`` of the ChargedTensor.
-        #      The "qtotal" is then the charge of the "artificial"/"dummy" leg.
-        
-        #  def detect_qtotal(flat_array, legcharges):
-        #      inds_max = np.unravel_index(np.argmax(np.abs(flat_array)), flat_array.shape)
-        #      val_max = abs(flat_array[inds_max])
-
-        #      test_array = zeros(legcharges)  # Array prototype with correct charges
-        #      qindices = [leg.get_qindex(i)[0] for leg, i in zip(legcharges, inds_max)]
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        #      q = np.sum([l.get_charge(qi) for l, qi in zip(self.legs, qindices)], axis=0)
-        #      return make_valid(q)  # TODO: leg.get_qindex, leg.get_charge
-
-    def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        pos = np.array([l.parse_index(idx) for l, idx in zip(a.legs, idcs)])
-        block = a.data.get_block(pos[:, 0])
-        if block is None:
-            return a.dtype.zero_scalar
-        return self.get_block_element(block, pos[:, 1])
-
-    def get_element_diagonal(self, a: DiagonalTensor, idx: int) -> complex | float | bool:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        block_idx, idx_within = a.legs[0].parse_index(idx)
-        block = a.data.get_block(np.array([block_idx]))
-        if block is None:
-            return a.dtype.zero_scalar
-        return self.get_block_element(block, [idx_within])
-            
-    def set_element(self, a: SymmetricTensor, idcs: list[int], value: complex | float) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        pos = np.array([l.parse_index(idx) for l, idx in zip(a.legs, idcs)])
-        n = a.data.get_block_num(pos[:, 0])
-        if n is None:
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            shape = [leg.multiplicities[sector_idx] for leg, sector_idx in zip(a.legs, pos[:, 0])]
-            block = self.zero_block(shape, dtype=a.dtype)
-        else:
-            block = a.data.blocks[n]
-        blocks = a.data.blocks[:]
-        blocks[n] = self.set_block_element(block, pos[:, 1], value)
-        return AbelianBackendData(dtype=a.data.dtype, blocks=blocks, block_inds=a.data.blocks_inds,
-                                  is_sorted=True)
-
-    def set_element_diagonal(self, a: DiagonalTensor, idx: int, value: complex | float | bool
-                             ) -> DiagonalData:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        block_idx, idx_within = a.legs[0].parse_index(idx)
-        n = a.data.get_block_num(np.array([block_idx]))
-        if n is None:
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            block = self.zero_block(shape=[a.legs[0].multiplicities[block_idx]], dtype=a.dtype)
-        else:
-            block = a.data.blocks[n]
-        blocks = a.data.blocks[:]
-        blocks[n] = self.set_block_element(block, [idx_within], value)
-        return AbelianBackendData(dtype=a.data.dtype, blocks=blocks, block_inds=a.data.blocks_inds,
-                                  is_sorted=True)
-
-    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
-        raise NotImplementedError  # TODO not yet reviewed
-        blocks = [self.block_get_diagonal(block, check_offdiagonal) for block in a.data.blocks]
-        return AbelianBackendData(a.dtype, blocks, a.data.block_inds, is_sorted=True)
-
-    def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        blocks = [self.block_from_diagonal(block) for block in a.data.blocks]
-        return AbelianBackendData(a.dtype, blocks, a.data.block_inds, is_sorted=True)
-
-    def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        blocks = [self.block_from_mask(block, dtype) for block in a.data.blocks]
-        return AbelianBackendData(dtype, blocks, a.data.block_inds, is_sorted=True)
-
-    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        a_blocks = a.data.blocks
-        b_blocks = b.data.blocks
-
-        a_block_inds = a.data.block_inds
-        a_block_inds_cont = a_block_inds[:, leg:leg+1]
-        if leg == a.num_legs - 1:
-            # due to lexsort(a_block_inds.T), a_block_inds_cont is sorted in this case
-            pass
-        else:
-            sort = np.lexsort(a_block_inds_cont.T)
-            a_blocks = [a_blocks[i] for i in sort]
-            a_block_inds = a_block_inds[sort, :]
-            a_block_inds_cont = a_block_inds_cont[sort, :]
-        b_block_inds = b.data.block_inds
-        
-        # ensure common dtypes
-        common_dtype = a.dtype.common(b.dtype)
-        if a.data.dtype != common_dtype:
-            a_blocks = [self.block_to_dtype(block, common_dtype) for block in a_blocks]
-        if b.data.dtype != common_dtype:
-            b_blocks = [self.block_to_dtype(block, common_dtype) for block in b_blocks]
-        
-        res_blocks = []
-        res_block_inds = []
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        # can assume that a.legs[leg] and b.legs[0] have same _sectors.
-        # only need to iterate over common blocks, the non-common multiply to 0.
-        # note: unlike the tdot implementation, we do not combine and reshape here.
-        #       this is because we know the result will have the same block-structure as `a`, and
-        #       we only need to scale the blocks on one axis, not perform a general tensordot.
-        #       but this also means that we may encounter duplicates in a_block_inds_cont,
-        #       i.e. multiple blocks of `a` which have the same sector on the leg to be scaled.
-        #       -> use iter_common_nonstrict_sorted_arrays instead of iter_common_sorted_arrays
-        for i, j in iter_common_nonstrict_sorted_arrays(a_block_inds_cont, b_block_inds[:, :1]):
-            res_blocks.append(self.block_scale_axis(a_blocks[i], b_blocks[j], axis=leg))
-            res_block_inds.append(a_block_inds[i])
-        if len(res_block_inds) > 0:
-            res_block_inds = np.array(res_block_inds)
-        else:
-            res_block_inds = np.zeros((0, a.num_legs), int)
-        
-        return AbelianBackendData(common_dtype, res_blocks, res_block_inds, is_sorted=True)
-    
-    def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs, maps_zero_to_zero: bool
-                                   ) -> DiagonalData:
-        a_blocks = a.data.blocks
-        if maps_zero_to_zero:
-            blocks = [func(block, **func_kwargs) for block in a.data.blocks]
-            block_inds = a.data.block_inds
-        else:
-            a_block_inds = a.data.block_inds
-            block_inds = np.repeat(np.arange(a.leg.num_sectors)[:, None], 2, axis=1)
-            blocks = []
-            for i, j in iter_common_noncommon_sorted_arrays(block_inds, a_block_inds):
-                if j is None:
-                    # use that block_inds is just arange -> block_inds[i, 0] == i
-                    block = self.zero_block([a.leg.multiplicities[i]], dtype=a.dtype)
-                else:
-                    block = a_blocks[j]
-                blocks.append(func(block, **func_kwargs))
-        if len(blocks) == 0:
-            dtype = self.block_dtype(func(self.zero_block([1], dtype=a.dtype)))
-        else:
-            dtype = self.block_dtype(blocks[0])
-        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
-
-    def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
-                                    func_kwargs, partial_zero_is_zero: bool
-                                    ) -> DiagonalData:
-        a_blocks = a.data.blocks
-        b_blocks = b.data.blocks
-        a_block_inds = a.data.block_inds
-        b_block_inds = b.data.block_inds
-        a_mults = a.leg.multiplicities
-        b_mults = b.leg.multiplicities
-        
-        blocks = []
-        block_inds = []
-        if partial_zero_is_zero:
-            for i, j in iter_common_sorted_arrays(a_block_inds, b_block_inds):
-                blocks.append(func(a_blocks[i], b_blocks[j], **func_kwargs))
-                block_inds.append(a_block_inds[i])
-        else:
-            for i, j in iter_common_noncommon_sorted_arrays(a_block_inds, b_block_inds):
-                if i is None:
-                    a_block = self.zero_block([b_mults[b_block_inds[j, 0]]], dtype=a.dtype)
-                    b_block = b_blocks[j]
-                    block_inds.append(b_block_inds[j])
-                elif j is None:
-                    a_block = a_blocks[i]
-                    b_block = self.zero_block([a_mults[a_block_inds[i, 0]]], dtype=b.dtype)
-                    block_inds.append(a_block_inds[i])
-                else:
-                    a_block = a_blocks[i]
-                    b_block = b_blocks[j]
-                    block_inds.append(a_block_inds[i])
-                blocks.append(func(a_block, b_block, **func_kwargs))
-        block_inds = np.array(block_inds)
-
-        if len(blocks) == 0:
-            block = func(self.ones_block([1], dtype=a.dtype), self.ones_block([1], dtype=b.dtype))
-            dtype = self.block_dtype(block)
-        else:
-            dtype = self.block_dtype(blocks[0])
-            
-        return AbelianBackendData(dtype=dtype, blocks=blocks, block_inds=block_inds, is_sorted=True)
-
-    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        # implementation similar to scale_axis, see notes there
-        tensor_blocks = tensor.data.blocks
-        mask_blocks = mask.data.blocks
-        tensor_block_inds = tensor.data.block_inds
-        tensor_block_inds_cont = tensor_block_inds[:, leg_idx:leg_idx + 1]
-        if leg_idx != tensor.num_legs - 1:
-            # due to np.lexsort(tensor_block_inds.T), only tensor_block_inds[:, -1] is sorted
-            sort = np.lexsort(tensor_block_inds_cont.T)
-            tensor_blocks = [tensor_blocks[i] for i in sort]
-            tensor_block_inds = tensor_block_inds[sort]
-            tensor_block_inds_cont = tensor_block_inds_cont[sort]
-        mask_block_inds = mask.data.block_inds
-        mask_block_inds_cont = mask_block_inds[:, 0:1]
-        sort = np.lexsort(mask_block_inds_cont.T)
-        mask_blocks = [mask_blocks[i] for i in sort]
-        mask_block_inds = mask_block_inds[sort]
-        mask_block_inds_cont = mask_block_inds_cont[sort]
-
-        res_blocks = []
-        res_block_inds = []
-        # need only common blocks : zeros masks to zero, and a missing mask block means all False
-        for i, j in iter_common_nonstrict_sorted_arrays(tensor_block_inds_cont, mask_block_inds_cont):
-            res_blocks.append(self.apply_mask_to_block(block=tensor_blocks[i], mask=mask_blocks[j], ax=leg_idx))
-            block_inds = tensor_block_inds[i].copy()
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            # tensor_block_inds[i] refer to mask.legs[0]._sectors
-            # need to adjust to refer to mask.legs[1]._sectors
-            block_inds[leg_idx] = mask_block_inds[j, 1]
-            res_block_inds.append(block_inds)
-        if len(res_block_inds) > 0:
-            res_block_inds = np.array(res_block_inds)
-        else:
-            res_block_inds = np.zeros((0, tensor.num_legs), int)
-        # OPTIMIZE (JU) block_inds might actually be sorted but i am not sure right now
-        return AbelianBackendData(tensor.dtype, res_blocks, res_block_inds, is_sorted=False)
-
-    def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
-        raise NotImplementedError  # TODO not yet reviewed
-        tensor_blocks = tensor.data.blocks
-        mask_blocks = mask.data.blocks
-        tensor_block_inds_cont = tensor.data.block_inds[:, :1]  # since tensor is Diagonal, this is sorted
-        mask_block_inds = mask.data.block_inds
-        mask_block_inds_cont = mask_block_inds[:, :1]
-        sort = np.lexsort(mask_block_inds_cont.T)
-        mask_blocks = [mask_blocks[i] for i in sort]
-        mask_block_inds = mask_block_inds[sort]
-        mask_block_inds_cont = mask_block_inds_cont[sort]
-        
-        res_blocks = []
-        res_block_inds = []  # gather only the entries of the first column in this list, repeat later
-        for i, j in iter_common_sorted_arrays(tensor_block_inds_cont, mask_block_inds_cont):
-            res_blocks.append(self.apply_mask_to_block(block=tensor_blocks[i], mask=mask_blocks[j], ax=0))
-            res_block_inds.append(mask_block_inds[j, 1])
-        if len(res_block_inds) > 0:
-            res_block_inds = np.repeat(np.array(res_block_inds)[:, None], 2, axis=1)
-        else:
-            res_block_inds = np.zeros((0, 2), int)
-        return AbelianBackendData(tensor.dtype, res_blocks, res_block_inds, is_sorted=True)
-
-    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
-        raise NotImplementedError  # TODO not yet reviewed
-        # for missing blocks, i.e. a zero block, the eigenvalues are zero, so we can just skip adding
-        # that block to the eigenvalues.
-        # for the eigenvectors, we choose the computational basis vectors, i.e. the matrix
-        # representation within that block is the identity matrix.
-        # we initialize all blocks to eye and override those where a has blocks.
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        eigvects_data = self.eye_data(legs=a.legs[0:1], dtype=a.dtype)
-        eigvals_blocks = []
-        for block, bi in zip(a.data.blocks, a.data.block_inds):
-            vals, vects = self.block_eigh(block, sort=sort)
-            eigvals_blocks.append(vals)
-            assert bi[0] == bi[1]  # TODO remove this check
-            eigvects_data.blocks[bi[0]] = vects
-        eigvals_data = AbelianBackendData(dtype=a.dtype.to_real, blocks=eigvals_blocks,
-                                          block_inds=a.data.block_inds, is_sorted=True)
-        return eigvals_data, eigvects_data
-
-    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        # need to consider basis_perm. see comment in to_dense_block_trivial_sector.
-        # here we need the inverse though
-        bi = leg.sectors_where(leg.symmetry.trivial_sector)
-        if leg.basis_perm is not None:
-            perm = np.argsort(leg.basis_perm[slice(*leg.slices[bi])])
-            block = self.apply_leg_permutations(block, [inverse_permutation(perm)])
-        return AbelianBackendData(
-            dtype=self.block_dtype(block), blocks=[block],
-            block_inds=np.array([[bi]]),
-            is_sorted=True
-        )
-
-    def to_dense_block_trivial_sector(self, tensor: SymmetricTensor) -> Block:
-        raise NotImplementedError  # TODO not yet reviewed
-        num_blocks = len(tensor.data.blocks)
-        if num_blocks == 1:
-            res = tensor.data.blocks[0]
-            # TODO dont use legs! use conventional_leg_order / domain / codomain
-            if tensor.legs[0].basis_perm is not None:
-                # we need to find the permutation perm such that res[perm] == dense_data[some_mask]
-                # so far we have
-                # res == internal_data[slice] == dense_data[basis_perm][slice] == dense_data[basis_perm[slice]]
-                # thus dense_data[some_mask] == res[perm] == dense_data[basis_perm[slice][perm]]
-                # i.e. perm needs to sort basis_perm[slice]
-                # TODO dont use legs! use conventional_leg_order / domain / codomain
-                bi = tensor.legs[0].sectors_where(tensor.legs[0].symmetry.trivial_sector)
-                perm = np.argsort(tensor.legs[0].basis_perm[slice(*tensor.legs[0].slices[bi])])
-                res = self.apply_leg_permutations(res, [perm])
-            return res
-        elif num_blocks == 0:
-            dim = tensor.legs[0]._non_dual_sector_multiplicity(tensor.symmetry.trivial_sector)
-            # no need to consider basis_perm, since its all 0 anyway
-            return self.zero_block(shape=[dim], dtype=tensor.data.dtype)
-        raise ValueError  # this should not happen for single-leg tensors
-
-    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
-                                                charge_leg: ElementarySpace) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        assert charge_leg.num_sectors == 1
-        bi = leg.sectors_where(leg.symmetry.dual_sector(charge_leg.sectors[0]))
-        assert bi is not None
-        assert self.block_shape(block) == (leg.multiplicities[bi],)
-        if leg.basis_perm is not None:
-            # see comment in to_dense_block_trivial_sector. here we need the inverse of that.
-            perm = np.argsort(leg.basis_perm[slice(*leg.slices[bi])])
-            block = self.apply_leg_permutations(block, [inverse_permutation(perm)])
-        return AbelianBackendData(
-            dtype=self.block_dtype(block),
-            blocks=[self.block_add_axis(block, pos=1)],
-            block_inds=np.array([[bi, 0]])
-        )
-
-    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO dont use legs! use conventional_leg_order / domain / codomain
-        num_blocks = len(tensor.data.blocks)
-        assert tensor.legs[1].num_sectors == 1
-        # find the block-index that the single allowed block has (or would have)
-        sector = tensor.legs[1].sectors[0]
-        bi = tensor.legs[0].sectors_where(tensor.symmetry.dual_sector(sector))
-        if num_blocks == 1:
-            res = tensor.data.blocks[0][:, 0]
-            if tensor.legs[0].basis_perm is not None:
-                # see comment in to_dense_block_trivial_sector
-                perm = np.argsort(tensor.legs[0].basis_perm[slice(*tensor.legs[0].slices[bi])])
-                res = self.apply_leg_permutations(res, [perm])
-            return res
-        elif num_blocks == 0:
-            dim = tensor.legs[0].multiplicities[bi]
-            # no need to consider basis_perm, since its all 0 anyway
-            return self.zero_block(shape=[dim], dtype=tensor.data.dtype)
-        raise ValueError  # should have been caught by input checks in ChargedTensor.to_dense_block_single_sector
-
-    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
-                         flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        block_inds = np.copy(tensor.data.block_inds)
-        for i, perm in zip(which_legs, perms):
-            # old_sector_idx = perm[new_sector_idx]
-            block_inds[:, i] = inverse_permutation(perm)[block_inds[:, i]]
-        return AbelianBackendData(dtype=tensor.data.dtype, blocks=tensor.data.blocks,
-                                  block_inds=block_inds, is_sorted=False)
-
-    def product_space_map_incoming_block_inds(self, space: ProductSpace, incoming_block_inds):
-        """Map incoming block indices to indices of :attr:`_block_ind_map`.
-
-        Needed for `combine_legs`.
-
-        Parameters
-        ----------
-        space : ProductSpace
-            The ProductSpace which indices are to be mapped
-        incoming_block_inds : 2D array
-            Rows are block indices :math:`(i_1, i_2, ... i_{nlegs})` for incoming legs.
-
-        Returns
-        -------
-        block_inds: 1D array
-            For each row j of `incoming_block_inds` an index `J` such that
-            ``self.metadata['_block_ind_map'][J, 2:-1] == block_inds[j]``.
-        """
-        raise NotImplementedError  # TODO not yet reviewed
-        # TODO move this back to ProductSpace?
-        assert incoming_block_inds.shape[1] == len(space.spaces)
-        # calculate indices of _block_ind_map by using the appropriate strides
-        strides = space.get_metadata('_strides', backend=self)
-        inds_before_perm = np.sum(incoming_block_inds * strides[np.newaxis, :], axis=1)
-        # now permute them to indices in _block_ind_map
-        return inverse_permutation(space.fusion_outcomes_sort)[inds_before_perm]

--- a/tenpy/linalg/backends/abelian.py
+++ b/tenpy/linalg/backends/abelian.py
@@ -1265,10 +1265,9 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
         block_inds = block_inds[:, keep]
         return AbelianBackendData(a.data.dtype, blocks, block_inds, is_sorted=True)
 
-    def norm(self, a: SymmetricTensor | DiagonalTensor, order: int | float = 2) -> float:
-        raise NotImplementedError  # TODO not yet reviewed
-        block_norms = [self.block_norm(b, order=order) for b in a.data.blocks]
-        return np.linalg.norm(block_norms, ord=order)
+    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
+        block_norms = [self.block_norm(b, order=2) for b in a.data.blocks]
+        return np.linalg.norm(block_norms, ord=2)
 
     def act_block_diagonal_square_matrix(self, a: SymmetricTensor, block_method: Callable[[Block], Block]
                                          ) -> Data:
@@ -1334,8 +1333,8 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
             dtype = self.block_dtype(blocks[0])
         return AbelianBackendData(dtype, blocks, b.data.block_inds, is_sorted=True)
 
-    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False,
-                  is_real: bool = False) -> ElementarySpace:
+    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False
+                  ) -> ElementarySpace:
         raise NotImplementedError  # TODO not yet reviewed
         raise NotImplementedError  # TODO
         # TODO how to handle ChargedTensor vs Tensor?
@@ -1405,7 +1404,7 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
         return AbelianBackendData(dtype=a.data.dtype, blocks=blocks, block_inds=a.data.blocks_inds,
                                   is_sorted=True)
 
-    def diagonal_data_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
+    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
         raise NotImplementedError  # TODO not yet reviewed
         blocks = [self.block_get_diagonal(block, check_offdiagonal) for block in a.data.blocks]
         return AbelianBackendData(a.dtype, blocks, a.data.block_inds, is_sorted=True)

--- a/tenpy/linalg/backends/abelian.py
+++ b/tenpy/linalg/backends/abelian.py
@@ -554,9 +554,9 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
         block_inds = []
 
         ia = 0  # next block of a to process
-        bi_a = a_block_inds[ia, 0]  # block_ind of that block => it belongs to leg.sectors[bi_a]
+        bi_a = -1 if len(a_block_inds) == 0 else a_block_inds[ia, 0]  # block_ind of that block => it belongs to leg.sectors[bi_a]
         ib = 0  # next block of b to process
-        bi_b = b_block_inds[ib, 0]  # block_ind of that block => it belongs to leg.sectors[bi_b]
+        bi_b = -1 if len(b_block_inds) == 0 else b_block_inds[ib, 0]  # block_ind of that block => it belongs to leg.sectors[bi_b]
         #
         for i in range(leg.multiplicities):
             if i == bi_a:
@@ -908,9 +908,9 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
         basis_perm_ranks = []
         #
         i1 = 0  # next block of mask1 to process
-        b1_i1 = mask1_block_inds[i1, 1]  # its block_ind for the large leg.
+        b1_i1 = -1 if len(mask1_block_inds) == 0 else mask1_block_inds[i1, 1]  # its block_ind for the large leg.
         i2 = 0
-        b2_i2 = mask2_block_inds[i2, 1]
+        b2_i2 = -1 if len(mask2_block_inds) == 0 else mask2_block_inds[i2, 1]
         #
         for sector_idx, (sector, slc) in enumerate(zip(large_leg.sectors, large_leg.slices)):
             if sector_idx == b1_i1:
@@ -1036,7 +1036,7 @@ class AbelianBackend(Backend, BlockBackend, metaclass=ABCMeta):
         basis_perm_ranks = []
         #
         i = 0
-        b_i = mask_blocks_inds[i, 1]
+        b_i = -1 if len(mask_blocks_inds) == 0 else mask_blocks_inds[i, 1]
         for sector_idx, (sector, slc) in enumerate(zip(large_leg.sectors, large_leg.slices)):
             if sector_idx == b_i:
                 block = mask_blocks[i]

--- a/tenpy/linalg/backends/abstract_backend.py
+++ b/tenpy/linalg/backends/abstract_backend.py
@@ -106,10 +106,6 @@ class Backend(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        ...
-
-    @abstractmethod
     def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
                         co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
                         ) -> Data:
@@ -374,6 +370,10 @@ class Backend(metaclass=ABCMeta):
 
         In the *internal* basis order of `spaces`.
         """
+        ...
+
+    @abstractmethod
+    def linear_combination(self, a, v: SymmetricTensor, b, w: SymmetricTensor) -> Data:
         ...
 
     @abstractmethod
@@ -889,8 +889,8 @@ class BlockBackend(metaclass=ABCMeta):
     def block_random_normal(self, dims: list[int], dtype: Dtype, sigma: float) -> Block:
         ...
 
-    def block_add(self, a: Block, b: Block) -> Block:
-        return a + b
+    def block_linear_combination(self, a, v: Block, b, w: Block) -> Block:
+        return a * v + b * w
 
     def block_mul(self, a: float | complex, b: Block) -> Block:
         return a * b

--- a/tenpy/linalg/backends/abstract_backend.py
+++ b/tenpy/linalg/backends/abstract_backend.py
@@ -173,15 +173,6 @@ class Backend(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def diagonal_data_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool
-                                       ) -> DiagonalData:
-        """Get the DiagonalData corresponding to a tensor with two legs.
-
-        Can assume that domain and codomain consist of the same single leg.
-        """
-        ...
-
-    @abstractmethod
     def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
                                     func_kwargs, partial_zero_is_zero: bool
                                     ) -> DiagonalData:
@@ -218,6 +209,15 @@ class Backend(metaclass=ABCMeta):
         """Generate diagonal data from a function ``func(shape: tuple[int], coupled: Sector) -> Block``."""
         ...
        
+    @abstractmethod
+    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool
+                                       ) -> DiagonalData:
+        """Get the DiagonalData corresponding to a tensor with two legs.
+
+        Can assume that domain and codomain consist of the same single leg.
+        """
+        ...
+
     @abstractmethod
     def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
         ...
@@ -395,7 +395,7 @@ class Backend(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def norm(self, a: SymmetricTensor | DiagonalTensor, order: int | float = 2) -> float:
+    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
         """Norm of a tensor. order has already been parsed and is a number"""
         ...
 

--- a/tenpy/linalg/backends/abstract_backend.py
+++ b/tenpy/linalg/backends/abstract_backend.py
@@ -223,7 +223,7 @@ class Backend(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def diagonal_to_block(self, a: DiagonalTensor) -> Block:
+    def diagonal_tensor_to_block(self, a: DiagonalTensor) -> Block:
         """Forget about symmetry structure and convert the diagonals of the blocks
         to a single 1D block.
         This is the diagonal of the respective non-symmetric 2D tensor.

--- a/tenpy/linalg/backends/array_api.py
+++ b/tenpy/linalg/backends/array_api.py
@@ -4,7 +4,7 @@ https://data-apis.org/array-api/latest/purpose_and_scope.html
 # Copyright (C) TeNPy Developers, GNU GPLv3
 from __future__ import annotations
 
-from .abstract_backend import BlockBackend, Block, Data
+from .abstract_backend import BlockBackend, Block
 from .no_symmetry import NoSymmetryBackend
 from .fusion_tree_backend import FusionTreeBackend
 from .abelian import AbelianBackend

--- a/tenpy/linalg/backends/fusion_tree_backend.py
+++ b/tenpy/linalg/backends/fusion_tree_backend.py
@@ -360,7 +360,7 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
         num_beta_trees = len(beta_tree_iter)
         return entries, num_alpha_trees, num_beta_trees
 
-    def diagonal_to_block(self, a: DiagonalTensor) -> Block:
+    def diagonal_tensor_to_block(self, a: DiagonalTensor) -> Block:
         assert a.symmetry.can_be_dropped
         res = self.zero_block([a.leg.dim], a.dtype)
         for i, j in iter_common_sorted_arrays(a.leg.sectors, a.data.coupled_sectors):

--- a/tenpy/linalg/backends/fusion_tree_backend.py
+++ b/tenpy/linalg/backends/fusion_tree_backend.py
@@ -721,10 +721,8 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
         raise NotImplementedError('squeeze_legs not implemented')  # TODO
 
-    def norm(self, a: SymmetricTensor | DiagonalTensor, order: int | float = 2) -> float:
+    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
         # OPTIMIZE should we offer the square-norm instead?
-        if order != 2:
-            raise ValueError(f'{self} only supports 2-norm.')
         norm_sq = 0
         for coupled, block in zip(a.data.coupled_sectors, a.data.blocks):
             norm_sq += a.symmetry.sector_dim(coupled) * (self.block_norm(block) ** 2)
@@ -771,7 +769,7 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
         return FusionTreeData(b.data.coupled_sectors, blocks, b.data.domain, b.data.codomain, dtype)
 
     def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False,
-                  is_real: bool = False) -> ElementarySpace:
+                  ) -> ElementarySpace:
         raise NotImplementedError('infer_leg not implemented')  # TODO
 
     def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
@@ -791,9 +789,9 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
         #      affects in general many entries of the blocks.
         raise NotImplementedError('set_element_diagonal not implemented')  # TODO
 
-    def diagonal_data_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool
+    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool
                                        ) -> DiagonalData:
-        raise NotImplementedError('diagonal_data_from_full_tensor not implemented')  # TODO
+        raise NotImplementedError('diagonal_tensor_from_full_tensor not implemented')  # TODO
 
     def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
         raise NotImplementedError('full_data_from_diagonal_tensor not implemented')  # TODO

--- a/tenpy/linalg/backends/fusion_tree_backend.py
+++ b/tenpy/linalg/backends/fusion_tree_backend.py
@@ -885,8 +885,8 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
                                                charge_leg: ElementarySpace) -> Data:
         raise NotImplementedError('inv_part_from_dense_block_single_sector not implemented')  # TODO
 
-    def inv_part_to_flat_block_single_sector(self, tensor: SymmetricTensor) -> Block:
-        raise NotImplementedError('inv_part_to_flat_block_single_sector not implemented')  # TODO
+    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError('inv_part_to_dense_block_single_sector not implemented')  # TODO
 
     def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
                          flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:

--- a/tenpy/linalg/backends/fusion_tree_backend.py
+++ b/tenpy/linalg/backends/fusion_tree_backend.py
@@ -490,7 +490,7 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
                 for a_sectors, m_dims, j1 in _iter_sectors_mults_slices(codomain.spaces, sym):
                     a_dims = sym.batch_sector_dim(a_sectors)
                     tree_block_height = tree_block_size(codomain, a_sectors)
-                    entries = a[*j1, *j2]  # [(a1,m1),...,(aJ,mJ), (b1,n1),...,(bK,nK)]
+                    entries = a[(*j1, *j2)]  # [(a1,m1),...,(aJ,mJ), (b1,n1),...,(bK,nK)]
                     # reshape to [a1,m1,...,aJ,mJ, b1,n1,...,bK,nK]
                     shape = [0] * (2 * num_legs)
                     shape[::2] = [*a_dims, *b_dims]
@@ -703,7 +703,7 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
                     shape = [d_a * m for d_a, m in zip(a_dims, m_dims)] \
                             + [d_b * n for d_b, n in zip(b_dims, n_dims)]
                     entries = self.block_reshape(entries, shape)
-                    res[*j1, *j2] += entries
+                    res[(*j1, *j2)] += entries
                     i1 += forest_b_height  # move down by one forest-block
                 i1 = 0  # reset to the top of the block
                 i2 += forest_b_width  # move right by one forest-block

--- a/tenpy/linalg/backends/fusion_tree_backend.py
+++ b/tenpy/linalg/backends/fusion_tree_backend.py
@@ -244,16 +244,76 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
     #   - test_leg_sanity
     #   - _fuse_spaces
 
-    def get_dtype_from_data(self, a: FusionTreeData) -> Dtype:
-        return a.dtype
+    # ABSTRACT METHODS
 
-    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> FusionTreeData:
-        blocks = [self.block_to_dtype(block, dtype) for block in a.data.blocks]
-        return FusionTreeData(a.data.coupled_sectors, blocks, a.data.domain, a.data.codomain, dtype)
+    def act_block_diagonal_square_matrix(self, a: SymmetricTensor,
+                                         block_method: Callable[[Block], Block]) -> Data:
+        raise NotImplementedError('act_block_diagonal_square_matrix not implemented')  # TODO
 
-    def supports_symmetry(self, symmetry: Symmetry) -> bool:
-        # supports all symmetries
-        return isinstance(symmetry, Symmetry)
+    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        assert a.data.num_domain_legs == b.data.num_domain_legs
+        dtype = a.data.dtype.common(b.data.dtype)
+        a_blocks = [self.block_to_dtype(_a, dtype) for _a in a.data.blocks]
+        b_blocks = [self.block_to_dtype(_b, dtype) for _b in b.data.blocks]
+        blocks = []
+        coupled_sectors = []
+        for i, j in iter_common_noncommon_sorted_arrays(a.data.coupled_sectors, b.data.coupled_sectors):
+            if i is None:
+                blocks.append(b_blocks[j])
+                coupled_sectors.append(b.data.coupled_sectors[j])
+            elif j is None:
+                blocks.append(a_blocks[i])
+                coupled_sectors.append(a.data.coupled_sectors[i])
+            else:
+                blocks.append(self.block_add(a_blocks[i], b_blocks[j]))
+                coupled_sectors.append(a.data.coupled_sectors[i])
+        if len(blocks) == 0:
+            coupled_sectors = a.symmetry.empty_sector_array
+        else:
+            coupled_sectors = np.array(coupled_sectors)
+        return FusionTreeData(coupled_sectors, blocks, a.data.domain, a.data.codomain, dtype)
+
+    def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
+                        co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
+                        ) -> Data:
+        raise NotImplementedError('add_trivial_leg not implemented')  # TODO
+
+    def almost_equal(self, a: SymmetricTensor, b: SymmetricTensor, rtol: float, atol: float
+                     ) -> bool:
+        for i, j in iter_common_noncommon_sorted_arrays(a.data.coupled_sectors, b.data.coupled_sectors):
+            if j is None:
+                if self.block_max_abs(a.data.blocks[i]) > atol:
+                    return False
+            if i is None:
+                if self.block_max_abs(b.data.blocks[j]) > atol:
+                    return False
+            else:
+                if not self.block_allclose(a.data.blocks[i], b.data.blocks[j], rtol=rtol, atol=atol):
+                    return False
+        return True
+
+    def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
+        raise NotImplementedError('apply_mask_to_DiagonalTensor not implemented')  # TODO
+
+    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
+        raise NotImplementedError('apply_mask_to_Tensor not implemented')  # TODO
+
+    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int],
+                     product_spaces: list[ProductSpace], new_axes: list[int],
+                     final_legs: list[Space]) -> Data:
+        raise NotImplementedError('combine_legs not implemented')  # TODO
+        
+    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
+        # TODO what does this even mean? transpose of dagger?
+        # TODO should we offer transpose and dagger too?
+        raise NotImplementedError('conj not implemented')  # TODO
+
+    def copy_data(self, a: SymmetricTensor) -> FusionTreeData:
+        return FusionTreeData(
+            coupled_sectors=a.data.coupled_sectors.copy(),  # OPTIMIZE do we need to copy these?
+            blocks=[self.block_copy(block) for block in a.data.blocks],
+            codomain=a.data.codomain, domain=a.data.domain
+        )
 
     def data_item(self, a: FusionTreeData) -> float | complex:
         if len(a.blocks) > 1:
@@ -262,103 +322,158 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
             return a.dtype.zero_scalar
         return self.block_item(a.blocks[0])
 
-    def to_dense_block(self, a: SymmetricTensor) -> Block:
-        assert a.symmetry.can_be_dropped
-        J = len(a.data.codomain.spaces)
-        K = len(a.data.domain.spaces)
-        num_legs = J + K
-        dtype = Dtype.common(a.data.dtype, a.symmetry.fusion_tensor_dtype)
-        sym = a.symmetry
-        # build in internal basis order first, then apply permutations in the end
-        # build in codomain/domain leg order first, then permute legs in the end
-        # [i1,...,iJ,j1,...,jK]
-        shape = [leg.dim for leg in a.data.codomain.spaces] + [leg.dim for leg in a.data.domain.spaces]
-        res = self.zero_block(shape, dtype)
-        for coupled, block in zip(a.data.coupled_sectors, a.data.blocks):
-            i1 = 0  # start row index of the current forest block
-            i2 = 0  # start column index of the current forest block
-            for b_sectors, n_dims, j2 in _iter_sectors_mults_slices(a.data.domain.spaces, sym):
-                b_dims = sym.batch_sector_dim(b_sectors)
-                tree_block_width = tree_block_size(a.data.domain, b_sectors)
-                for a_sectors, m_dims, j1 in _iter_sectors_mults_slices(a.data.codomain.spaces, sym):
-                    a_dims = sym.batch_sector_dim(a_sectors)
-                    tree_block_height = tree_block_size(a.data.codomain, a_sectors)
-                    entries, num_alpha_trees, num_beta_trees = self._get_forest_block_contribution(
-                        block, sym, a.data.codomain, a.data.domain, coupled, a_sectors, b_sectors,
-                        a_dims, b_dims, tree_block_width, tree_block_height, i1, i2, m_dims, n_dims,
-                        dtype
-                    )
-                    forest_b_height = num_alpha_trees * tree_block_height
-                    forest_b_width = num_beta_trees * tree_block_width
-                    if forest_b_height == 0 or forest_b_width == 0:
-                        continue
-                    # entries : [a1,...,aJ, b1,...,bK, m1,...,mJ, n1,...,nK]
-                    # permute to [a1,m1,...,aJ,mJ, b1,n1,...,bK,nK]
-                    perm = [i + offset for i in range(num_legs) for offset in [0, num_legs]]
-                    entries = self.block_permute_axes(entries, perm)
-                    # reshape to [(a1,m1),...,(aJ,mJ), (b1,n1),...,(bK,nK)]
-                    shape = [d_a * m for d_a, m in zip(a_dims, m_dims)] \
-                            + [d_b * n for d_b, n in zip(b_dims, n_dims)]
-                    entries = self.block_reshape(entries, shape)
-                    res[*j1, *j2] += entries
-                    i1 += forest_b_height  # move down by one forest-block
-                i1 = 0  # reset to the top of the block
-                i2 += forest_b_width  # move right by one forest-block
-        # permute leg order [i1,...,iJ,j1,...,jK] -> [i1,...,iJ,jK,...,j1]
-        res = self.block_permute_axes(res, [*range(J), *reversed(range(J, J + K))])
-        # apply permutation to public basis order
-        res = self.apply_basis_perm(res, conventional_leg_order(a), inv=True)
-        return res
+    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int,
+                         max_lines: int) -> list[str]:
+        raise NotImplementedError  # TODO not yet reviewed
+        from ..dummy_config import printoptions
+        if len(a.data.blocks) == 0:
+            return [f'{indent}* Data : no non-zero blocks']
 
-    def _get_forest_block_contribution(self, block, sym: Symmetry, codomain, domain, coupled,
-                                       a_sectors, b_sectors, a_dims, b_dims, tree_block_width,
-                                       tree_block_height, i1_init, i2_init, m_dims, n_dims,
-                                       dtype):
-        """Helper function for :meth:`to_dense_block`.
+        lines = []
+        for alpha_tree, beta_tree, entries in _tree_block_iter(a.data, backend=self):
+            # build (a_before_Z) <- (a_after_Z) <- coupled <- (b_after_Z) <- (b_before_Z)
+            a_before_Z, a_after_Z, coupled = alpha_tree._str_uncoupled_coupled(
+                a.symmetry, alpha_tree.uncoupled, alpha_tree.coupled, alpha_tree.are_dual
+            ).split(' -> ')
+            b_before_Z, b_after_Z, coupled = beta_tree._str_uncoupled_coupled(
+                a.symmetry, beta_tree.uncoupled, beta_tree.coupled, beta_tree.are_dual
+            ).split(' -> ')
+            sectors = f'{a_after_Z} <- {coupled} <- {b_after_Z}'
+            if a_before_Z != a_after_Z:
+                sectors = a_before_Z + ' <- ' + sectors
+            if b_before_Z != b_after_Z:
+                sectors = sectors + ' <- ' + b_before_Z
 
-        Obtain the contributions from a given forest block
+            if a.symmetry.fusion_style is FusionStyle.single:
+                lines.append(f'{indent}* Data for sectors {sectors}')
+            elif a.symmetry.fusion_style is FusionStyle.multiple_unique:
+                # dont need multiplicity labels
+                a_inner = ', '.join(a.symmetry.sector_str(i) for i in alpha_tree.inner_sectors)
+                b_inner = ', '.join(a.symmetry.sector_str(i) for i in beta_tree.inner_sectors)
+                lines.append(f'{indent}* Data for trees {sectors}')
+                lines.append(f'{indent}  with inner sectors ({a_inner}) and ({b_inner})')
+            else:
+                a_inner = ', '.join(a.symmetry.sector_str(i) for i in alpha_tree.inner_sectors)
+                b_inner = ', '.join(a.symmetry.sector_str(i) for i in beta_tree.inner_sectors)
+                a_mults = ', '.join(map(str, alpha_tree.multiplicities))
+                b_mults = ', '.join(map(str, beta_tree.multiplicities))
+                lines.append(f'{indent}* Data for trees {sectors}')
+                lines.append(f'{indent}  with inner sectors ({a_inner}) and ({b_inner})')
+                lines.append(f'{indent}  with multiplicities ({a_mults}) <- ({b_mults})')
+            lines.extend(self._block_repr_lines(entries, indent=indent + printoptions.indent * ' ',
+                                                max_width=max_width, max_lines=max_lines))
 
-        Parameters:
-            block: The current block
-            sym: The symmetry
-            codomain, domain: The codomain and domain of the new tensor
-            coupled, dim_c: The coupled sector of the current block and its quantum dimension
-            a_sectors: The codomain uncoupled sectors [a1, a2, ..., aJ]
-            b_sectors: The domain uncoupled sectors [b1, b2, ..., bK]
-            tree_block_width: Equal to ``tree_block_size(domain, b_sectors)``
-            tree_block_height: Equal to ``tree_block_size(codomain, a_sectors)``
-            i1_init, i2_init: The start indices of the current forest block within the block
+            if (len(lines) > max_lines) or any(len(line) > max_width for line in lines):
+                # fallback to just stating number of blocks.
+                num_entries = sum(prod(self.block_shape(b)) for b in a.data.blocks)
+                return [
+                    f'{indent}* Data: {num_entries} entries in {len(a.data.blocks)} blocks.'
+                ]
+        return lines
 
-        Returns:
-            entries: The entries of the dense block corresponding to the given uncoupled sectors.
-                     Legs [a1,...,aJ, b1,...,bK, m1,...,mJ, n1,...,nK]
-            num_alpha_trees: The number of fusion trees from ``a_sectors`` to ``coupled``
-            num_beta_trees : The number of fusion trees from ``b_sectors`` to ``coupled``
-        """
-        # OPTIMIZE do one loop per vertex in the tree instead.
-        i1 = i1_init  # i1: start row index of the current tree block within the block
-        i2 = i2_init  # i2: start column index of the current tree block within the block
-        alpha_tree_iter = fusion_trees(sym, a_sectors, coupled, [sp.is_dual for sp in codomain.spaces])
-        beta_tree_iter = fusion_trees(sym, b_sectors, coupled, [sp.is_dual for sp in domain.spaces])
-        entries = self.zero_block([*a_dims, *b_dims, *m_dims, *n_dims], dtype)
-        for alpha_tree in alpha_tree_iter:
-            Y = self.block_conj(alpha_tree.as_block(backend=self))  # [a1,...,aJ,c]
-            for beta_tree in beta_tree_iter:
-                X = beta_tree.as_block(backend=self)  # [b1,...,bK,c]
-                symmetry_data = self.block_tdot(Y, X, -1, -1)  # [a1,...,aJ,b1,...,bK]
-                idx1 = slice(i1, i1 + tree_block_height)
-                idx2 = slice(i2, i2 + tree_block_width)
-                degeneracy_data = block[idx1, idx2]  # [M, N]
-                # [M, N] -> [m1,...,mJ,n1,...,nK]
-                degeneracy_data = self.block_reshape(degeneracy_data, m_dims + n_dims)
-                entries += self.block_outer(symmetry_data, degeneracy_data)  # [{aj} {bk} {mj} {nk}]
-                i2 += tree_block_width
-            i2 = i2_init  # reset to the left of the current forest-block
-            i1 += tree_block_height
-        num_alpha_trees = len(alpha_tree_iter)  # OPTIMIZE count loop iterations above instead?
-                                                #          (same in _add_forest_block_entries)
-        num_beta_trees = len(beta_tree_iter)
-        return entries, num_alpha_trees, num_beta_trees
+    def diagonal_all(self, a: DiagonalTensor) -> bool:
+        if len(a.data.blocks) < a.domain.num_sectors:
+            # there are missing blocks. -> they contain False -> all(a) == False
+            return False
+        # now it is enough to check the existing blocks
+        return all(self.block_all(b) for b in a.data.blocks)
+
+    def diagonal_any(self, a: DiagonalTensor) -> bool:
+        return any(self.block_any(b) for b in a.data.blocks)
+    
+    def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
+                                    func_kwargs, partial_zero_is_zero: bool) -> DiagonalData:
+        a_coupled = a.data.coupled_sectors
+        b_coupled = b.data.coupled_sectors
+        if partial_zero_is_zero:
+            blocks = []
+            coupled_sectors = []
+            for i, j in iter_common_sorted_arrays(a_coupled, b_coupled):
+                coupled = a_coupled[i]
+                coupled_sectors.append(coupled)
+                blocks.append(func(a.data.blocks[i], b.data.blocks[j], **func_kwargs))
+        else:
+            i_a = 0  # during the loop: a_coupled[:i_a] was already visited
+            i_b = 0  # same for b_coupled
+            coupled_sectors = a.domain.sectors
+            blocks = []
+            for coupled  in coupled_sectors:
+                if np.all(coupled == a_coupled[i_a]):
+                    a_block = a.data.block[i_a]
+                    i_a += 1
+                else:
+                    a_block = self.zero_block([block_size(a.domain, coupled)], dtype=a.dtype)
+                if np.all(coupled == b_coupled[i_b]):
+                    b_block = b.data.block[i_b]
+                    i_b += 1
+                else:
+                    b_block = self.zero_block([block_size(a.domain, coupled)], dtype=b.dtype)
+                blocks.append(func(a_block, b_block, **func_kwargs))
+        if len(blocks) > 0:
+            dtype = self.block_dtype(blocks[0])
+        else:
+            a_block = self.ones_block([1], dtype=a.dtype)
+            b_block = self.ones_block([1], dtype=b.dtype)
+            example_block = func(a_block, b_block, **func_kwargs)
+            dtype = self.block_dtype(example_block)
+        return FusionTreeData(coupled_sectors=coupled_sectors, blocks=blocks, domain=a.data.domain,
+                              codomain=a.data.codomain, dtype=dtype)
+
+    def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs,
+                                   maps_zero_to_zero: bool) -> DiagonalData:
+        if maps_zero_to_zero:
+            blocks = [func(b, **func_kwargs) for b in a.data.blocks]
+            coupled_sectors = a.data.coupled_sectors
+        else:
+            coupled_sectors = a.domain.sectors
+            blocks = []
+            for i, j in iter_common_noncommon_sorted_arrays(coupled_sectors, a.data.coupled_sectors):
+                if j is None:
+                    block = self.zero_block([block_size(a.domain, coupled_sectors[i])], dtype=a.dtype)
+                else:
+                    block = a.data.blocks[j]
+                blocks.append(func(block, **func_kwargs))
+        if len(blocks) > 0:
+            dtype = self.block_dtype(blocks[0])
+        else:
+            dtype = self.block_dtype(func(self.ones_block([1], dtype=a.dtype), **func_kwargs))
+        return FusionTreeData(coupled_sectors=coupled_sectors, blocks=blocks,
+                              domain=a.data.domain, codomain=a.data.codomain, dtype=dtype)
+
+    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
+        dtype = self.block_dtype(a)
+        a = self.apply_basis_perm(a, co_domain.spaces)
+        coupled_sectors = co_domain.sectors
+        blocks = []
+        for coupled, mult, slc in zip(co_domain.sectors, co_domain.multiplicities, co_domain.slices):
+            dim_c = co_domain.symmetry.sector_dim(coupled)
+            entries = self.block_reshape(a[slice(*slc)], (dim_c, mult))
+            # project onto the identity on the coupled sector
+            block = self.block_sum(entries, 0) / dim_c
+            projected = self.block_outer(self.ones_block([dim_c], dtype=dtype), block)
+            if self.block_norm(entries - projected) > tol * self.block_norm(entries):
+                raise ValueError('Block is not symmetric up to tolerance.')
+            blocks.append(block)
+        return FusionTreeData(coupled_sectors, blocks, co_domain, co_domain, dtype)
+
+    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
+        coupled_sectors = co_domain.sectors
+        blocks = [func((block_size(co_domain, coupled),), coupled) for coupled in coupled_sectors]
+        if len(blocks) > 0:
+            sample_block = blocks[0]
+            coupled_sectors = np.asarray(coupled_sectors, int)
+        else:
+            sample_block = func((1,), co_domain.symmetry.trivial_sector)
+            coupled_sectors = co_domain.symmetry.empty_sector_array
+        dtype = self.block_dtype(sample_block)
+        return FusionTreeData(coupled_sectors, blocks, co_domain, co_domain, dtype)
+
+    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool
+                                       ) -> DiagonalData:
+        raise NotImplementedError('diagonal_tensor_from_full_tensor not implemented')  # TODO
+
+    def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
+        raise NotImplementedError('diagonal_tensor_trace_full not implemented')  # TODO
 
     def diagonal_tensor_to_block(self, a: DiagonalTensor) -> Block:
         assert a.symmetry.can_be_dropped
@@ -373,6 +488,25 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
         res = self.apply_basis_perm(res, [a.leg], inv=True)
         return res
 
+    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+
+    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
+        # TODO do SVD first, comments there apply.
+        raise NotImplementedError('eigh not implemented')  # TODO
+
+    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> FusionTreeData:
+        # Note: the identity has the same matrix elements in all ONB, so ne need to consider
+        #       the basis perms.
+        coupled_sectors = co_domain.sectors
+        blocks = [self.eye_matrix(block_size(co_domain, c), dtype) for c in coupled_sectors]
+        return FusionTreeData(coupled_sectors, blocks, co_domain, co_domain, dtype)
+
+    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
+                         flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
+        # TODO think carefully about what this means.
+        raise NotImplementedError('flip_leg_duality not implemented')  # TODO
+    
     def from_dense_block(self, a: Block, codomain: ProductSpace, domain: ProductSpace, tol: float
                          ) -> FusionTreeData:
         sym = codomain.symmetry
@@ -444,9 +578,263 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
         coupled_sectors = np.asarray(coupled_sectors, int)
         return FusionTreeData(coupled_sectors, blocks, domain, codomain, dtype)
     
+    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
+        raise NotImplementedError('from_dense_block_trivial_sector not implemented')  # TODO
+
     def from_random_normal(self, codomain: ProductSpace, domain: ProductSpace, sigma: float,
                            dtype: Dtype) -> Data:
         raise NotImplementedError  # TODO
+
+    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> FusionTreeData:
+        coupled_sectors = []
+        blocks = []
+        for i, _ in iter_common_sorted_arrays(domain.sectors, codomain.sectors):
+            coupled = domain.sectors[i]
+            shape = (block_size(codomain, coupled), block_size(domain, coupled))
+            coupled_sectors.append(coupled)
+            blocks.append(func(shape, coupled))
+        if len(blocks) > 0:
+            sample_block = blocks[0]
+            coupled_sectors = np.asarray(coupled_sectors, int)
+        else:
+            sample_block = func((1, 1), codomain.symmetry.trivial_sector)
+            coupled_sectors = domain.symmetry.empty_sector_array
+        dtype = self.block_dtype(sample_block)
+        return FusionTreeData(coupled_sectors, blocks, domain, codomain, dtype)
+
+    def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
+        raise NotImplementedError('full_data_from_diagonal_tensor not implemented')  # TODO
+
+    def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
+        raise NotImplementedError('full_data_from_mask not implemented')  # TODO
+
+    def get_dtype_from_data(self, a: FusionTreeData) -> Dtype:
+        return a.dtype
+
+    def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
+        raise NotImplementedError('get_element not implemented')  # TODO
+
+    def get_element_diagonal(self, a: DiagonalTensor, idx: int) -> complex | float | bool:
+        raise NotImplementedError('get_element_diagonal not implemented')  # TODO
+
+    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False,
+                  ) -> ElementarySpace:
+        raise NotImplementedError('infer_leg not implemented')  # TODO
+
+    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool,
+              axs2: list[int] | None) -> complex:
+        raise NotImplementedError('inner not implemented')  # TODO
+    
+    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
+                                               charge_leg: ElementarySpace) -> Data:
+        raise NotImplementedError('inv_part_from_dense_block_single_sector not implemented')  # TODO
+
+    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError('inv_part_to_dense_block_single_sector not implemented')  # TODO
+
+    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+
+    def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace) -> DiagonalData:
+        raise NotImplementedError('mask_from_block not implemented')  # TODO
+
+    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+        
+    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
+        if a == 0.:
+            return self.zero_data(b.codomain, b.domain, b.dtype)
+        blocks = [self.block_mul(a, T) for T in b.data.blocks]
+        if len(blocks) == 0:
+            if isinstance(a, float):
+                dtype = b.data.dtype
+            else:
+                dtype = b.data.dtype.to_complex()
+        else:
+            dtype = self.block_dtype(blocks[0])
+        return FusionTreeData(b.data.coupled_sectors, blocks, b.data.domain, b.data.codomain, dtype)
+
+    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
+        # OPTIMIZE should we offer the square-norm instead?
+        norm_sq = 0
+        for coupled, block in zip(a.data.coupled_sectors, a.data.blocks):
+            norm_sq += a.symmetry.sector_dim(coupled) * (self.block_norm(block) ** 2)
+        return self.block_sqrt(norm_sq)
+
+    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        # TODO what target leg order is easiest? does it match the one specified in Backend.outer?
+        raise NotImplementedError('outer not implemented')  # TODO
+
+    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
+        # TODO decide signature
+        raise NotImplementedError('permute_legs not implemented')  # TODO
+
+    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool
+           ) -> tuple[Data, Data, ElementarySpace]:
+        # TODO do SVD first, comments there apply.
+        raise NotImplementedError('qr not implemented')  # TODO
+
+    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
+        raise NotImplementedError('scale_axis not implemented')  # TODO
+
+    def set_element(self, a: SymmetricTensor, idcs: list[int], value: complex | float) -> Data:
+        # TODO not sure this can even be done sensibly, one entry of the dense block
+        #      affects in general many entries of the blocks.
+        raise NotImplementedError('set_element not implemented')  # TODO
+
+    def set_element_diagonal(self, a: DiagonalTensor, idx: int, value: complex | float | bool
+                             ) -> DiagonalData:
+        # TODO not sure this can even be done sensibly, one entry of the dense block
+        #      affects in general many entries of the blocks.
+        raise NotImplementedError('set_element_diagonal not implemented')  # TODO
+
+    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int],
+                   final_legs: list[Space]) -> Data:
+        # TODO do we need metadata to split, like in abelian?
+        raise NotImplementedError('split_legs not implemented')  # TODO
+
+    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
+        raise NotImplementedError('squeeze_legs not implemented')  # TODO
+
+    def supports_symmetry(self, symmetry: Symmetry) -> bool:
+        # supports all symmetries
+        return isinstance(symmetry, Symmetry)
+
+    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None,
+            compute_u: bool, compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
+        # TODO need to redesign Backend.svd specification! need to allow more than two legs!
+        # TODO need to be able to specify levels of braiding in general case!
+        raise NotImplementedError('svd not implemented')  # TODO
+
+    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int],
+             axs_b: list[int]) -> Data:
+        # TODO need to be able to specify levels of braiding in general case!
+        # TODO offer separate planar version? or just high
+        raise NotImplementedError('tdot not implemented')  # TODO
+
+    def to_dense_block(self, a: SymmetricTensor) -> Block:
+        assert a.symmetry.can_be_dropped
+        J = len(a.data.codomain.spaces)
+        K = len(a.data.domain.spaces)
+        num_legs = J + K
+        dtype = Dtype.common(a.data.dtype, a.symmetry.fusion_tensor_dtype)
+        sym = a.symmetry
+        # build in internal basis order first, then apply permutations in the end
+        # build in codomain/domain leg order first, then permute legs in the end
+        # [i1,...,iJ,j1,...,jK]
+        shape = [leg.dim for leg in a.data.codomain.spaces] + [leg.dim for leg in a.data.domain.spaces]
+        res = self.zero_block(shape, dtype)
+        for coupled, block in zip(a.data.coupled_sectors, a.data.blocks):
+            i1 = 0  # start row index of the current forest block
+            i2 = 0  # start column index of the current forest block
+            for b_sectors, n_dims, j2 in _iter_sectors_mults_slices(a.data.domain.spaces, sym):
+                b_dims = sym.batch_sector_dim(b_sectors)
+                tree_block_width = tree_block_size(a.data.domain, b_sectors)
+                for a_sectors, m_dims, j1 in _iter_sectors_mults_slices(a.data.codomain.spaces, sym):
+                    a_dims = sym.batch_sector_dim(a_sectors)
+                    tree_block_height = tree_block_size(a.data.codomain, a_sectors)
+                    entries, num_alpha_trees, num_beta_trees = self._get_forest_block_contribution(
+                        block, sym, a.data.codomain, a.data.domain, coupled, a_sectors, b_sectors,
+                        a_dims, b_dims, tree_block_width, tree_block_height, i1, i2, m_dims, n_dims,
+                        dtype
+                    )
+                    forest_b_height = num_alpha_trees * tree_block_height
+                    forest_b_width = num_beta_trees * tree_block_width
+                    if forest_b_height == 0 or forest_b_width == 0:
+                        continue
+                    # entries : [a1,...,aJ, b1,...,bK, m1,...,mJ, n1,...,nK]
+                    # permute to [a1,m1,...,aJ,mJ, b1,n1,...,bK,nK]
+                    perm = [i + offset for i in range(num_legs) for offset in [0, num_legs]]
+                    entries = self.block_permute_axes(entries, perm)
+                    # reshape to [(a1,m1),...,(aJ,mJ), (b1,n1),...,(bK,nK)]
+                    shape = [d_a * m for d_a, m in zip(a_dims, m_dims)] \
+                            + [d_b * n for d_b, n in zip(b_dims, n_dims)]
+                    entries = self.block_reshape(entries, shape)
+                    res[*j1, *j2] += entries
+                    i1 += forest_b_height  # move down by one forest-block
+                i1 = 0  # reset to the top of the block
+                i2 += forest_b_width  # move right by one forest-block
+        # permute leg order [i1,...,iJ,j1,...,jK] -> [i1,...,iJ,jK,...,j1]
+        res = self.block_permute_axes(res, [*range(J), *reversed(range(J, J + K))])
+        # apply permutation to public basis order
+        res = self.apply_basis_perm(res, conventional_leg_order(a), inv=True)
+        return res
+
+    def to_dense_block_trivial_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError('to_dense_block_trivial_sector not implemented')  # TODO
+
+    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> FusionTreeData:
+        blocks = [self.block_to_dtype(block, dtype) for block in a.data.blocks]
+        return FusionTreeData(a.data.coupled_sectors, blocks, a.data.domain, a.data.codomain, dtype)
+
+    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]
+                   ) -> float | complex:
+        raise NotImplementedError('trace_full not implemented')  # TODO
+
+    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int],
+                      remaining_idcs: list[int]) -> Data:
+        raise NotImplementedError('trace_partial not implemented')  # TODO
+
+    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype
+                  ) -> FusionTreeData:
+        return FusionTreeData(coupled_sectors=codomain.symmetry.empty_sector_array, blocks=[],
+                              domain=domain, codomain=codomain, dtype=dtype)
+
+    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
+        return FusionTreeData(coupled_sectors=co_domain.symmetry.empty_sector_array, blocks=[],
+                              domain=co_domain, codomain=co_domain, dtype=dtype)
+
+    # INTERNAL FUNCTIONS
+
+    def _get_forest_block_contribution(self, block, sym: Symmetry, codomain, domain, coupled,
+                                       a_sectors, b_sectors, a_dims, b_dims, tree_block_width,
+                                       tree_block_height, i1_init, i2_init, m_dims, n_dims,
+                                       dtype):
+        """Helper function for :meth:`to_dense_block`.
+
+        Obtain the contributions from a given forest block
+
+        Parameters:
+            block: The current block
+            sym: The symmetry
+            codomain, domain: The codomain and domain of the new tensor
+            coupled, dim_c: The coupled sector of the current block and its quantum dimension
+            a_sectors: The codomain uncoupled sectors [a1, a2, ..., aJ]
+            b_sectors: The domain uncoupled sectors [b1, b2, ..., bK]
+            tree_block_width: Equal to ``tree_block_size(domain, b_sectors)``
+            tree_block_height: Equal to ``tree_block_size(codomain, a_sectors)``
+            i1_init, i2_init: The start indices of the current forest block within the block
+
+        Returns:
+            entries: The entries of the dense block corresponding to the given uncoupled sectors.
+                     Legs [a1,...,aJ, b1,...,bK, m1,...,mJ, n1,...,nK]
+            num_alpha_trees: The number of fusion trees from ``a_sectors`` to ``coupled``
+            num_beta_trees : The number of fusion trees from ``b_sectors`` to ``coupled``
+        """
+        # OPTIMIZE do one loop per vertex in the tree instead.
+        i1 = i1_init  # i1: start row index of the current tree block within the block
+        i2 = i2_init  # i2: start column index of the current tree block within the block
+        alpha_tree_iter = fusion_trees(sym, a_sectors, coupled, [sp.is_dual for sp in codomain.spaces])
+        beta_tree_iter = fusion_trees(sym, b_sectors, coupled, [sp.is_dual for sp in domain.spaces])
+        entries = self.zero_block([*a_dims, *b_dims, *m_dims, *n_dims], dtype)
+        for alpha_tree in alpha_tree_iter:
+            Y = self.block_conj(alpha_tree.as_block(backend=self))  # [a1,...,aJ,c]
+            for beta_tree in beta_tree_iter:
+                X = beta_tree.as_block(backend=self)  # [b1,...,bK,c]
+                symmetry_data = self.block_tdot(Y, X, -1, -1)  # [a1,...,aJ,b1,...,bK]
+                idx1 = slice(i1, i1 + tree_block_height)
+                idx2 = slice(i2, i2 + tree_block_width)
+                degeneracy_data = block[idx1, idx2]  # [M, N]
+                # [M, N] -> [m1,...,mJ,n1,...,nK]
+                degeneracy_data = self.block_reshape(degeneracy_data, m_dims + n_dims)
+                entries += self.block_outer(symmetry_data, degeneracy_data)  # [{aj} {bk} {mj} {nk}]
+                i2 += tree_block_width
+            i2 = i2_init  # reset to the left of the current forest-block
+            i1 += tree_block_height
+        num_alpha_trees = len(alpha_tree_iter)  # OPTIMIZE count loop iterations above instead?
+                                                #          (same in _add_forest_block_entries)
+        num_beta_trees = len(beta_tree_iter)
+        return entries, num_alpha_trees, num_beta_trees
 
     def _add_forest_block_entries(self, block, entries, sym: Symmetry, codomain, domain, coupled,
                                 dim_c, a_sectors, b_sectors, tree_block_width, tree_block_height,
@@ -508,385 +896,3 @@ class FusionTreeBackend(Backend, BlockBackend, metaclass=ABCMeta):
         num_alpha_trees = len(alpha_tree_iter)  # OPTIMIZE count loop iterations above instead?
         num_beta_trees = len(beta_tree_iter)
         return num_alpha_trees, num_beta_trees
-
-    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
-        dtype = self.block_dtype(a)
-        a = self.apply_basis_perm(a, co_domain.spaces)
-        coupled_sectors = co_domain.sectors
-        blocks = []
-        for coupled, mult, slc in zip(co_domain.sectors, co_domain.multiplicities, co_domain.slices):
-            dim_c = co_domain.symmetry.sector_dim(coupled)
-            entries = self.block_reshape(a[slice(*slc)], (dim_c, mult))
-            # project onto the identity on the coupled sector
-            block = self.block_sum(entries, 0) / dim_c
-            projected = self.block_outer(self.ones_block([dim_c], dtype=dtype), block)
-            if self.block_norm(entries - projected) > tol * self.block_norm(entries):
-                raise ValueError('Block is not symmetric up to tolerance.')
-            blocks.append(block)
-        return FusionTreeData(coupled_sectors, blocks, co_domain, co_domain, dtype)
-
-    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
-        coupled_sectors = co_domain.sectors
-        blocks = [func((block_size(co_domain, coupled),), coupled) for coupled in coupled_sectors]
-        if len(blocks) > 0:
-            sample_block = blocks[0]
-            coupled_sectors = np.asarray(coupled_sectors, int)
-        else:
-            sample_block = func((1,), co_domain.symmetry.trivial_sector)
-            coupled_sectors = co_domain.symmetry.empty_sector_array
-        dtype = self.block_dtype(sample_block)
-        return FusionTreeData(coupled_sectors, blocks, co_domain, co_domain, dtype)
-
-    def diagonal_all(self, a: DiagonalTensor) -> bool:
-        raise NotImplementedError
-
-    def diagonal_any(self, a: DiagonalTensor) -> bool:
-        raise NotImplementedError
-    
-    def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace) -> DiagonalData:
-        raise NotImplementedError('mask_from_block not implemented')  # TODO
-
-    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
-        
-    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
-
-    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
-
-    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> FusionTreeData:
-        coupled_sectors = []
-        blocks = []
-        for i, _ in iter_common_sorted_arrays(domain.sectors, codomain.sectors):
-            coupled = domain.sectors[i]
-            shape = (block_size(codomain, coupled), block_size(domain, coupled))
-            coupled_sectors.append(coupled)
-            blocks.append(func(shape, coupled))
-        if len(blocks) > 0:
-            sample_block = blocks[0]
-            coupled_sectors = np.asarray(coupled_sectors, int)
-        else:
-            sample_block = func((1, 1), codomain.symmetry.trivial_sector)
-            coupled_sectors = domain.symmetry.empty_sector_array
-        dtype = self.block_dtype(sample_block)
-        return FusionTreeData(coupled_sectors, blocks, domain, codomain, dtype)
-
-    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype
-                  ) -> FusionTreeData:
-        return FusionTreeData(coupled_sectors=codomain.symmetry.empty_sector_array, blocks=[],
-                              domain=domain, codomain=codomain, dtype=dtype)
-
-    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
-        return FusionTreeData(coupled_sectors=co_domain.symmetry.empty_sector_array, blocks=[],
-                              domain=co_domain, codomain=co_domain, dtype=dtype)
-
-    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> FusionTreeData:
-        # Note: the identity has the same matrix elements in all ONB, so ne need to consider
-        #       the basis perms.
-        coupled_sectors = co_domain.sectors
-        blocks = [self.eye_matrix(block_size(co_domain, c), dtype) for c in coupled_sectors]
-        return FusionTreeData(coupled_sectors, blocks, co_domain, co_domain, dtype)
-
-    def copy_data(self, a: SymmetricTensor) -> FusionTreeData:
-        return FusionTreeData(
-            coupled_sectors=a.data.coupled_sectors.copy(),  # OPTIMIZE do we need to copy these?
-            blocks=[self.block_copy(block) for block in a.data.blocks],
-            codomain=a.data.codomain, domain=a.data.domain
-        )
-
-    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int,
-                         max_lines: int) -> list[str]:
-        raise NotImplementedError  # TODO not yet reviewed
-        from ..dummy_config import printoptions
-        if len(a.data.blocks) == 0:
-            return [f'{indent}* Data : no non-zero blocks']
-
-        lines = []
-        for alpha_tree, beta_tree, entries in _tree_block_iter(a.data, backend=self):
-            # build (a_before_Z) <- (a_after_Z) <- coupled <- (b_after_Z) <- (b_before_Z)
-            a_before_Z, a_after_Z, coupled = alpha_tree._str_uncoupled_coupled(
-                a.symmetry, alpha_tree.uncoupled, alpha_tree.coupled, alpha_tree.are_dual
-            ).split(' -> ')
-            b_before_Z, b_after_Z, coupled = beta_tree._str_uncoupled_coupled(
-                a.symmetry, beta_tree.uncoupled, beta_tree.coupled, beta_tree.are_dual
-            ).split(' -> ')
-            sectors = f'{a_after_Z} <- {coupled} <- {b_after_Z}'
-            if a_before_Z != a_after_Z:
-                sectors = a_before_Z + ' <- ' + sectors
-            if b_before_Z != b_after_Z:
-                sectors = sectors + ' <- ' + b_before_Z
-
-            if a.symmetry.fusion_style is FusionStyle.single:
-                lines.append(f'{indent}* Data for sectors {sectors}')
-            elif a.symmetry.fusion_style is FusionStyle.multiple_unique:
-                # dont need multiplicity labels
-                a_inner = ', '.join(a.symmetry.sector_str(i) for i in alpha_tree.inner_sectors)
-                b_inner = ', '.join(a.symmetry.sector_str(i) for i in beta_tree.inner_sectors)
-                lines.append(f'{indent}* Data for trees {sectors}')
-                lines.append(f'{indent}  with inner sectors ({a_inner}) and ({b_inner})')
-            else:
-                a_inner = ', '.join(a.symmetry.sector_str(i) for i in alpha_tree.inner_sectors)
-                b_inner = ', '.join(a.symmetry.sector_str(i) for i in beta_tree.inner_sectors)
-                a_mults = ', '.join(map(str, alpha_tree.multiplicities))
-                b_mults = ', '.join(map(str, beta_tree.multiplicities))
-                lines.append(f'{indent}* Data for trees {sectors}')
-                lines.append(f'{indent}  with inner sectors ({a_inner}) and ({b_inner})')
-                lines.append(f'{indent}  with multiplicities ({a_mults}) <- ({b_mults})')
-            lines.extend(self._block_repr_lines(entries, indent=indent + printoptions.indent * ' ',
-                                                max_width=max_width, max_lines=max_lines))
-
-            if (len(lines) > max_lines) or any(len(line) > max_width for line in lines):
-                # fallback to just stating number of blocks.
-                num_entries = sum(prod(self.block_shape(b)) for b in a.data.blocks)
-                return [
-                    f'{indent}* Data: {num_entries} entries in {len(a.data.blocks)} blocks.'
-                ]
-        return lines
-
-    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int],
-             axs_b: list[int]) -> Data:
-        # TODO need to be able to specify levels of braiding in general case!
-        # TODO offer separate planar version? or just high
-        raise NotImplementedError('tdot not implemented')  # TODO
-
-    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None,
-            compute_u: bool, compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
-        # TODO need to redesign Backend.svd specification! need to allow more than two legs!
-        # TODO need to be able to specify levels of braiding in general case!
-        raise NotImplementedError('svd not implemented')  # TODO
-
-    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool
-           ) -> tuple[Data, Data, ElementarySpace]:
-        # TODO do SVD first, comments there apply.
-        raise NotImplementedError('qr not implemented')  # TODO
-
-    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        # TODO what target leg order is easiest? does it match the one specified in Backend.outer?
-        raise NotImplementedError('outer not implemented')  # TODO
-
-    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool,
-              axs2: list[int] | None) -> complex:
-        raise NotImplementedError('inner not implemented')  # TODO
-    
-    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
-        # TODO decide signature
-        raise NotImplementedError('permute_legs not implemented')  # TODO
-
-    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]
-                   ) -> float | complex:
-        raise NotImplementedError('trace_full not implemented')  # TODO
-
-    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int],
-                      remaining_idcs: list[int]) -> Data:
-        raise NotImplementedError('trace_partial not implemented')  # TODO
-
-    def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
-        raise NotImplementedError('diagonal_tensor_trace_full not implemented')  # TODO
-
-    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
-        # TODO what does this even mean? transpose of dagger?
-        # TODO should we offer transpose and dagger too?
-        raise NotImplementedError('conj not implemented')  # TODO
-
-    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int],
-                     product_spaces: list[ProductSpace], new_axes: list[int],
-                     final_legs: list[Space]) -> Data:
-        raise NotImplementedError('combine_legs not implemented')  # TODO
-        
-    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int],
-                   final_legs: list[Space]) -> Data:
-        # TODO do we need metadata to split, like in abelian?
-        raise NotImplementedError('split_legs not implemented')  # TODO
-
-    def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
-                        co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
-                        ) -> Data:
-        raise NotImplementedError('add_trivial_leg not implemented')  # TODO
-
-    def almost_equal(self, a: SymmetricTensor, b: SymmetricTensor, rtol: float, atol: float
-                     ) -> bool:
-        for i, j in iter_common_noncommon_sorted_arrays(a.data.coupled_sectors, b.data.coupled_sectors):
-            if j is None:
-                if self.block_max_abs(a.data.blocks[i]) > atol:
-                    return False
-            if i is None:
-                if self.block_max_abs(b.data.blocks[j]) > atol:
-                    return False
-            else:
-                if not self.block_allclose(a.data.blocks[i], b.data.blocks[j], rtol=rtol, atol=atol):
-                    return False
-        return True
-
-    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
-        raise NotImplementedError('squeeze_legs not implemented')  # TODO
-
-    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
-        # OPTIMIZE should we offer the square-norm instead?
-        norm_sq = 0
-        for coupled, block in zip(a.data.coupled_sectors, a.data.blocks):
-            norm_sq += a.symmetry.sector_dim(coupled) * (self.block_norm(block) ** 2)
-        return self.block_sqrt(norm_sq)
-
-    def act_block_diagonal_square_matrix(self, a: SymmetricTensor,
-                                         block_method: Callable[[Block], Block]) -> Data:
-        raise NotImplementedError('act_block_diagonal_square_matrix not implemented')  # TODO
-
-    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        assert a.data.num_domain_legs == b.data.num_domain_legs
-        dtype = a.data.dtype.common(b.data.dtype)
-        a_blocks = [self.block_to_dtype(_a, dtype) for _a in a.data.blocks]
-        b_blocks = [self.block_to_dtype(_b, dtype) for _b in b.data.blocks]
-        blocks = []
-        coupled_sectors = []
-        for i, j in iter_common_noncommon_sorted_arrays(a.data.coupled_sectors, b.data.coupled_sectors):
-            if i is None:
-                blocks.append(b_blocks[j])
-                coupled_sectors.append(b.data.coupled_sectors[j])
-            elif j is None:
-                blocks.append(a_blocks[i])
-                coupled_sectors.append(a.data.coupled_sectors[i])
-            else:
-                blocks.append(self.block_add(a_blocks[i], b_blocks[j]))
-                coupled_sectors.append(a.data.coupled_sectors[i])
-        if len(blocks) == 0:
-            coupled_sectors = a.symmetry.empty_sector_array
-        else:
-            coupled_sectors = np.array(coupled_sectors)
-        return FusionTreeData(coupled_sectors, blocks, a.data.domain, a.data.codomain, dtype)
-
-    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
-        if a == 0.:
-            return self.zero_data(b.codomain, b.domain, b.dtype)
-        blocks = [self.block_mul(a, T) for T in b.data.blocks]
-        if len(blocks) == 0:
-            if isinstance(a, float):
-                dtype = b.data.dtype
-            else:
-                dtype = b.data.dtype.to_complex()
-        else:
-            dtype = self.block_dtype(blocks[0])
-        return FusionTreeData(b.data.coupled_sectors, blocks, b.data.domain, b.data.codomain, dtype)
-
-    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False,
-                  ) -> ElementarySpace:
-        raise NotImplementedError('infer_leg not implemented')  # TODO
-
-    def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
-        raise NotImplementedError('get_element not implemented')  # TODO
-
-    def get_element_diagonal(self, a: DiagonalTensor, idx: int) -> complex | float | bool:
-        raise NotImplementedError('get_element_diagonal not implemented')  # TODO
-
-    def set_element(self, a: SymmetricTensor, idcs: list[int], value: complex | float) -> Data:
-        # TODO not sure this can even be done sensibly, one entry of the dense block
-        #      affects in general many entries of the blocks.
-        raise NotImplementedError('set_element not implemented')  # TODO
-
-    def set_element_diagonal(self, a: DiagonalTensor, idx: int, value: complex | float | bool
-                             ) -> DiagonalData:
-        # TODO not sure this can even be done sensibly, one entry of the dense block
-        #      affects in general many entries of the blocks.
-        raise NotImplementedError('set_element_diagonal not implemented')  # TODO
-
-    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool
-                                       ) -> DiagonalData:
-        raise NotImplementedError('diagonal_tensor_from_full_tensor not implemented')  # TODO
-
-    def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
-        raise NotImplementedError('full_data_from_diagonal_tensor not implemented')  # TODO
-
-    def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
-        raise NotImplementedError('full_data_from_mask not implemented')  # TODO
-
-    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
-        raise NotImplementedError('scale_axis not implemented')  # TODO
-
-    # TODO how does entropy work here, should it consider quantum dimensions?
-
-    def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs,
-                                   maps_zero_to_zero: bool) -> DiagonalData:
-        if maps_zero_to_zero:
-            blocks = [func(b, **func_kwargs) for b in a.data.blocks]
-            coupled_sectors = a.data.coupled_sectors
-        else:
-            coupled_sectors = a.domain.sectors
-            blocks = []
-            for i, j in iter_common_noncommon_sorted_arrays(coupled_sectors, a.data.coupled_sectors):
-                if j is None:
-                    block = self.zero_block([block_size(a.domain, coupled_sectors[i])], dtype=a.dtype)
-                else:
-                    block = a.data.blocks[j]
-                blocks.append(func(block, **func_kwargs))
-        if len(blocks) > 0:
-            dtype = self.block_dtype(blocks[0])
-        else:
-            dtype = self.block_dtype(func(self.ones_block([1], dtype=a.dtype), **func_kwargs))
-        return FusionTreeData(coupled_sectors=coupled_sectors, blocks=blocks,
-                              domain=a.data.domain, codomain=a.data.codomain, dtype=dtype)
-
-    def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
-                                    func_kwargs, partial_zero_is_zero: bool) -> DiagonalData:
-        a_coupled = a.data.coupled_sectors
-        b_coupled = b.data.coupled_sectors
-        if partial_zero_is_zero:
-            blocks = []
-            coupled_sectors = []
-            for i, j in iter_common_sorted_arrays(a_coupled, b_coupled):
-                coupled = a_coupled[i]
-                coupled_sectors.append(coupled)
-                blocks.append(func(a.data.blocks[i], b.data.blocks[j], **func_kwargs))
-        else:
-            i_a = 0  # during the loop: a_coupled[:i_a] was already visited
-            i_b = 0  # same for b_coupled
-            coupled_sectors = a.domain.sectors
-            blocks = []
-            for coupled  in coupled_sectors:
-                if np.all(coupled == a_coupled[i_a]):
-                    a_block = a.data.block[i_a]
-                    i_a += 1
-                else:
-                    a_block = self.zero_block([block_size(a.domain, coupled)], dtype=a.dtype)
-                if np.all(coupled == b_coupled[i_b]):
-                    b_block = b.data.block[i_b]
-                    i_b += 1
-                else:
-                    b_block = self.zero_block([block_size(a.domain, coupled)], dtype=b.dtype)
-                blocks.append(func(a_block, b_block, **func_kwargs))
-        if len(blocks) > 0:
-            dtype = self.block_dtype(blocks[0])
-        else:
-            a_block = self.ones_block([1], dtype=a.dtype)
-            b_block = self.ones_block([1], dtype=b.dtype)
-            example_block = func(a_block, b_block, **func_kwargs)
-            dtype = self.block_dtype(example_block)
-        return FusionTreeData(coupled_sectors=coupled_sectors, blocks=blocks, domain=a.data.domain,
-                              codomain=a.data.codomain, dtype=dtype)
-
-    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
-        raise NotImplementedError('apply_mask_to_Tensor not implemented')  # TODO
-
-    def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
-        raise NotImplementedError('apply_mask_to_DiagonalTensor not implemented')  # TODO
-
-    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
-        # TODO do SVD first, comments there apply.
-        raise NotImplementedError('eigh not implemented')  # TODO
-
-    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
-        raise NotImplementedError('from_dense_block_trivial_sector not implemented')  # TODO
-
-    def to_dense_block_trivial_sector(self, tensor: SymmetricTensor) -> Block:
-        raise NotImplementedError('to_dense_block_trivial_sector not implemented')  # TODO
-
-    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
-                                               charge_leg: ElementarySpace) -> Data:
-        raise NotImplementedError('inv_part_from_dense_block_single_sector not implemented')  # TODO
-
-    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
-        raise NotImplementedError('inv_part_to_dense_block_single_sector not implemented')  # TODO
-
-    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
-                         flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
-        # TODO think carefully about what this means.
-        raise NotImplementedError('flip_leg_duality not implemented')  # TODO

--- a/tenpy/linalg/backends/fusion_tree_backend.py
+++ b/tenpy/linalg/backends/fusion_tree_backend.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from .abstract_backend import (
     Backend, BlockBackend, Block, Data, DiagonalData, MaskData, iter_common_sorted_arrays,
-    iter_common_noncommon_sorted_arrays, conventional_leg_order
+    iter_common_noncommon_sorted_arrays
 )
 from ..dtypes import Dtype
 from ..symmetries import Sector, SectorArray, Symmetry, FusionStyle

--- a/tenpy/linalg/backends/no_symmetry.py
+++ b/tenpy/linalg/backends/no_symmetry.py
@@ -67,9 +67,6 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
                                          ) -> Data:
         return block_method(a.data)
 
-    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        return self.block_add(a.data, b.data)
-
     def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
                         co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
                         ) -> Data:
@@ -217,6 +214,9 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
         return tensor.data[:, 0]
 
+    def linear_combination(self, a, v: SymmetricTensor, b, w: SymmetricTensor) -> Data:
+        return self.block_linear_combination(a, v.data, b, w.data)
+        
     def mask_binary_operand(self, mask1: Mask, mask2: Mask, func
                             ) -> tuple[DiagonalData, ElementarySpace]:
         large_leg = mask1.large_leg

--- a/tenpy/linalg/backends/no_symmetry.py
+++ b/tenpy/linalg/backends/no_symmetry.py
@@ -4,7 +4,7 @@ from abc import ABCMeta
 from typing import TYPE_CHECKING, Callable
 import numpy as np
 
-from .abstract_backend import Backend, BlockBackend, Data, DiagonalData, Block
+from .abstract_backend import Backend, BlockBackend, Data, DiagonalData, Block, conventional_leg_order
 from ..dtypes import Dtype
 from ..symmetries import no_symmetry, Symmetry
 from ..spaces import Space, ElementarySpace, ProductSpace
@@ -15,7 +15,7 @@ __all__ = ['NoSymmetryBackend']
 if TYPE_CHECKING:
     # can not import Tensor at runtime, since it would be a circular import
     # this clause allows mypy etc to evaluate the type-hints anyway
-    from ..tensors import BlockDiagonalTensor, DiagonalTensor, Mask
+    from ..tensors import SymmetricTensor, DiagonalTensor, Mask
 
 
 # TODO eventually remove BlockBackend inheritance, it is not needed,
@@ -29,8 +29,9 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     -----
     The data stored for the various tensor classes defined in ``tenpy.linalg.tensors`` is::
 
-        - ``Tensor``:
+        - ``SymmetricTensor``:
             A single Block with as many axes as there a legs on the tensor.
+            Same leg order as ``Tensor.legs``, i.e. ``[*codomain, *reversed(domain)]``.
 
         - ``DiagonalTensor`` :
             A single 1D Block. The diagonal of the corresponding 2D block of a ``Tensor``.
@@ -39,18 +40,18 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
             These bool values indicate which indices of the large leg are kept for the small leg.
 
     """
-    DataCls = "Block of BlockBackend"
+    DataCls = "Block of BlockBackend"  # is dynamically set by __init__
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.DataCls = self.BlockCls
 
-    def test_data_sanity(self, a: BlockDiagonalTensor | DiagonalTensor | Mask, is_diagonal: bool):
+    def test_data_sanity(self, a: SymmetricTensor | DiagonalTensor | Mask, is_diagonal: bool):
         super().test_data_sanity(a, is_diagonal=is_diagonal)
         if is_diagonal:
             assert self.block_shape(a.data) == (a.legs[0].dim,), f'{self.block_shape(a)} != {(a.legs[0].dim,)}'
         else:
-            assert self.block_shape(a.data) == tuple(a.shape), f'{self.block_shape(a)} != {tuple(a.shape.dims)}'
+            assert self.block_shape(a.data) == a.shape, f'{self.block_shape(a)} != {a.shape}'
 
     def test_mask_sanity(self, a: Mask):
         super().test_mask_sanity(a)
@@ -60,7 +61,7 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def get_dtype_from_data(self, a: Data) -> Dtype:
         return self.block_dtype(a)
 
-    def to_dtype(self, a: BlockDiagonalTensor, dtype: Dtype) -> Data:
+    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> Data:
         return self.block_to_dtype(a.data, dtype)
 
     def supports_symmetry(self, symmetry: Symmetry) -> bool:
@@ -69,143 +70,181 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def data_item(self, a: Data | DiagonalData) -> float | complex:
         return self.block_item(a)
 
-    def to_dense_block(self, a: BlockDiagonalTensor) -> Block:
+    def to_dense_block(self, a: SymmetricTensor) -> Block:
         return self.apply_basis_perm(a.data, a.legs, inv=True)
 
     def diagonal_to_block(self, a: DiagonalTensor) -> Block:
-        return self.apply_basis_perm(a.data, [a.legs[0]], inv=True)
+        return self.apply_basis_perm(a.data, [a.leg], inv=True)
 
-    def from_dense_block(self, a: Block, legs: list[Space], num_domain_legs: int,
-                         tol: float = 1e-8) -> Data:
-        assert all(leg.symmetry == no_symmetry for leg in legs)
-        return self.apply_basis_perm(a, legs)
+    def from_dense_block(self, a: Block, codomain: ProductSpace, domain: ProductSpace, tol: float
+                         ) -> Data:
+        assert codomain.symmetry == domain.symmetry == no_symmetry
+        return self.apply_basis_perm(a, list(conventional_leg_order(codomain, domain)))
 
-    def diagonal_from_block(self, a: Block, leg: Space) -> DiagonalData:
-        return self.apply_basis_perm(a, [leg])
+    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
+        return self.apply_basis_perm(a, co_domain.spaces)
+
+    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
+        coupled = co_domain.symmetry.trivial_sector
+        shape = (co_domain.dim,)
+        return func(shape, coupled)
 
     def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace
                         ) -> DiagonalData:
-        data = self.block_to_dtype(a, Dtype.bool)
         data = self.apply_basis_perm(data, [large_leg])
         return data
 
-    def from_block_func(self, func, legs: list[Space], num_domain_legs: int, func_kwargs={}):
-        return func(tuple(l.dim for l in legs), **func_kwargs)
+    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+        
+    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError
+    
+    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError  # TODO
 
-    def diagonal_from_block_func(self, func, leg: Space, func_kwargs={}) -> DiagonalData:
-        return func((leg.dim,), **func_kwargs)
+    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> Data:
+        """Generate tensor data from a function ``func(shape: tuple[int], coupled: Sector) -> Block``."""
+        coupled = codomain.symmetry.trivial_sector
+        shape = tuple(l.dim for l in conventional_leg_order(codomain, domain))
+        return func(shape, coupled)
 
-    def zero_data(self, legs: list[Space], dtype: Dtype, num_domain_legs: int):
-        return self.zero_block(shape=[l.dim for l in legs], dtype=dtype)
+    def from_random_normal(self, codomain: ProductSpace, domain: ProductSpace, sigma: float,
+                           dtype: Dtype) -> Data:
+        raise NotImplementedError  # TODO
 
-    def zero_diagonal_data(self, leg: Space, dtype: Dtype) -> DiagonalData:
-        return self.zero_block(shape=[leg.dim], dtype=dtype)
+    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype):
+        return self.zero_block(shape=[l.dim for l in conventional_leg_order(codomain, domain)],
+                               dtype=dtype)
 
-    def eye_data(self, legs: list[Space], dtype: Dtype) -> Data:
+    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
+        return self.zero_block(shape=[co_domain.dim], dtype=dtype)
+
+    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> Data:
         # Note: the identity has the same matrix elements in all ONB, so ne need to consider
         #       the basis perms.
-        return self.eye_block(legs=[l.dim for l in legs], dtype=dtype)
+        return self.eye_block(legs=[l.dim for l in co_domain.spaces], dtype=dtype)
 
-    def copy_data(self, a: BlockDiagonalTensor | DiagonalTensor) -> Data | DiagonalData:
+    def copy_data(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
         return self.block_copy(a.data)
 
-    def _data_repr_lines(self, a: BlockDiagonalTensor, indent: str, max_width: int, max_lines: int):
+    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int, max_lines: int):
+        raise NotImplementedError  # TODO not yet reviewed
         return [f'{indent}* Data:'] + self._block_repr_lines(a.data, indent=indent + '  ', max_width=max_width,
                                                             max_lines=max_lines - 1)
 
-    def tdot(self, a: BlockDiagonalTensor, b: BlockDiagonalTensor, axs_a: list[int], axs_b: list[int]) -> Data:
+    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int], axs_b: list[int]) -> Data:
+        # TODO interface may change
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_tdot(a.data, b.data, axs_a, axs_b)
 
-    def svd(self, a: BlockDiagonalTensor, new_vh_leg_dual: bool, algorithm: str | None, compute_u: bool,
+    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None, compute_u: bool,
             compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
+        raise NotImplementedError  # TODO not yet reviewed
         u, s, vh = self.matrix_svd(a.data, algorithm=algorithm, compute_u=compute_u, compute_vh=compute_vh)
         new_leg = ElementarySpace.from_trivial_sector(len(s), is_dual=new_vh_leg_dual)
         return u, s, vh, new_leg
 
-    def qr(self, a: BlockDiagonalTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
+    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
+        raise NotImplementedError  # TODO not yet reviewed
         q, r = self.matrix_qr(a.data, full=full)
         new_leg_dim = self.block_shape(r)[0]
         new_leg = ElementarySpace.from_trivial_sector(new_leg_dim, is_dual=new_r_leg_dual)
         return q, r, new_leg
 
-    def outer(self, a: BlockDiagonalTensor, b: BlockDiagonalTensor) -> Data:
+    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_outer(a.data, b.data)
 
-    def inner(self, a: BlockDiagonalTensor, b: BlockDiagonalTensor, do_conj: bool, axs2: list[int] | None) -> complex:
+    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool, axs2: list[int] | None) -> complex:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_inner(a.data, b.data, do_conj=do_conj, axs2=axs2)
 
-    def permute_legs(self, a: BlockDiagonalTensor, permutation: list[int] | None, num_domain_legs: int) -> Data:
+    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
+        # TODO decide signature
+        raise NotImplementedError  # TODO not yet reviewed
         if permutation is None:
             return a.data
         return self.block_permute_axes(a.data, permutation)
 
-    def trace_full(self, a: BlockDiagonalTensor, idcs1: list[int], idcs2: list[int]) -> float | complex:
+    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]) -> float | complex:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_trace_full(a.data, idcs1, idcs2)
 
-    def trace_partial(self, a: BlockDiagonalTensor, idcs1: list[int], idcs2: list[int], remaining_idcs: list[int]) -> Data:
+    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int], remaining_idcs: list[int]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_trace_partial(a.data, idcs1, idcs2, remaining_idcs)
 
     def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_sum_all(a.data)
 
-    def conj(self, a: BlockDiagonalTensor | DiagonalTensor) -> Data | DiagonalData:
+    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_conj(a.data)
 
-    def combine_legs(self, a: BlockDiagonalTensor, combine_slices: list[int, int],
+    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int],
                      product_spaces: list[ProductSpace], new_axes: list[int],
                      final_legs: list[Space]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_combine_legs(a.data, combine_slices)
 
-    def split_legs(self, a: BlockDiagonalTensor, leg_idcs: list[int],
+    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int],
                    final_legs: list[Space]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_split_legs(a.data, leg_idcs, [[s.dim for s in a.legs[i].spaces]
                                                         for i in leg_idcs])
 
-    def add_trivial_leg(self, a: BlockDiagonalTensor, pos: int, to_domain: bool) -> Data:
-        return self.block_add_axis(a.data, pos)
+    def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
+                        co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
+                        ) -> Data:
+        return self.block_add_axis(a.data, legs_pos)
 
-    def almost_equal(self, a: BlockDiagonalTensor, b: BlockDiagonalTensor, rtol: float, atol: float) -> bool:
+    def almost_equal(self, a: SymmetricTensor, b: SymmetricTensor, rtol: float, atol: float) -> bool:
         return self.block_allclose(a.data, b.data, rtol=rtol, atol=atol)
 
-    def squeeze_legs(self, a: BlockDiagonalTensor, idcs: list[int]) -> Data:
+    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_squeeze_legs(a.data, idcs)
 
-    def norm(self, a: BlockDiagonalTensor | DiagonalTensor, order: int | float = 2) -> float:
+    def norm(self, a: SymmetricTensor | DiagonalTensor, order: int | float = 2) -> float:
         return self.block_norm(a.data, order=order)
 
-    def act_block_diagonal_square_matrix(self, a: BlockDiagonalTensor, block_method: Callable[[Block], Block]
+    def act_block_diagonal_square_matrix(self, a: SymmetricTensor, block_method: Callable[[Block], Block]
                                          ) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return block_method(a.data)
 
-    def add(self, a: BlockDiagonalTensor, b: BlockDiagonalTensor) -> Data:
+    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
         return self.block_add(a.data, b.data)
 
-    def mul(self, a: float | complex, b: BlockDiagonalTensor) -> Data:
+    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
         return self.block_mul(a, b.data)
 
     def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False,
                   is_real: bool = False) -> ElementarySpace:
+        raise NotImplementedError  # TODO not yet reviewed
         idx, *more = [n for n, leg in enumerate(legs) if leg is None]
         if more:
             raise ValueError('Can only infer one leg')
         dim = self.block_shape(block)[idx]
         return ElementarySpace.from_trivial_sector(dim, is_dual=is_dual)
 
-    def get_element(self, a: BlockDiagonalTensor, idcs: list[int]) -> complex | float | bool:
+    def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
         return self.get_block_element(a.data, idcs)
 
     def get_element_diagonal(self, a: DiagonalTensor, idx: int) -> complex | float | bool:
         # a.data is a single 1D block
         return self.get_block_element(a.data, [idx])
 
-    def set_element(self, a: BlockDiagonalTensor, idcs: list[int], value: complex | float) -> Data:
+    def set_element(self, a: SymmetricTensor, idcs: list[int], value: complex | float) -> Data:
         return self.set_block_element(a.data, idcs, value)
 
     def set_element_diagonal(self, a: DiagonalTensor, idx: int, value: complex | float | bool
                              ) -> DiagonalData:
         return self.set_block_element(a.data, [idx], value)
     
-    def diagonal_data_from_full_tensor(self, a: BlockDiagonalTensor, check_offdiagonal: bool) -> DiagonalData:
+    def diagonal_data_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
         return self.block_get_diagonal(a.data, check_offdiagonal=check_offdiagonal)
 
     def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
@@ -214,7 +253,8 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
         return self.block_from_mask(a.data, dtype=dtype)
 
-    def scale_axis(self, a: BlockDiagonalTensor, b: DiagonalTensor, leg: int) -> Data:
+    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_scale_axis(a.data, b.data, leg)
 
     def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs, maps_zero_to_zero: bool
@@ -226,30 +266,41 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
                                     ) -> DiagonalData:
         return func(a.data, b.data, **func_kwargs)
 
-    def apply_mask_to_Tensor(self, tensor: BlockDiagonalTensor, mask: Mask, leg_idx: int) -> Data:
+    def diagonal_all(self, a: DiagonalTensor) -> bool:
+        return self.block_all(a.data)
+
+    def diagonal_any(self, a: DiagonalTensor) -> bool:
+        return self.block_any(a.data)
+
+    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
         return self.apply_mask_to_block(tensor.data, mask.data, ax=leg_idx)
 
     def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
         return self.apply_mask_to_block(tensor.data, mask.data, ax=0)
 
-    def eigh(self, a: BlockDiagonalTensor, sort: str = None) -> tuple[DiagonalData, Data]:
+    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.block_eigh(a.data, sort=sort)
 
-    def from_flat_block_trivial_sector(self, block: Block, leg: Space) -> Data:
+    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         assert self.block_shape(block) == (leg.dim,)
         return self.apply_basis_perm(block, [leg])
 
-    def to_flat_block_trivial_sector(self, tensor: BlockDiagonalTensor) -> Block:
+    def to_dense_block_trivial_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.apply_basis_perm(tensor.data, tensor.legs, inv=True)
 
-    def inv_part_from_flat_block_single_sector(self, block: Block, leg: Space,
-                                               dummy_leg: ElementarySpace) -> Data:
-        block = self.apply_basis_perm(block, [leg])
+    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
+                                               charge_leg: ElementarySpace) -> Data:
+        block = self.apply_basis_perm(vector, [space])
         return self.block_add_axis(block, pos=1)
 
-    def inv_part_to_flat_block_single_sector(self, tensor: BlockDiagonalTensor) -> Block:
+    def inv_part_to_flat_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+        raise NotImplementedError  # TODO not yet reviewed
         return self.apply_basis_perm(tensor.data[:, 0], [tensor.legs[0]], inv=True)
 
-    def flip_leg_duality(self, tensor: BlockDiagonalTensor, which_legs: list[int],
+    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
                          flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed
         return tensor.data

--- a/tenpy/linalg/backends/no_symmetry.py
+++ b/tenpy/linalg/backends/no_symmetry.py
@@ -130,7 +130,7 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
         return self.block_sum_all(a.data)
 
-    def diagonal_to_block(self, a: DiagonalTensor) -> Block:
+    def diagonal_tensor_to_block(self, a: DiagonalTensor) -> Block:
         return self.apply_basis_perm(a.data, [a.leg], inv=True)
 
     def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:

--- a/tenpy/linalg/backends/no_symmetry.py
+++ b/tenpy/linalg/backends/no_symmetry.py
@@ -58,142 +58,14 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
         assert self.block_shape(a.data) == (a.legs[0].dim,)
         assert self.block_sum_all(a.data) == a.legs[1].dim
 
-    def get_dtype_from_data(self, a: Data) -> Dtype:
-        return self.block_dtype(a)
+    # ABSTRACT METHODS:
 
-    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> Data:
-        return self.block_to_dtype(a.data, dtype)
+    def act_block_diagonal_square_matrix(self, a: SymmetricTensor, block_method: Callable[[Block], Block]
+                                         ) -> Data:
+        return block_method(a.data)
 
-    def supports_symmetry(self, symmetry: Symmetry) -> bool:
-        return symmetry == no_symmetry
-
-    def data_item(self, a: Data | DiagonalData) -> float | complex:
-        return self.block_item(a)
-
-    def to_dense_block(self, a: SymmetricTensor) -> Block:
-        return self.apply_basis_perm(a.data, a.legs, inv=True)
-
-    def diagonal_to_block(self, a: DiagonalTensor) -> Block:
-        return self.apply_basis_perm(a.data, [a.leg], inv=True)
-
-    def from_dense_block(self, a: Block, codomain: ProductSpace, domain: ProductSpace, tol: float
-                         ) -> Data:
-        assert codomain.symmetry == domain.symmetry == no_symmetry
-        return self.apply_basis_perm(a, list(conventional_leg_order(codomain, domain)))
-
-    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
-        return self.apply_basis_perm(a, co_domain.spaces)
-
-    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
-        coupled = co_domain.symmetry.trivial_sector
-        shape = (co_domain.dim,)
-        return func(shape, coupled)
-
-    def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace
-                        ) -> DiagonalData:
-        data = self.apply_basis_perm(data, [large_leg])
-        return data
-
-    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
-        
-    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError
-    
-    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
-        raise NotImplementedError  # TODO
-
-    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> Data:
-        """Generate tensor data from a function ``func(shape: tuple[int], coupled: Sector) -> Block``."""
-        coupled = codomain.symmetry.trivial_sector
-        shape = tuple(l.dim for l in conventional_leg_order(codomain, domain))
-        return func(shape, coupled)
-
-    def from_random_normal(self, codomain: ProductSpace, domain: ProductSpace, sigma: float,
-                           dtype: Dtype) -> Data:
-        raise NotImplementedError  # TODO
-
-    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype):
-        return self.zero_block(shape=[l.dim for l in conventional_leg_order(codomain, domain)],
-                               dtype=dtype)
-
-    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
-        return self.zero_block(shape=[co_domain.dim], dtype=dtype)
-
-    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> Data:
-        # Note: the identity has the same matrix elements in all ONB, so ne need to consider
-        #       the basis perms.
-        return self.eye_block(legs=[l.dim for l in co_domain.spaces], dtype=dtype)
-
-    def copy_data(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
-        return self.block_copy(a.data)
-
-    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int, max_lines: int):
-        raise NotImplementedError  # TODO not yet reviewed
-        return [f'{indent}* Data:'] + self._block_repr_lines(a.data, indent=indent + '  ', max_width=max_width,
-                                                            max_lines=max_lines - 1)
-
-    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int], axs_b: list[int]) -> Data:
-        # TODO interface may change
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_tdot(a.data, b.data, axs_a, axs_b)
-
-    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None, compute_u: bool,
-            compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
-        raise NotImplementedError  # TODO not yet reviewed
-        u, s, vh = self.matrix_svd(a.data, algorithm=algorithm, compute_u=compute_u, compute_vh=compute_vh)
-        new_leg = ElementarySpace.from_trivial_sector(len(s), is_dual=new_vh_leg_dual)
-        return u, s, vh, new_leg
-
-    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
-        raise NotImplementedError  # TODO not yet reviewed
-        q, r = self.matrix_qr(a.data, full=full)
-        new_leg_dim = self.block_shape(r)[0]
-        new_leg = ElementarySpace.from_trivial_sector(new_leg_dim, is_dual=new_r_leg_dual)
-        return q, r, new_leg
-
-    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_outer(a.data, b.data)
-
-    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool, axs2: list[int] | None) -> complex:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_inner(a.data, b.data, do_conj=do_conj, axs2=axs2)
-
-    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
-        # TODO decide signature
-        raise NotImplementedError  # TODO not yet reviewed
-        if permutation is None:
-            return a.data
-        return self.block_permute_axes(a.data, permutation)
-
-    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]) -> float | complex:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_trace_full(a.data, idcs1, idcs2)
-
-    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int], remaining_idcs: list[int]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_trace_partial(a.data, idcs1, idcs2, remaining_idcs)
-
-    def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_sum_all(a.data)
-
-    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_conj(a.data)
-
-    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int],
-                     product_spaces: list[ProductSpace], new_axes: list[int],
-                     final_legs: list[Space]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_combine_legs(a.data, combine_slices)
-
-    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int],
-                   final_legs: list[Space]) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        return self.block_split_legs(a.data, leg_idcs, [[s.dim for s in a.legs[i].spaces]
-                                                        for i in leg_idcs])
+    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        return self.block_add(a.data, b.data)
 
     def add_trivial_leg(self, a: SymmetricTensor, legs_pos: int, add_to_domain: bool,
                         co_domain_pos: int, new_codomain: ProductSpace, new_domain: ProductSpace
@@ -203,32 +75,107 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def almost_equal(self, a: SymmetricTensor, b: SymmetricTensor, rtol: float, atol: float) -> bool:
         return self.block_allclose(a.data, b.data, rtol=rtol, atol=atol)
 
-    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
+    def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
+        return self.apply_mask_to_block(tensor.data, mask.data, ax=0)
+
+    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
+        return self.apply_mask_to_block(tensor.data, mask.data, ax=leg_idx)
+
+    def combine_legs(self, a: SymmetricTensor, combine_slices: list[int, int],
+                     product_spaces: list[ProductSpace], new_axes: list[int],
+                     final_legs: list[Space]) -> Data:
         raise NotImplementedError  # TODO not yet reviewed
-        return self.block_squeeze_legs(a.data, idcs)
+        return self.block_combine_legs(a.data, combine_slices)
 
-    def norm(self, a: SymmetricTensor | DiagonalTensor, order: int | float = 2) -> float:
-        return self.block_norm(a.data, order=order)
+    def conj(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
+        return self.block_conj(a.data)
 
-    def act_block_diagonal_square_matrix(self, a: SymmetricTensor, block_method: Callable[[Block], Block]
-                                         ) -> Data:
-        raise NotImplementedError  # TODO not yet reviewed
-        return block_method(a.data)
+    def copy_data(self, a: SymmetricTensor | DiagonalTensor) -> Data | DiagonalData:
+        return self.block_copy(a.data)
 
-    def add(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
-        return self.block_add(a.data, b.data)
+    def data_item(self, a: Data | DiagonalData) -> float | complex:
+        return self.block_item(a)
 
-    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
-        return self.block_mul(a, b.data)
+    def _data_repr_lines(self, a: SymmetricTensor, indent: str, max_width: int, max_lines: int):
+        block_lines = self._block_repr_lines(a.data, indent=indent + '  ', max_width=max_width,
+                                             max_lines=max_lines - 1)
+        return [f'{indent}* Data:', *block_lines]
 
-    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False,
-                  is_real: bool = False) -> ElementarySpace:
-        raise NotImplementedError  # TODO not yet reviewed
-        idx, *more = [n for n, leg in enumerate(legs) if leg is None]
-        if more:
-            raise ValueError('Can only infer one leg')
-        dim = self.block_shape(block)[idx]
-        return ElementarySpace.from_trivial_sector(dim, is_dual=is_dual)
+    def diagonal_all(self, a: DiagonalTensor) -> bool:
+        return self.block_all(a.data)
+
+    def diagonal_any(self, a: DiagonalTensor) -> bool:
+        return self.block_any(a.data)
+
+    def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
+                                    func_kwargs, partial_zero_is_zero: bool
+                                    ) -> DiagonalData:
+        return func(a.data, b.data, **func_kwargs)
+    
+    def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs, maps_zero_to_zero: bool
+                                   ) -> DiagonalData:
+        return func(a.data, **func_kwargs)
+    
+    def diagonal_from_block(self, a: Block, co_domain: ProductSpace, tol: float) -> DiagonalData:
+        return self.apply_basis_perm(a, co_domain.spaces)
+
+    def diagonal_from_sector_block_func(self, func, co_domain: ProductSpace) -> DiagonalData:
+        coupled = co_domain.symmetry.trivial_sector
+        shape = (co_domain.dim,)
+        return func(shape, coupled)
+
+    def diagonal_tensor_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
+        return self.block_get_diagonal(a.data, check_offdiagonal=check_offdiagonal)
+
+    def diagonal_tensor_trace_full(self, a: DiagonalTensor) -> float | complex:
+        return self.block_sum_all(a.data)
+
+    def diagonal_to_block(self, a: DiagonalTensor) -> Block:
+        return self.apply_basis_perm(a.data, [a.leg], inv=True)
+
+    def diagonal_to_mask(self, tens: DiagonalTensor) -> tuple[DiagonalData, ElementarySpace]:
+        raise NotImplementedError  # TODO
+
+    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
+        return self.block_eigh(a.data, sort=sort)
+
+    def eye_data(self, co_domain: ProductSpace, dtype: Dtype) -> Data:
+        # Note: the identity has the same matrix elements in all ONB, so ne need to consider
+        #       the basis perms.
+        return self.eye_block(legs=[l.dim for l in co_domain.spaces], dtype=dtype)
+
+    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
+                         flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
+        return tensor.data
+
+    def from_dense_block(self, a: Block, codomain: ProductSpace, domain: ProductSpace, tol: float
+                         ) -> Data:
+        return self.apply_basis_perm(a, conventional_leg_order(codomain, domain))
+
+    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
+        # there are no other sectors, so this is just the unmodified block.
+        assert self.block_shape(block) == (leg.dim,)
+        return self.apply_basis_perm(block, [leg])
+
+    def from_random_normal(self, codomain: ProductSpace, domain: ProductSpace, sigma: float,
+                           dtype: Dtype) -> Data:
+        shape = [leg.dim for leg in conventional_leg_order(codomain, domain)]
+        return self.block_random_normal(shape, dtype=dtype, sigma=sigma)
+
+    def from_sector_block_func(self, func, codomain: ProductSpace, domain: ProductSpace) -> Data:
+        """Generate tensor data from a function ``func(shape: tuple[int], coupled: Sector) -> Block``."""
+        coupled = codomain.symmetry.trivial_sector
+        shape = tuple(l.dim for l in conventional_leg_order(codomain, domain))
+        return func(shape, coupled)
+
+    def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
+        return self.block_from_diagonal(a.data)
+
+    def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
+        return self.block_from_mask(a.data, dtype=dtype)
+
+    def get_dtype_from_data(self, a: Data) -> Dtype:
+        return self.block_dtype(a)
 
     def get_element(self, a: SymmetricTensor, idcs: list[int]) -> complex | float | bool:
         return self.get_block_element(a.data, idcs)
@@ -237,6 +184,66 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
         # a.data is a single 1D block
         return self.get_block_element(a.data, [idx])
 
+    def infer_leg(self, block: Block, legs: list[Space | None], is_dual: bool = False
+                  ) -> ElementarySpace:
+        idx, *more = [n for n, leg in enumerate(legs) if leg is None]
+        if more:
+            raise ValueError('Can only infer one leg')
+        dim = self.block_shape(block)[idx]
+        return ElementarySpace.from_trivial_sector(dim, is_dual=is_dual)
+
+    def inner(self, a: SymmetricTensor, b: SymmetricTensor, do_conj: bool, axs2: list[int] | None) -> complex:
+        raise NotImplementedError  # TODO not yet reviewed
+        return self.block_inner(a.data, b.data, do_conj=do_conj, axs2=axs2)
+
+    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
+                                                charge_leg: ElementarySpace) -> Data:
+        block = self.apply_basis_perm(vector, [space])
+        return self.block_add_axis(block, pos=1)
+
+    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+        return self.apply_basis_perm(tensor.data[:, 0], [tensor.legs[0]], inv=True)
+
+    def mask_binary_operand(self, mask1: Mask, mask2: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        data = func(mask1.data, mask2.data)
+        raise NotImplementedError
+    
+    def mask_from_block(self, a: Block, large_leg: Space, small_leg: ElementarySpace
+                        ) -> DiagonalData:
+        data = self.apply_basis_perm(data, [large_leg])
+        return data
+
+    def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
+        data = func(mask.data)
+        raise NotImplementedError
+        
+    def mul(self, a: float | complex, b: SymmetricTensor) -> Data:
+        return self.block_mul(a, b.data)
+
+    def norm(self, a: SymmetricTensor | DiagonalTensor) -> float:
+        return self.block_norm(a.data)
+
+    def outer(self, a: SymmetricTensor, b: SymmetricTensor) -> Data:
+        raise NotImplementedError  # TODO not yet reviewed. careful with leg order!
+        return self.block_outer(a.data, b.data)
+
+    def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
+        # TODO decide signature
+        raise NotImplementedError  # TODO not yet reviewed
+        if permutation is None:
+            return a.data
+        return self.block_permute_axes(a.data, permutation)
+
+    def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
+        raise NotImplementedError  # TODO not yet reviewed
+        q, r = self.matrix_qr(a.data, full=full)
+        new_leg_dim = self.block_shape(r)[0]
+        new_leg = ElementarySpace.from_trivial_sector(new_leg_dim, is_dual=new_r_leg_dual)
+        return q, r, new_leg
+
+    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
+        return self.block_scale_axis(a.data, b.data, leg)
+
     def set_element(self, a: SymmetricTensor, idcs: list[int], value: complex | float) -> Data:
         return self.set_block_element(a.data, idcs, value)
 
@@ -244,63 +251,52 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
                              ) -> DiagonalData:
         return self.set_block_element(a.data, [idx], value)
     
-    def diagonal_data_from_full_tensor(self, a: SymmetricTensor, check_offdiagonal: bool) -> DiagonalData:
-        return self.block_get_diagonal(a.data, check_offdiagonal=check_offdiagonal)
-
-    def full_data_from_diagonal_tensor(self, a: DiagonalTensor) -> Data:
-        return self.block_from_diagonal(a.data)
-
-    def full_data_from_mask(self, a: Mask, dtype: Dtype) -> Data:
-        return self.block_from_mask(a.data, dtype=dtype)
-
-    def scale_axis(self, a: SymmetricTensor, b: DiagonalTensor, leg: int) -> Data:
+    def split_legs(self, a: SymmetricTensor, leg_idcs: list[int],
+                   final_legs: list[Space]) -> Data:
         raise NotImplementedError  # TODO not yet reviewed
-        return self.block_scale_axis(a.data, b.data, leg)
+        return self.block_split_legs(a.data, leg_idcs, [[s.dim for s in a.legs[i].spaces]
+                                                        for i in leg_idcs])
 
-    def diagonal_elementwise_unary(self, a: DiagonalTensor, func, func_kwargs, maps_zero_to_zero: bool
-                                   ) -> DiagonalData:
-        return func(a.data, **func_kwargs)
+    def squeeze_legs(self, a: SymmetricTensor, idcs: list[int]) -> Data:
+        return self.block_squeeze_legs(a.data, idcs)
 
-    def diagonal_elementwise_binary(self, a: DiagonalTensor, b: DiagonalTensor, func,
-                                    func_kwargs, partial_zero_is_zero: bool
-                                    ) -> DiagonalData:
-        return func(a.data, b.data, **func_kwargs)
+    def supports_symmetry(self, symmetry: Symmetry) -> bool:
+        return symmetry == no_symmetry
 
-    def diagonal_all(self, a: DiagonalTensor) -> bool:
-        return self.block_all(a.data)
-
-    def diagonal_any(self, a: DiagonalTensor) -> bool:
-        return self.block_any(a.data)
-
-    def apply_mask_to_Tensor(self, tensor: SymmetricTensor, mask: Mask, leg_idx: int) -> Data:
-        return self.apply_mask_to_block(tensor.data, mask.data, ax=leg_idx)
-
-    def apply_mask_to_DiagonalTensor(self, tensor: DiagonalTensor, mask: Mask) -> DiagonalData:
-        return self.apply_mask_to_block(tensor.data, mask.data, ax=0)
-
-    def eigh(self, a: SymmetricTensor, sort: str = None) -> tuple[DiagonalData, Data]:
+    def svd(self, a: SymmetricTensor, new_vh_leg_dual: bool, algorithm: str | None, compute_u: bool,
+            compute_vh: bool) -> tuple[Data, DiagonalData, Data, ElementarySpace]:
+        # TODO interface may change
         raise NotImplementedError  # TODO not yet reviewed
-        return self.block_eigh(a.data, sort=sort)
+        u, s, vh = self.matrix_svd(a.data, algorithm=algorithm, compute_u=compute_u, compute_vh=compute_vh)
+        new_leg = ElementarySpace.from_trivial_sector(len(s), is_dual=new_vh_leg_dual)
+        return u, s, vh, new_leg
 
-    def from_dense_block_trivial_sector(self, block: Block, leg: Space) -> Data:
+    def tdot(self, a: SymmetricTensor, b: SymmetricTensor, axs_a: list[int], axs_b: list[int]) -> Data:
+        # TODO interface may change
         raise NotImplementedError  # TODO not yet reviewed
-        assert self.block_shape(block) == (leg.dim,)
-        return self.apply_basis_perm(block, [leg])
+        return self.block_tdot(a.data, b.data, axs_a, axs_b)
+
+    def to_dense_block(self, a: SymmetricTensor) -> Block:
+        return self.apply_basis_perm(a.data, a.legs, inv=True)
 
     def to_dense_block_trivial_sector(self, tensor: SymmetricTensor) -> Block:
-        raise NotImplementedError  # TODO not yet reviewed
+        # there are no other sectors, so this is essentially the same as to_dense_block.
         return self.apply_basis_perm(tensor.data, tensor.legs, inv=True)
 
-    def inv_part_from_dense_block_single_sector(self, vector: Block, space: Space,
-                                               charge_leg: ElementarySpace) -> Data:
-        block = self.apply_basis_perm(vector, [space])
-        return self.block_add_axis(block, pos=1)
+    def to_dtype(self, a: SymmetricTensor, dtype: Dtype) -> Data:
+        return self.block_to_dtype(a.data, dtype)
 
-    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+    def trace_full(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int]) -> float | complex:
         raise NotImplementedError  # TODO not yet reviewed
-        return self.apply_basis_perm(tensor.data[:, 0], [tensor.legs[0]], inv=True)
+        return self.block_trace_full(a.data, idcs1, idcs2)
 
-    def flip_leg_duality(self, tensor: SymmetricTensor, which_legs: list[int],
-                         flipped_legs: list[Space], perms: list[np.ndarray]) -> Data:
+    def trace_partial(self, a: SymmetricTensor, idcs1: list[int], idcs2: list[int], remaining_idcs: list[int]) -> Data:
         raise NotImplementedError  # TODO not yet reviewed
-        return tensor.data
+        return self.block_trace_partial(a.data, idcs1, idcs2, remaining_idcs)
+
+    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype):
+        return self.zero_block(shape=[l.dim for l in conventional_leg_order(codomain, domain)],
+                               dtype=dtype)
+
+    def zero_diagonal_data(self, co_domain: ProductSpace, dtype: Dtype) -> DiagonalData:
+        return self.zero_block(shape=[co_domain.dim], dtype=dtype)

--- a/tenpy/linalg/backends/no_symmetry.py
+++ b/tenpy/linalg/backends/no_symmetry.py
@@ -296,7 +296,7 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
         block = self.apply_basis_perm(vector, [space])
         return self.block_add_axis(block, pos=1)
 
-    def inv_part_to_flat_block_single_sector(self, tensor: SymmetricTensor) -> Block:
+    def inv_part_to_dense_block_single_sector(self, tensor: SymmetricTensor) -> Block:
         raise NotImplementedError  # TODO not yet reviewed
         return self.apply_basis_perm(tensor.data[:, 0], [tensor.legs[0]], inv=True)
 

--- a/tenpy/linalg/backends/no_symmetry.py
+++ b/tenpy/linalg/backends/no_symmetry.py
@@ -252,9 +252,9 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def mask_unary_operand(self, mask: Mask, func) -> tuple[DiagonalData, ElementarySpace]:
         large_leg = mask.large_leg
         basis_perm = large_leg._basis_perm
+        data = func(mask.data)
         if basis_perm is not None:
             basis_perm = rank_data(basis_perm[data])
-        data = func(mask.data)
         small_leg = ElementarySpace.from_trivial_sector(
             dim=self.block_sum_all(data), symmetry=large_leg.symmetry, is_dual=large_leg.is_dual,
             basis_perm=basis_perm
@@ -274,9 +274,9 @@ class NoSymmetryBackend(Backend, BlockBackend, metaclass=ABCMeta):
     def permute_legs(self, a: SymmetricTensor, **kw) -> Data:
         # TODO decide signature
         raise NotImplementedError  # TODO not yet reviewed
-        if permutation is None:
-            return a.data
-        return self.block_permute_axes(a.data, permutation)
+        # if permutation is None:
+        #     return a.data
+        # return self.block_permute_axes(a.data, permutation)
 
     def qr(self, a: SymmetricTensor, new_r_leg_dual: bool, full: bool) -> tuple[Data, Data, ElementarySpace]:
         raise NotImplementedError  # TODO not yet reviewed

--- a/tenpy/linalg/backends/numpy.py
+++ b/tenpy/linalg/backends/numpy.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy
 
 from .abelian import AbelianBackend
-from .abstract_backend import BlockBackend, Block, Data
+from .abstract_backend import BlockBackend, Block
 from .no_symmetry import NoSymmetryBackend
 from .fusion_tree_backend import FusionTreeBackend
 from ..dtypes import Dtype, _numpy_dtype_to_tenpy, _tenpy_dtype_to_numpy

--- a/tenpy/linalg/backends/numpy.py
+++ b/tenpy/linalg/backends/numpy.py
@@ -217,8 +217,8 @@ class NumpyBlockBackend(BlockBackend):
     def block_from_mask(self, mask: Block, dtype: Dtype) -> Block:
         M, = mask.shape
         N = np.sum(mask)
-        res = np.zeros((M, N), dtype=self.backend_dtype_map[dtype])
-        res[mask, np.arange(N)] = 1
+        res = np.zeros((N, M), dtype=self.backend_dtype_map[dtype])
+        res[np.arange(N), mask] = 1
         return res
 
     def block_sum(self, a: Block, ax: int) -> Block:

--- a/tenpy/linalg/backends/torch.py
+++ b/tenpy/linalg/backends/torch.py
@@ -2,22 +2,15 @@
 from __future__ import annotations
 from numpy import prod
 import numpy
-from typing import TYPE_CHECKING
 
 from .abelian import AbelianBackend
-from .abstract_backend import BlockBackend, Block, Data
+from .abstract_backend import BlockBackend, Block
 from .no_symmetry import NoSymmetryBackend
 from .fusion_tree_backend import FusionTreeBackend
 from ..dtypes import Dtype
 
 __all__ = ['TorchBlockBackend', 'NoSymmetryTorchBackend', 'AbelianTorchBackend',
            'FusionTreeTorchBackend']
-
-
-if TYPE_CHECKING:
-    # can not import Tensor at runtime, since it would be a circular import
-    # this clause allows mypy etc to evaluate the type-hints anyway
-    from ..tensors import SymmetricTensor
 
 
 class TorchBlockBackend(BlockBackend):

--- a/tenpy/linalg/backends/torch.py
+++ b/tenpy/linalg/backends/torch.py
@@ -228,8 +228,8 @@ class TorchBlockBackend(BlockBackend):
     def block_from_mask(self, mask: Block, dtype: Dtype) -> Block:
         M, = mask.shape
         N = torch_module.sum(mask)
-        res = torch_module.zeros((M, N), dtype=self.backend_dtype_map[dtype])
-        res[mask, torch_module.arange(N)] = 1
+        res = torch_module.zeros((N, M), dtype=self.backend_dtype_map[dtype])
+        res[torch_module.arange(N), mask] = 1
         return res
 
     def block_sum(self, a: Block, ax: int) -> Block:

--- a/tenpy/linalg/krylov_based.py
+++ b/tenpy/linalg/krylov_based.py
@@ -177,7 +177,7 @@ class KrylovBased(metaclass=ABCMeta):
             # If you get this warning, you can try to set the parameters
             # `reortho`=True and `N_cache` >= `N_max`
             logger.warning("poorly conditioned H matrix in KrylovBased! |psi_0| = %f", psif_norm)
-        return psif._mul_scalar(1. / psif_norm)
+        return psif.multiply_scalar(1. / psif_norm)
 
     def _to_cache(self, psi):
         """add psi to cache, keep at most self.N_cache."""
@@ -245,7 +245,7 @@ class Arnoldi(KrylovBased):
         norm = w.norm()
         self.psi0 = w / norm
         for k in range(self.N_max):
-            w = w ._mul_scalar(1. / norm)
+            w = w .multiply_scalar(1. / norm)
             self._to_cache(w)
             w = self.H.matvec(w)
             for i, v_i in enumerate(self._cache):

--- a/tenpy/linalg/matrix_operations.py
+++ b/tenpy/linalg/matrix_operations.py
@@ -278,7 +278,7 @@ def truncated_svd(a: Tensor, u_legs: list[int | str] = None, vh_legs: list[int |
     else:
         # norm(S[mask]) == S_norm * new_norm
         renormalize = normalize_to / S_norm / new_norm
-        S = S._mul_scalar(renormalize)
+        S = S.multiply_scalar(renormalize)
     return U, S, V, err, renormalize
 
 

--- a/tenpy/linalg/matrix_operations.py
+++ b/tenpy/linalg/matrix_operations.py
@@ -609,8 +609,8 @@ def eigh(a: Tensor, legs1: list[int | str] = None, legs2: list[int | str] = None
     U : Tensor
         A tensor containing the normalized eigenvectors. It is unitary, in the sense that combining
         the leading legs yields a unitary matrix. Legs are ``[*a.get_legs(legs1), new_leg]``,
-        where ``new_leg = ProductSpace(*a.get_legs(leg1)).as_VectorSpace().dual``.
-        In particular, the new leg is always a plain `VectorSpace`, never a `ProductSpace`.
+        where ``new_leg = ProductSpace(*a.get_legs(leg1)).as_ElementarySpace().dual``.
+        In particular, the new leg is always a `ElementarySpace`, never a `ProductSpace`.
     """
     # TODO (JU) should we support `UPLO` arg? (use lower or upper triangular part)
     if not isinstance(a, BlockDiagonalTensor):
@@ -625,14 +625,14 @@ def eigh(a: Tensor, legs1: list[int | str] = None, legs2: list[int | str] = None
     if need_combine:
         U_leg_0 = ProductSpace([a.legs[i1] for i1 in idcs1], backend=backend)
         a = a.combine_legs(idcs1, idcs2, product_spaces=[U_leg_0, U_leg_0.dual])
-        D_leg_0 = U_leg_0.as_VectorSpace()
+        D_leg_0 = U_leg_0.as_ElementarySpace()
         U_leg_1 = D_leg_0.dual
     else:
         if idcs1[0] == 1:  # implies idcs1 == [1], idcs2 == [0]
             a = a.permute_legs([1, 0])
         U_leg_0 = a.legs[0]
-        D_leg_0 = U_leg_0.as_VectorSpace()
-        U_leg_1 = a.legs[1].as_VectorSpace()
+        D_leg_0 = U_leg_0.as_ElementarySpace()
+        U_leg_1 = a.legs[1].as_ElementarySpace()
     
     d_data, u_data = backend.eigh(a, sort=sort)
 

--- a/tenpy/linalg/misc.py
+++ b/tenpy/linalg/misc.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 from typing import Sequence, TypeVar
 import numpy as np
-from functools import wraps
 
 __all__ = ['force_str_len', 'UNSPECIFIED', 'inverse_permutation', 'duplicate_entries',
            'join_as_many_as_possible', 'make_stride', 'find_row_differences', 'unstridify']

--- a/tenpy/linalg/spaces.py
+++ b/tenpy/linalg/spaces.py
@@ -1,70 +1,30 @@
 # Copyright (C) TeNPy Developers, GNU GPLv3
-
 from __future__ import annotations
+from abc import ABCMeta, abstractmethod
 import numpy as np
 from numpy import ndarray
-import copy
 import bisect
 import itertools as it
 from typing import TYPE_CHECKING, Sequence, Iterator
 
-from tenpy.linalg.dummy_config import printoptions
-
-from .symmetries import (Sector, SectorArray, Symmetry, ProductSymmetry, NoSymmetry, no_symmetry,
-                         FusionStyle, SymmetryError)
-from .misc import make_stride, find_row_differences, unstridify, join_as_many_as_possible
+from .dummy_config import printoptions
+from .symmetries import (Sector, SectorArray, Symmetry, ProductSymmetry, no_symmetry, FusionStyle,
+                         SymmetryError)
+from .misc import make_stride, find_row_differences, unstridify, join_as_many_as_possible, UNSPECIFIED
 from ..tools.misc import inverse_permutation, rank_data, to_iterable
 from ..tools.string import format_like_list
 
 if TYPE_CHECKING:
     from .backends.abstract_backend import Backend, Block
 
+__all__ = ['Space', 'ElementarySpace', 'ProductSpace']
 
-__all__ = ['VectorSpace', 'ProductSpace']
 
+class Space(metaclass=ABCMeta):
+    """A space, which decomposes into sectors of a given symmetry.
 
-class VectorSpace:
-    r"""A vector space, which decomposes into sectors of a given symmetry.
-
-    A vector space is characterized by a basis, and in particular a defined order of basis elements.
-    Each basis vector lies in one of the sectors of the :attr:`symmetry`.
-
-    For efficiency of the internal data manipulations, we want to use an internal basis,
-    which is ordered such that::
-
-        - The basis elements that belong to the same sector appear contiguously.
-          This allows us to directly read-off the blocks that contain the free parameters.
-
-        - The sectors are sorted. This makes look-ups more efficient.
-          For a ket-space (``is_dual is False``), we sort according to ``np.lexsort(sectors.T)``.
-          Regarding bra-spaces, see the notes on duality below.
-    
-    A VectorSpace instance captures this information, i.e. the permutation of the basis that
-    achieves the above properties, which sectors appear and how often.
-
-    We give special treatment to the dual ``V.dual`` of a given space ``V`` (with ``V.is_dual is False``).
-    It is most convenient to facilitate contractions etc. to only switch a single boolean flag when
-    going to the dual space and keeping all other attributes the same. Thus, both ``V.dual`` and
-    ``V`` have the same :attr:`_non_dual_sectors`, :attr:`multiplicities` etc. and in particular
-    the same basis order. As a consequence, the actual :attr:`sectors`, which are a property,
-    computed from the :attr:`_non_dual_sectors` only when needed, that `V.dual` decomposes into
-    are not sorted.
-
-    .. note ::
-
-        The notion of a basis and its associated attributes and functions is only a useful
-        concept if ``symmetry.can_be_dropped``, i.e. if we can think of the sectors as 
-        complex vector spaces. This is not the case, e.g. anyonic symmetries, or fermion grading.
-        In these cases, there is are no substitute non-symmetric tensors that have the same behavior,
-        e.g. because of non-trivial braiding which only the symmetric tensors can exhibit.
-        In particular :attr:`sector_dims`, :attr:`slices` and :attr:`dim`, :attr:`sectors_of_basis`,
-        :meth:`from_basis` etc. may not be defined and either be set to None or raise errors.
-
-    .. note ::
-    
-        It is best to think of ``VectorSpace``s as immutable objects.
-        In practice they are mutable, i.e. you could change their attributes.
-        This may lead to unexpected behavior, however, since it might make the cached metadata inconsistent.
+    This is a base classes, the concrete subclasses are :class:`ElementarySpace`
+    and :class:`ProductSpace`.
 
     Attributes
     ----------
@@ -73,10 +33,10 @@ class VectorSpace:
     sectors : 2D numpy array of int
         The sectors that compose this space. A 2D array of integers with axes [s, q] where s goes
         over different sectors and q over the (one or more) numbers needed to label a sector.
-        The sectors (to be precise, the rows `sectors[i, :]`) are unique. The order is an
-        implementation detail and not physical, see :attr:`_non_dual_sectors`
+        The sectors (to be precise, the rows ``sectors[i, :]``) are unique and sorted, such that
+        ``np.lexsort(sectors.T)`` is trivial. We use :attr:`multiplicities` for duplicates.
     multiplicities : 1D numpy array of int
-        How often each of the `sectors` appears. A 1D array of positive integers with axis [s].
+        How often each of the :attr:`sectors` appears. A 1D array of positive integers with axis [s].
         ``sectors[i, :]`` appears ``multiplicities[i]`` times.
     sector_dims : 1D array of int | None
         If ``symmetry.can_be_dropped``, the integer dimension of each of the :attr:`sectors`.
@@ -90,70 +50,15 @@ class VectorSpace:
         indices (in the *internal* basis order) that belong to this sector.
         Conversely, ``basis_perm[slices[n, 0]:slices[n, 1]]`` are the elements of the public
         basis that live in ``sectors[n]``. Only available if ``symmetry.can_be_dropped``.
-    is_real : bool
-        If the space is over the real or complex numbers.
-    is_dual : bool
-        Whether this is the dual (a.k.a. bra) space or the regular (a.k.a. ket) space.
-    basis_perm : ndarray | None
-        The tensor manipulations of `tenpy.linalg` benefit from choosing a canonical order for the
-        basis of vector spaces. This attribute translates between the "public" order of the basis,
-        in which e.g. the inputs to :meth:`from_dense_block` are interpreted to this internal order,
-        such that ``public_basis[basis_perm] == internal_basis``.
-        This internal order is such that the basis vectors are grouped by sector and such that
-        sectors occur in the canonical sorted order, see :attr:`_non_dual_sectors`.
-        We store the inverse as `_inverse_basis_perm`.
-        For `ProductSpace`s we always set a trivial permutation.
-        We can translate indices as ``public_idx == basis_perm[internal_idx]``.
-        Only available if ``symmetry.can_be_dropped``.
-        ``_basis_perm`` is the internal version which may be ``None`` if the permutation is trivial.
-    inverse_basis_perm : ndarray | None
-        Inverse of :attr:`basis_perm`. ``_inverse_basis_perm`` is the internal version.
-        Only available if ``symmetry.can_be_dropped``.
-    sectors_of_basis : 2D numpy array of int | None
-        The sectors of every element of the "public" computational basis.
-        Multi-dimensional sectors (such as e.g. the spin-1/2 sector of SU(2)) are listed multiple
-        times (once for each basis state in the multiplet), such that the length is the total
-        dimension. Only available if ``symmetry.can_be_dropped``.
-    _non_dual_sectors : 2D numpy array of int
-        Internally stored version of :attr:`sectors`. For ket spaces (``is_dual=True``),
-        these are the same as :attr:`sectors`, for bra spaces these are their duals.
-        They are sorted such that ``np.lexsort(_non_dual_sectors.T)`` is trivial.
+    is_bra_space : bool
+        Whether this is a bra space. For :class:`ElementarySpace`, this is the same is
+        :attr:`ElementarySpace.is_dual`. For :class:`ProductSpace`, it is always ``False``.
     """
-    def __init__(self, symmetry: Symmetry, sectors: SectorArray, multiplicities: ndarray = None,
-                 basis_perm: ndarray = None, is_real: bool = False, _is_dual: bool = False):
-        """Initialize a VectorSpace
-
-        `VectorSpace.__init__` is not very user-friendly. Use :meth:`from_sectors` instead.
-        
-        Parameters
-        ----------
-        symmetry: Symmetry
-            The symmetry associated with this space.
-        sectors: 2D array_like of int
-            For a ket-space (``_is_dual=False``), the sectors of the symmetry that compose this space.
-            For a bra-space, the duals of that.
-            Must be sorted such that ``np.lexsort(_non_dual_sectors.T)`` is trivial.
-            Sectors may not contain duplicates. Multiplicity is specified via the separate arg below.
-        multiplicities: 1D array_like of int, optional
-            How often each of the `sectors` appears. A 1D array of positive integers with axis [s].
-            ``sectors[i_s, :]`` appears ``multiplicities[i_s]`` times.
-            If not given, a multiplicity ``1`` is assumed for all `sectors`.
-        basis_perm : ndarray, optional
-            See the attribute :attr:`basis_perm`.
-            Per default the trivial permutation ``[0, 1, 2, ...]`` is used.
-        is_real : bool
-            If the space is over the real or complex (default) numbers.
-        _is_dual : bool
-            Whether this is the "normal" (i.e. ket) or dual (i.e. bra) space.
-
-            .. warning :
-                For ``_is_dual is True``, the passed `sectors` are interpreted as the sectors of the
-                ("non-dual") ket-space isomorphic to self.
-        """
+    
+    def __init__(self, symmetry: Symmetry, sectors: SectorArray | Sequence[Sequence[int]],
+                 multiplicities: Sequence[int] | None, is_bra_space: bool):
         self.symmetry = symmetry
-        self.is_real = is_real
-        self.is_dual = _is_dual
-        self._non_dual_sectors = sectors = np.asarray(sectors, dtype=int)
+        self.sectors = sectors = np.asarray(sectors, dtype=int)
         if sectors.ndim != 2 or sectors.shape[1] != symmetry.sector_ind_len:
             msg = (f'Wrong sectors.shape: Expected (*, {symmetry.sector_ind_len}), '
                    f'got {sectors.shape}.')
@@ -177,24 +82,15 @@ class VectorSpace:
             self.sector_qdims = sector_qdims = symmetry.batch_qdim(sectors)
             self.slices = None
             self.dim = np.sum(sector_qdims * multiplicities)
-        if basis_perm is None:
-            self._basis_perm = None
-            self._inverse_basis_perm = None
-        else:
-            if not symmetry.can_be_dropped:
-                msg = f'basis_perm is meaningless for {symmetry}.'
-                raise SymmetryError(msg)
-            # OPTIMIZE set to None if trivial but explicit?
-            self._basis_perm = basis_perm = np.asarray(basis_perm, dtype=int)
-            self._inverse_basis_perm = inverse_permutation(basis_perm)
+        self.is_bra_space = is_bra_space
 
     def test_sanity(self):
+        assert self.dim >= 0
         # sectors
-        assert all(self.symmetry.is_valid_sector(s) for s in self._non_dual_sectors)
-        assert len(self._non_dual_sectors) == self.num_sectors
-        assert len(np.unique(self._non_dual_sectors, axis=0)) == self.num_sectors, 'duplicate sectors'
-        assert self._non_dual_sectors.shape == (self.num_sectors, self.symmetry.sector_ind_len)
-        assert np.all(np.lexsort(self._non_dual_sectors.T) == np.arange(self.num_sectors)), 'wrong order'
+        assert self.sectors.shape == (self.num_sectors, self.symmetry.sector_ind_len), 'wrong sectors.shape'
+        assert all(self.symmetry.is_valid_sector(s) for s in self.sectors), 'invalid sectors'
+        assert len(np.unique(self.sectors, axis=0)) == self.num_sectors, 'duplicate sectors'
+        assert np.all(np.lexsort(self.sectors.T) == np.arange(self.num_sectors)), 'wrong sector order'
         # multiplicities
         assert np.all(self.multiplicities > 0)
         assert self.multiplicities.shape == (self.num_sectors,)
@@ -202,41 +98,178 @@ class VectorSpace:
             # slices
             assert self.slices.shape == (self.num_sectors, 2)
             slice_diffs = self.slices[:, 1] - self.slices[:, 0]
-            assert np.all(self.sector_dims == self.symmetry.batch_sector_dim(self._non_dual_sectors))
+            assert np.all(self.sector_dims == self.symmetry.batch_sector_dim(self.sectors))
             expect_diffs = self.sector_dims * self.multiplicities
             assert np.all(slice_diffs == expect_diffs)
             # slices should be consecutive
-            if len(self.slices) > 0:
+            if self.num_sectors > 0:
                 assert self.slices[0, 0] == 0
                 assert np.all(self.slices[1:, 0] == self.slices[:-1, 1])
                 assert self.slices[-1, 1] == self.dim
-            # basis_perm
-            if self._basis_perm is None:
-                assert self._inverse_basis_perm is None
-            else:
-                assert self._basis_perm.shape == (self.dim,)
-                assert len(np.unique(self._basis_perm)) == self.dim
-                assert np.all(self._basis_perm[self._inverse_basis_perm] == np.arange(self.dim))
+
+    # ABSTRACT
+
+    @property
+    @abstractmethod
+    def dual(self):
+        ...
+
+    @abstractmethod
+    def __eq__(self, other):
+        ...
+
+    @abstractmethod
+    def as_ElementarySpace(self, is_dual: bool = None) -> ElementarySpace:
+        ...
+
+    @abstractmethod
+    def change_symmetry(self, symmetry: Symmetry, sector_map: callable, backend: Backend = None,
+                        injective: bool = False) -> ElementarySpace:
+        """Change the symmetry by specifying how the sectors change.
+
+        Parameters
+        ----------
+        symmetry : :class:`~tenpy.linalg.groups.Symmetry`
+            The symmetry of the new space
+        sector_map : function (SectorArray,) -> (SectorArray,)
+            A map of sectors (2D int arrays), such that ``new_sectors = sector_map(old_sectors)``.
+            The map is assumed to cooperate with duality, i.e. we assume without checking that
+            ``symmetry.dual_sectors(sector_map(old_sectors))`` is the same as
+            ``sector_map(old_symmetry.dual_sectors(old_sectors))``.
+            TODO do we need to assume more, i.e. compatibility with fusion?
+        backend : :class: `~tenpy.linalg.backends.abstract_backend.Backend`
+            This parameter is ignored. We only include it to have matching signatures
+            with :meth:`ProductSpace.change_symmetry`.
+        injective: bool
+            If ``True``, the `sector_map` is assumed to be injective, i.e. produce a list of
+            unique outputs, if the inputs are unique.
+
+        Returns
+        -------
+        A space with the new symmetry. The order of the basis is preserved, but every
+        basis element lives in a new sector, according to `sector_map`.
+        """
+        ...
+
+    @abstractmethod
+    def drop_symmetry(self, which: int | list[int] = None):
+        """Drop some or all symmetries.
+
+        Parameters
+        ----------
+        which : None | (list of) int
+            If ``None`` (default) the entire symmetry is dropped and the result has ``no_symmetry``.
+            An integer or list of integers assume that ``self.symmetry`` is a ``ProductSymmetry``
+            and indicates which of its factors to drop.
+        """
+        ...
+
+    @abstractmethod
+    def _repr(self, show_symmetry: bool):
+        ...
+
+    # CONCRETE IMPLEMENTATIONS
+
+    def __repr__(self):
+        res = self._repr(show_symmetry=True)
+        if res is None:
+            return f'<{self.__class__.__name__}>'
+        return res
+
+    @property
+    def num_parameters(self) -> int:
+        """The number of linearly independent *symmetric* tensors in this space."""
+        return self.sector_multiplicity(self.symmetry.trivial_sector)
+
+    def sectors_where(self, sector: Sector) -> int | None:
+        # TODO / OPTIMIZE : use that sectors are sorted to speed up the lookup
+        where = np.where(np.all(self.sectors == sector, axis=1))[0]
+        if len(where) == 0:
+            return None
+        if len(where) == 1:
+            return where[0]
+        raise RuntimeError  # sectors should have unique entries, so this should not happen
+
+    def sector_multiplicity(self, sector: Sector) -> int:
+        idx = self.sectors_where(sector)
+        if idx is None:
+            return 0
+        return self.multiplicities[idx]
+
+
+class ElementarySpace(Space):
+    r"""A space which is graded by a symmetry, but has no further structure.
+
+    We distinguish ket spaces :math:`V_k := a_1 \oplus a_2 \oplus \dots \plus a_N` with
+    ``is_dual=False`` and bra spaces :math:`V_b := [b_1 \oplus b_2 \oplus \dots \plus b_N]^*`
+    with ``is_dual=True``. The bra space also decomposes into sectors, as
+    :math:`V_b \cong \bar{b}_1 \oplus \bar{b}_2 \oplus \dots \plus \bar{b}_N`,
+    where :math:`\bar{b}` is the :meth:`Symmetry.dual_sector` of :math:`b`.
+    The :attr:`sectors` of a space then describe the :math:`\{a_n\}` for the ket space
+    :math:`V_k` and the :math:`\{\bar{b}_n\}` for the bra space :math:`V_b`.
+
+    If the symmetry :attr:`Symmetry.can_be_dropped`, there is a notion of a basis for the
+    spaces. We demand the basis to be compatible with the symmetry, i.e. each basis vector
+    needs to lie in one of the sectors of the symmetry. The *internal* basis order that results
+    from demanding that the sectors are contiguous and sorted may, however, not be the desired
+    basis order, e.g. for matrix representations. For example, the standard basis of a spin-1
+    degree of freedom with ``'Sz_parity'`` conservation has sectors ``[[1], [0], [1]]`` and is
+    neither sorted by sector nor contiguous. We allow these different *public* basis orders
+    and store the relevant perturbation as :attr:`basis_perm`.
+    See also :attr:`sectors_of_basis` and :meth:`from_basis`.
+
+    Parameters
+    ----------
+    symmetry, sectors, multiplicities, is_dual, basis_perm
+        Like attributes of the same name, and nested lists are allowed in place of arrays.
+
+    Attributes
+    ----------
+    is_dual: bool
+        If this is a bra or a ket space, such that ``ElementarySpace(sym, sec, is_dual=True)``
+        is equivalent to ``ElementarySpace(sym, sec, is_dual=False).flip_is_dual()`` and equal to
+        ``ElementarySpace(sym, dual_sectors(sec), is_dual=False).dual``.
+    """
+    
+    def __init__(self, symmetry: Symmetry, sectors: SectorArray, multiplicities: ndarray = None,
+                 is_dual: bool = False, basis_perm: ndarray | None = None):
+        Space.__init__(self, symmetry=symmetry, sectors=sectors, multiplicities=multiplicities,
+                       is_bra_space=is_dual)
+        self.is_dual = is_dual
+        if basis_perm is None:
+            self._basis_perm = self._inverse_basis_perm = None
         else:
-            assert self.slices is None
+            if not symmetry.can_be_dropped:
+                msg = f'basis_perm is meaningless for {symmetry}.'
+                raise SymmetryError(msg)
+            self._basis_perm = basis_perm = np.asarray(basis_perm, dtype=int)
+            self._inverse_basis_perm = inverse_permutation(basis_perm)
+
+    def test_sanity(self):
+        assert self.is_bra_space == self.is_dual
+        if not self.symmetry.can_be_dropped:
             assert self._basis_perm is None
+        if self._basis_perm is None:
             assert self._inverse_basis_perm is None
-        assert self.dim >= 0
+        else:
+            assert self._inverse_basis_perm is not None
+            assert self._basis_perm.shape == self._inverse_basis_perm.shape == (self.dim,)
+            assert len(np.unique(self._basis_perm)) == self.dim  # is a permutation
+            assert len(np.unique(self._inverse_basis_perm)) == self.dim  # is a permutation
+            assert np.all(self._basis_perm[self._inverse_basis_perm] == np.arange(self.dim))
+        super().test_sanity()
 
     @classmethod
     def from_basis(cls, symmetry: Symmetry, sectors_of_basis: Sequence[Sequence[int]],
-                   is_real: bool = False):
-        """Create a VectorSpace by specifying the sector of every basis element.
-
-        This classmethod always creates a ket-space (i.e. ``res.is_dual is False``).
-        Use ``VectorSpace.from_basis(...).dual`` for a bra-space.
+                   is_dual: bool = False) -> ElementarySpace:
+        """Create an ElementarySpace by specifying the sector of every basis element.
 
         .. note ::
             Unlike :meth:`from_sectors`, this method expects the same sector to be listed
             multiple times, if the sector is multi-dimensional. The Hilbert Space of a spin-one-half
-            D.O.F. can e.g. be created as ``VectorSpace.from_basis(su2, [[spin_half], [spin_half]])``
-            or as ``VectorSpace.from_sectors(su2, [[1]])``. In the former case we need to list the
-            same sector both for the spin up and spin down state.
+            D.O.F. can e.g. be created as ``ElementarySpace.from_basis(su2, [spin_half, spin_half])``
+            or as ``ElementarySpace.from_sectors(su2, [[spin_half]])``. In the former case we need to
+            list the same sector both for the spin up and spin down state.
 
         Parameters
         ----------
@@ -248,8 +281,9 @@ class VectorSpace:
             occurrences. They need not be contiguous though. They will be grouped by order of
             appearance, such that they ``m``-th time a sector appears, that basis state is interpreted
             as the ``(m % d)``-th state of the multiplet.
-        is_real : bool
-            If the space is over the real or complex (default) numbers.
+        is_dual : bool
+            If the space is a bra space of a ket space. Either way, it decomposes into the given
+            sectors.
 
         See Also
         --------
@@ -274,54 +308,123 @@ class VectorSpace:
                    'integer multiple of their dimension.')
             raise ValueError(msg)
         return cls(symmetry=symmetry, sectors=sectors, multiplicities=multiplicities,
-                   basis_perm=basis_perm, is_real=is_real, _is_dual=False)
+                   is_dual=is_dual, basis_perm=basis_perm)
 
     @classmethod
-    def from_independent_symmetries(cls, independent_descriptions: list[VectorSpace],
-                                    symmetry: Symmetry = None):
-        """Create a VectorSpace with multiple independent symmetries.
+    def from_independent_symmetries(cls, independent_descriptions: list[ElementarySpace]
+                                    ) -> ElementarySpace:
+        """Create an ElementarySpace with multiple independent symmetries.
 
         Parameters
         ----------
-        independent_descriptions : list of :class:`VectorSpace`
-            Each entry describes the resulting :class:`VectorSpace` in terms of *one* of
+        independent_descriptions : list of :class:`ElementarySpace`
+            Each entry describes the resulting :class:`ElementarySpace` in terms of *one* of
             the independent symmetries. Spaces with a :class:`NoSymmetry` are ignored.
-        symmetry: :class:`~tenpy.linalg.groups.Symmetry`, optional
-            The resulting symmetry can optionally be passed. We assume without checking that
-            it :meth:`~tenpy.linalg.groups.Symmetry.is_same_symmetry` as the default
-            ``ProductSymmetry.from_nested_factors([s.symmetry for s in independent_descriptions])``.
-
-        Returns
-        -------
-        :class:`VectorSpace`
-            A space with the overall `symmetry`.
         """
-        if not all(sp.symmetry.can_be_dropped for sp in independent_descriptions):
-            msg = f'from_independent_symmetries is not supported for {symmetry}.'
-            # TODO is there a way to define this?
-            #      the straight-forward picture works only if we have a vectorspace and can identify states.
-            raise SymmetryError(msg)
+        # OPTIMIZE this can be implemented better. if many consecutive basis elements have the same
+        #          resulting sector, we can skip over all of them.
         assert len(independent_descriptions) > 0
         dim = independent_descriptions[0].dim
         assert all(s.dim == dim for s in independent_descriptions)
-        # ignore those with np_symmetry
+        # ignore those with no_symmetry
         independent_descriptions = [s for s in independent_descriptions if s.symmetry != no_symmetry]
         if len(independent_descriptions) == 0:
             # all descriptions had no_symmetry
             return cls.from_trivial_sector(dim=dim)
-        if symmetry is None:
-            symmetry = ProductSymmetry.from_nested_factors(
-                [s.symmetry for s in independent_descriptions]
-            )
-        sectors_of_basis = np.concatenate([s.sectors_of_basis for s in independent_descriptions], axis=1)
-        if (is_real := any(s.is_real for s in independent_descriptions)):
-            assert all(s.is_real for s in independent_descriptions)
-        return cls.from_basis(symmetry=symmetry, sectors_of_basis=sectors_of_basis, is_real=is_real)
+        symmetry = ProductSymmetry.from_nested_factors(
+            [s.symmetry for s in independent_descriptions]
+        )
+        if not symmetry.can_be_dropped:
+            msg = f'from_independent_symmetries is not supported for {symmetry}.'
+            # TODO is there a way to define this?
+            #      the straight-forward picture works only if we have a vector space and can identify states.
+            raise SymmetryError(msg)
+        sectors_of_basis = np.concatenate([s.sectors_of_basis for s in independent_descriptions],
+                                          axis=1)
+        return cls.from_basis(symmetry, sectors_of_basis)
 
     @classmethod
-    def from_trivial_sector(cls, dim: int, symmetry: Symmetry = no_symmetry, is_real: bool = False,
-                            is_dual: bool = False):
-        """Create a VectorSpace that lives in the trivial sector (i.e. it is symmetric).
+    def from_null_space(cls, symmetry: Symmetry, is_dual: bool = False) -> ElementarySpace:
+        """The zero-dimensional space, i.e. the span of the empty set."""
+        return cls(symmetry=symmetry, sectors=symmetry.empty_sector_array,
+                   multiplicities=np.zeros(0, int), is_dual=is_dual)
+
+    @classmethod
+    def from_sectors(cls, symmetry: Symmetry, sectors: SectorArray,
+                     multiplicities: Sequence[int] = None, is_dual: bool = False,
+                     basis_perm: ndarray = None, unique_sectors: bool = False,
+                     return_sorting_perm: bool = False
+                     ) -> ElementarySpace | tuple[ElementarySpace, ndarray]:
+        """Similar to the constructor, but with fewer requirements.
+
+        .. note ::
+            Unlike :meth:`from_basis`, this method expects a multi-dimensional sector to be listed
+            only once to mean its entire multiplet of basis states. The Hilbert Space of a spin-1/2
+            D.O.F. can e.g. be created as ``ElementarySpace.from_basis(su2, [spin_half, spin_half])``
+            or as ``ElementarySpace.from_sectors(su2, [spin_half])``. In the former case we need to
+            list the same sector both for the spin up and spin down state.
+
+        Parameters
+        ----------
+        symmetry: Symmetry
+            The symmetry associated with this space.
+        sectors: 2D array_like of int
+            The sectors of the symmetry that compose this space.
+            Can be in any order and may contain duplicates (see `unique_sectors`).
+        multiplicities: 1D array_like of int, optional
+            How often each of the `sectors` appears. A 1D array of positive integers with axis [s].
+            ``sectors[i_s, :]`` appears ``multiplicities[i_s]`` times.
+            If not given, a multiplicity ``1`` is assumed for all `sectors`.
+        is_dual: bool
+            If the result is a bra- or a ket space.
+        basis_perm: ndarray, optional
+            The permutation from the desired public basis to the basis described by `sectors`
+            and `multiplicities`.
+        unique_sectors: bool
+            If ``True``, the `sectors` are assumed to be duplicate-free.
+        return_sorting_perm: bool
+            If ``True``, the permutation ``np.lexsort(sectors.T)`` is returned too.
+
+        Returns
+        -------
+        space: ElementarySpace
+        sector_sort: 1D array, optional
+            Only returned ``if return_sorting_perm``. The permutation that sorts the `sectors`.
+        """
+        sectors = np.asarray(sectors, dtype=int)
+        assert sectors.ndim == 2 and sectors.shape[1] == symmetry.sector_ind_len
+        if multiplicities is None:
+            multiplicities = np.ones((len(sectors),), dtype=int)
+        else:
+            multiplicities = np.asarray(multiplicities, dtype=int)
+            assert multiplicities.shape == ((len(sectors),))
+        num_states = symmetry.batch_sector_dim(sectors) * multiplicities
+        basis_slices = np.concatenate([[0], np.cumsum(num_states)], axis=0)
+        # sort sectors
+        sectors, multiplicities, sort = _sort_sectors(sectors, multiplicities)
+        if symmetry.can_be_dropped:
+            if basis_perm is None:
+                basis_perm = np.arange(np.sum(num_states))
+            basis_perm = np.concatenate([basis_perm[basis_slices[i]: basis_slices[i + 1]]
+                                         for i in sort])
+        else:
+            assert basis_perm is None
+        # combine duplicate sectors (does not affect basis_perm)
+        if not unique_sectors:
+            mult_slices = np.concatenate([[0], np.cumsum(multiplicities)], axis=0)
+            diffs = find_row_differences(sectors, include_len=True)
+            multiplicities = mult_slices[diffs[1:]] - mult_slices[diffs[:-1]]
+            sectors = sectors[diffs[:-1]]  # [:-1] to exclude len
+        res = cls(symmetry=symmetry, sectors=sectors, multiplicities=multiplicities,
+                  is_dual=is_dual, basis_perm=basis_perm)
+        if return_sorting_perm:
+            return res, sort
+        return res
+
+    @classmethod
+    def from_trivial_sector(cls, dim: int, symmetry: Symmetry = no_symmetry, is_dual: bool = False,
+                            basis_perm: ndarray = None) -> ElementarySpace:
+        """Create an ElementarySpace that lives in the trivial sector (i.e. it is symmetric).
 
         Parameters
         ----------
@@ -332,94 +435,69 @@ class VectorSpace:
         is_real, is_dual : bool
             If the space should be real / dual.
         """
-        return cls(symmetry=symmetry, sectors=[symmetry.trivial_sector], multiplicities=[dim],
-                   is_real=is_real, _is_dual=is_dual)
-
-    @classmethod
-    def from_sectors(cls, symmetry: Symmetry, sectors: SectorArray, multiplicities: ndarray = None,
-                     basis_perm: ndarray = None, is_real: bool = False, return_perm: bool = False,
-                     _is_dual: bool = False):
-        """Like constructor, but fewer requirements on `sectors`.
-
-        .. note ::
-            Unlike :meth:`from_basis`, this method expects a multi-dimensional sector to be listed
-            only once to mean its entire multiplet of basis states. The Hilbert Space of a spin-1/2
-            D.O.F. can e.g. be created as ``VectorSpace.from_basis(su2, [spin_half, spin_half])``
-            or as ``VectorSpace.from_sectors(su2, [spin_half])``. In the former case we need to
-            list the same sector both for the spin up and spin down state.
-
-        Parameters
-        ----------
-        symmetry: Symmetry
-            The symmetry associated with this space.
-        sectors: 2D array_like of int
-            The sectors of the symmetry that compose this space.
-            Can be in any order and may contain duplicates.
-        multiplicities: 1D array_like of int, optional
-            How often each of the `sectors` appears. A 1D array of positive integers with axis [s].
-            ``sectors[i_s, :]`` appears ``multiplicities[i_s]`` times.
-            If not given, a multiplicity ``1`` is assumed for all `sectors`.
-        basis_perm : ndarray, optional
-            The permutation from the desired public basis to the basis described by `sectors`
-            and `multiplicities`. Per default the trivial permutation ``[0, 1, 2, ...]`` is used.
-        is_real : bool
-            If the space is over the real or complex numbers.
-        _is_dual : bool
-            Whether this is the "normal" (i.e. ket) or dual (i.e. bra) space.
-
-            .. warning :
-                For ``_is_dual is True``, the passed `sectors` are interpreted as the sectors of the
-                ("non-dual") ket-space isomorphic to self.
-
-        Returns
-        -------
-        space : VectorSpace
-        sector_sort : bool, optional
-            Only returned `if return_perm`. The permutation that sorts the `sectors`.
-        """
-        sectors = np.asarray(sectors, dtype=int)
-        assert sectors.ndim == 2 and sectors.shape[1] == symmetry.sector_ind_len
-        if multiplicities is None:
-            multiplicities = np.ones((len(sectors),), dtype=int)
-        else:
-            multiplicities = np.asarray(multiplicities, dtype=int)
-            assert multiplicities.shape == ((len(sectors),))
-        if basis_perm is None:
-            basis_perm = np.arange(np.sum(symmetry.batch_sector_dim(sectors) * multiplicities))
-        num_states = symmetry.batch_sector_dim(sectors) * multiplicities
-        basis_slices = np.concatenate([[0], np.cumsum(num_states)], axis=0)
-        # sort sectors
-        sort = np.lexsort(sectors.T)
-        sectors = sectors[sort]
-        multiplicities = multiplicities[sort]
-        mult_slices = np.concatenate([[0], np.cumsum(multiplicities)], axis=0)
-        basis_perm = np.concatenate([basis_perm[basis_slices[i]: basis_slices[i + 1]] for i in sort])
-        # merge duplicate sectors (does not affect basis_perm)
-        diffs = find_row_differences(sectors, include_len=True)
-        multiplicities = mult_slices[diffs[1:]] - mult_slices[diffs[:-1]]
-        sectors = sectors[diffs[:-1]]  # [:-1] to exclude len
-        res = cls(symmetry=symmetry, sectors=sectors, multiplicities=multiplicities,
-                  basis_perm=basis_perm, is_real=is_real, _is_dual=_is_dual)
-        if return_perm:
-            return res, sort
-        return res
-
-    @classmethod
-    def null_space(cls, symmetry: Symmetry, is_real: bool = False, is_dual: bool = False
-                   ) -> VectorSpace:
-        """The zero-dimensional space, i.e. the span of the empty set."""
-        sectors = np.zeros((0, symmetry.sector_ind_len), dtype=symmetry.trivial_sector.dtype)
-        multiplicities = np.zeros(0, int)
-        return cls(symmetry=symmetry, sectors=sectors, multiplicities=multiplicities,
-                   is_real=is_real, _is_dual=is_dual)
+        return cls(symmetry=symmetry, sectors=symmetry.trivial_sector[None, :],
+                   multiplicities=[dim], is_dual=is_dual, basis_perm=basis_perm)
 
     @property
-    def sectors(self):
-        # OPTIMIZE cachedproperty?
-        if self.is_dual:
-            return self.symmetry.dual_sectors(self._non_dual_sectors)
-        else:
-            return self._non_dual_sectors
+    def basis_perm(self) -> ndarray:
+        """Permutation that translates between public and internal basis order.
+
+        For the inverse permutation, see :attr:`inverse_basis_perm`.
+
+        The tensor manipulations of ``tenpy.linalg`` benefit from choosing a canonical order for the
+        basis of vector spaces. This attribute translates between the "public" order of the basis,
+        in which e.g. the inputs to :meth:`from_dense_block` are interpreted to this internal order,
+        such that ``public_basis[basis_perm] == internal_basis``.
+        The internal order is such that the basis vectors are grouped and sorted by sector.
+        We can translate indices as ``public_idx == basis_perm[internal_idx]``.
+        Only available if ``symmetry.can_be_dropped``, as otherwise there is no well-defined
+        notion of a basis.
+        
+        ``_basis_perm`` is the internal version which may be ``None`` if the permutation is trivial.
+        """
+        if not self.symmetry.can_be_dropped:
+            msg = f'basis_perm is meaningless for {self.symmetry}.'
+            raise SymmetryError(msg)
+        if self._basis_perm is None:
+            return np.arange(self.dim)
+        return self._basis_perm
+    
+    @property
+    def dual(self) -> ElementarySpace:
+        return ElementarySpace.from_sectors(
+            symmetry=self.symmetry, sectors=self.symmetry.dual_sectors(self.sectors),
+            multiplicities=self.multiplicities, is_dual=not self.is_dual,
+            basis_perm=self._basis_perm, unique_sectors=True
+        )
+
+    @property
+    def inverse_basis_perm(self) -> ndarray:
+        """Inverse permutation of :attr:`basis_perm`."""
+        if not self.symmetry.can_be_dropped:
+            msg = f'basis_perm is meaningless for {self.symmetry}.'
+            raise SymmetryError(msg)
+        if self._inverse_basis_perm is None:
+            return np.arange(self.dim)
+        return self._inverse_basis_perm
+
+    @property
+    def is_trivial(self) -> bool:
+        """Whether self is the trivial space.
+
+        The trivial space is a one-dimensional space which consists only of the trivial sector,
+        appearing exactly once. In a mathematical sense, the trivial sector _is_ the trivial space.
+        We count both the bra space and the ket space with these attributes as trivial.
+
+        TODO name is maybe not ideal... the ElementarySpace.from_null_space could also be called "trivial"
+             this space is the unit of fusion
+        """
+        if self.num_sectors != 1:
+            return False
+        if self.multiplicities[0] != 1:
+            return False
+        if not np.all(self.sectors[0] == self.symmetry.trivial_sector):
+            return False
+        return True
 
     @property
     def sectors_of_basis(self):
@@ -429,178 +507,183 @@ class VectorSpace:
             raise SymmetryError(msg)
         # build in internal basis, then permute
         res = np.zeros((self.dim, self.symmetry.sector_ind_len), dtype=int)
-        # multi-dimensional sectors are captured by compatible slices.
         for sect, slc in zip(self.sectors, self.slices):
             res[slice(*slc), :] = sect[None, :]
         if self._inverse_basis_perm is not None:
             res = res[self._inverse_basis_perm]
         return res
 
-    def as_VectorSpace(self):
-        """Convert to a :class:`VectorSpace` which is *not* a :class:`ProductSpace`."""
-        # already a VectorSpace. nothing to do.
-        return self
-
-    def change_symmetry(self, symmetry: Symmetry, sector_map: callable,
-                        backend: Backend = None) -> VectorSpace:
-        """Change the symmetry by specifying how the sectors change.
-
-        Parameters
-        ----------
-        symmetry : :class:`~tenpy.linalg.groups.Symmetry`
-            The symmetry of the new space
-        sector_map : function (SectorArray,) -> (SectorArray,)
-            A mapping of sectors (2D ndarrays of int), such
-            that ``new_sectors = sector_map(old_sectors)``.
-            The map is assumed to cooperate with duality, i.e. we assume without checking that
-            ``symmetry.dual_sectors(sector_map(old_sectors))`` is the same as
-            ``sector_map(old_symmetry.dual_sectors(old_sectors))``.
-            TODO do we need to assume more, i.e. compatibility with fusion?
-        backend : :class: `~tenpy.linalg.backends.abstract_backend.Backend`
-            This parameter is ignored. We only include it to have matching signatures
-            with :meth:`ProductSpace.change_symmetry`.
-
-        Returns
-        -------
-        :class:`VectorSpace`
-            A space with the new symmetry. The order of the basis is preserved, but every
-            basis element lives in a new sector, according to `sector_map`.
-        """
-        # OPTIMIZE could we directly map the _non_dual sectors ?
-        res = VectorSpace.from_sectors(
-            symmetry=symmetry, sectors=sector_map(self.sectors), multiplicities=self.multiplicities,
-            basis_perm=self._basis_perm, is_real=self.is_real
-        )
-        if self.is_dual:
-            res = res.dual
-        return res
-
-    def drop_symmetry(self, which: int | list[int] = None, remaining_symmetry: Symmetry = None):
-        """Drop some or all symmetries.
-
-        Parameters
-        ----------
-        which : None | (list of) int
-            If ``None`` (default) the entire symmetry is dropped and the result has ``no_symmetry``.
-            An integer or list of integers assume that ``self.symmetry`` is a ``ProductSymmetry``
-            and indicates which of its factors to drop.
-        remaining_symmetry : :class:`~tenpy.linalg.groups.Symmetry`, optional
-            The resulting symmetry can optionally be passed, e.g. to control its name.
-            Should be a :class:`~tenpy.linalg.groups.NoSymmetry` if all symmetries are
-            dropped or :class:`~tenpy.linalg.groups.ProductSymmetry` otherwise.
-            Is not checked for correctness (TODO or should we?).
-    
-        Returns
-        -------
-        A new VectorSpace instance with reduced `symmetry`.
-        """
-        if which is None:
-            pass
-        elif which == []:
-            return self
-        elif isinstance(self.symmetry, ProductSymmetry):
-            which = to_iterable(which)
-            num_factors = len(self.symmetry.factors)
-            # normalize negative indices to be in range(num_factors)
-            for i, w in enumerate(which):
-                if not -num_factors <= w < num_factors:
-                    raise ValueError(f'which entry {w} out of bounds for {num_factors} symmetries.')
-                if w < 0:
-                    which[i] += num_factors
-            if len(which) == num_factors:
-                which = None
-        elif which == 0 or which == [0]:
-            which = None
-        else:
-            msg = f'Can not drop which={which} for a single (non-ProductSymmetry) symmetry.'
-            raise ValueError(msg)
-        
-        if which is None:
-            return VectorSpace(no_symmetry, sectors=[no_symmetry.trivial_sector],
-                               multiplicities=[self.dim], basis_perm=self._basis_perm,
-                               is_real=self.is_real, _is_dual=self.is_dual)
-
-        if remaining_symmetry is None:
-            factors = [f for i, f in enumerate(self.symmetry.factors) if i not in which]
-            if len(factors) == 1:
-                remaining_symmetry = factors[0]
+    def _repr(self, show_symmetry: bool):
+        # used by Space.__repr__
+        indent = printoptions.indent * ' '
+        # 1) Try showing all data
+        if 3 * self.sectors.size < printoptions.linewidth:
+            # otherwise there is no chance to print all sectors in one line anyway
+            if self._basis_perm is None:
+                basis_perm = 'None'
             else:
-                remaining_symmetry = ProductSymmetry(factors)
-        # TODO check compatible otherwise?
+                basis_perm = format_like_list(self._basis_perm)
+            elements = [f'ElementarySpace(']
+            if show_symmetry:
+                elements.append(f'{self.symmetry!r}')
+            elements.extend([
+                f'sectors={format_like_list(self.symmetry.sector_str(a) for a in self.sectors)}',
+                f'multiplicities={format_like_list(self.multiplicities)}',
+                f'basis_perm={basis_perm}',
+                f'is_dual={self.is_dual}',
+                ')'
+            ])
+            one_line = ', '.join(elements)
+            if len(one_line) <= printoptions.linewidth:
+                return one_line
+            if all(len(l) <= printoptions.linewidth for l in elements) and len(elements) <= printoptions.maxlines_spaces:
+                elements[1:-1] = [f'{indent}{line},' for line in elements[1:-1]]
+                return '\n'.join(elements)
+        # 2) Try showing summarized data
+        elements = [f'<ElementarySpace:']
+        if show_symmetry:
+            elements.append(f'{self.symmetry!s}')
+        elements.extend([
+            f'{self.num_sectors} sectors',
+            f'basis_perm={"None" if self._basis_perm is None else "[...]"}',
+            f'is_dual={self.is_dual}',
+            '>',
+        ])
+        one_line = ' '.join(elements)
+        if len(one_line) < printoptions.linewidth:
+            return one_line
+        if all(len(l) <= printoptions.linewidth for l in elements) and len(elements) <= printoptions.maxlines_spaces:
+            elements[1:-1] = [f'{indent}{line},' for line in elements[1:-1]]
+            return '\n'.join(elements)
+        # 3) Try showing only symmetry
+        if show_symmetry:
+            elements[2:-1] = []
+            one_line = ' '.join(elements)
+            if len(one_line) < printoptions.linewidth:
+                return one_line
+            if all(len(l) <= printoptions.linewidth for l in elements) and len(elements) <= printoptions.maxlines_spaces:
+                elements[1:-1] = [f'{indent}{line},' for line in elements[1:-1]]
+                return '\n'.join(elements)
+        # 4) Show no data at all
+        return None
 
+    def __eq__(self, other):
+        if not isinstance(other, ElementarySpace):
+            return NotImplemented
+        if self.is_dual != other.is_dual:
+            return False
+        if self.symmetry != other.symmetry:
+            return False
+        if self.num_sectors != other.num_sectors:  # check this first to safely compare later
+            return False
+        if not np.all(self.multiplicities == other.multiplicities):
+            return False
+        if not np.all(self.sectors == other.sectors):
+            return False
+        if (self._basis_perm is not None) or (other._basis_perm is not None):
+            # otherwise both are trivial and this match
+            if not np.all(self.basis_perm == other.basis_perm):
+                return False
+        return True
+
+    def as_ElementarySpace(self, is_dual: bool = None) -> ElementarySpace:
+        if (is_dual is None) or (is_dual == self.is_dual):
+            return self
+        return self.with_opposite_duality()
+
+    def as_ket_space(self):
+        """The ket space (``is_dual=False``) isomorphic or equal to self."""
+        if not self.is_dual:
+            return self
+        return self.with_opposite_duality()
+
+    def as_bra_space(self):
+        """The bra space (``is_dual=False``) isomorphic or equal to self."""
+        if self.is_dual:
+            return self
+        return self.with_opposite_duality()
+
+    def change_symmetry(self, symmetry: Symmetry, sector_map: callable, backend: Backend = None,
+                        injective: bool = False
+                        ) -> ElementarySpace:
+        # backend is just there to have the same signature as ProductSpace.change_symmetry
+        # TODO / OPTIMIZE can avoid some computation if the map is injective.
+        #                 then we just need to sort the new sectors, no need to combine
+        return ElementarySpace.from_sectors(
+            symmetry=symmetry, sectors=sector_map(self.sectors), multiplicities=self.multiplicities,
+            is_dual=self.is_dual, basis_perm=self._basis_perm, unique_sectors=injective
+        )
+
+    def direct_sum(self, *others: ElementarySpace) -> ElementarySpace:
+        """Form the direct sum (i.e. stacking).
+
+        The basis of the new space results from concatenating the individual bases.
+        
+        Spaces must have the same symmetry and is_dual.
+        The result is a space with the same symmetry and is_dual, whose sectors are those
+        that appear in any of the spaces and multiplicities are the sum of the multiplicities
+        in each of the spaces.
+        """
+        if not others:
+            return self
+        assert all(o.symmetry == self.symmetry for o in others)
+        assert all(o.is_dual == self.is_dual for o in others)
+        if self.symmetry.can_be_dropped:
+            offsets = np.cumsum([self.dim, *(o.dim for o in others)])
+            basis_perm = np.concatenate(
+                [self.basis_perm] + [o.basis_perm + n for o, n in zip(others, offsets)]
+            )
+        else:
+            basis_perm = None
+        return ElementarySpace.from_sectors(
+            symmetry=self.symmetry,
+            sectors=np.concatenate([self.sectors, *(o.sectors for o in others)]),
+            multiplicities=np.concatenate([self.multiplicities, *(o.multiplicities for o in others)]),
+            is_dual=self.is_dual, basis_perm=basis_perm
+        )
+
+    def drop_symmetry(self, which: int | list[int] = None):
+        which, remaining_symmetry = _parse_inputs_drop_symmetry(which, self.symmetry)
+        if which is None:
+            return ElementarySpace.from_trivial_sector(
+                dim=self.dim, symmetry=remaining_symmetry, is_dual=self.is_dual,
+                basis_perm=self._basis_perm
+            )
         mask = np.ones((self.symmetry.sector_ind_len,), dtype=bool)
         for i in which:
             start, stop = self.symmetry.sector_slices[i:i + 2]
             mask[start:stop] = False
-
         return self.change_symmetry(symmetry=remaining_symmetry,
                                     sector_map=lambda sectors: sectors[:, mask])
 
-    def sector(self, i: int) -> Sector:
-        """Return the `i`-th sector. Equivalent to ``self.sectors[i]``."""
-        sector = self._non_dual_sectors[i, :]
-        if self.is_dual:
-            return self.symmetry.dual_sector(sector)
-        return sector
-
-    def take_slice(self, blockmask) -> VectorSpace:
-        """Take a "slice" of the leg, keeping only some of the basis states.
-
-        Any ProductSpace structure is lost.
-
-        Parameters
-        ----------
-        blockmask : 1D array-like of bool
-            For every basis state of self, if it should be kept (``True``) or discarded (``False``).
+    def is_subspace_of(self, other: ElementarySpace) -> bool:
+        """Whether self is a subspace of other.
+        
+        Per convention, self is never a subspace of other, if the :attr:`is_dual` or the
+        :attr:`symmetry` are different.
+        The :attr:`basis_perm`s are not considered.
         """
-        if not self.symmetry.can_be_dropped:
-            msg = f'take_slice is meaningless for {self.symmetry}.'
-            raise SymmetryError(msg)
-        blockmask = np.asarray(blockmask, dtype=bool)
-        if self._basis_perm is not None:
-            blockmask = blockmask[self._basis_perm]
-        sectors = []
-        mults = []
-        dims = self.symmetry.batch_sector_dim
-        for a, d_a, slc in zip(self._non_dual_sectors, self.sector_dims, self.slices):
-            sector_mask = blockmask[slice(*slc)]
-            per_basis_state = np.reshape(sector_mask, (-1, d_a))
-            if not np.all(per_basis_state == per_basis_state[:, 0, None]):
-                msg = 'Multiplets need to be kept or discarded as a whole.'
-                raise ValueError(msg)
-            num_kept = np.sum(sector_mask)
-            assert num_kept % d_a == 0  # should be guaranteed by check above already, but to be sure...
-            mult = num_kept // d_a
-            if mult > 0:
-                sectors.append(a)
-                mults.append(mult)
-        if len(sectors) == 0:
-            sectors = np.zeros(shape=(0, self.symmetry.sector_ind_len),
-                               dtype=self.symmetry.trivial_sector.dtype)
-            mults = np.zeros(0, int)
-        # build basis_perm for small leg.
-        # it is determined by demanding
-        #    a) that the following diagram commutes
-        #
-        #        (self, public) ---- self.basis_perm ---->  (self, internal)
-        #         |                                           |
-        #         v public_blockmask                          v projection_internal
-        #         |                                           |
-        #        (res, public) ----- small_leg_perm ----->  (res, internal)
-        #
-        #    b) that projection_internal is also just a mask (i.e it preserves ordering)
-        #       which is given by public_blockmask[self.basis_perm]
-        #
-        # this allows us to internally (e.g. in the abelian backend) store only 1D boolean masks
-        # as blocks.
-        #
-        # note that we have already converted blockmask to public_blockmask[self.basis_perm] above
-        basis_perm = rank_data(self.basis_perm[blockmask])
-        return VectorSpace(symmetry=self.symmetry, sectors=sectors, multiplicities=mults,
-                           basis_perm=basis_perm, is_real=self.is_real, _is_dual=self.is_dual)
+        if self.is_dual != other.is_dual:
+            return False
+        if not self.symmetry.is_same_symmetry(other.symmetry):
+            return False
+        if self.num_sectors == 0:
+            return True
+        # sectors are sorted, so we can just iterate over both of them
+        n_self = 0
+        for other_sector, other_mult in zip(other.sectors, other.multiplicities):
+            if np.all(self.sectors[n_self] == other_sector):
+                if self.multiplicities[n_self] > other_mult:
+                    return False
+                n_self += 1
+            if n_self == self.num_sectors:
+                # have checked all sectors of self
+                return True
+        # reaching this line means self has sectors which other does not have
+        return False
 
     def parse_index(self, idx: int) -> tuple[int, int]:
-        """Utility function to translate an index for this VectorSpace.
+        """Utility function to translate an index.
 
         Parameters
         ----------
@@ -625,603 +708,272 @@ class VectorSpace:
         return sector_idx, multiplicity_idx
 
     def idx_to_sector(self, idx: int) -> Sector:
-        """Returns the sector associated with an index.
-        
-        This is the sector that the `idx`-th element of the public computational basis of self lives in.
+        sector_idx, _ = self.parse_index(idx)
+        return self.sectors[sector_idx]
+
+    def take_slice(self, blockmask: Block) -> ElementarySpace:
+        """Take a "slice" of the leg, keeping only some of the basis states.
+
+        Parameters
+        ----------
+        blockmask : 1D array-like of bool
+            For every basis state of self, if it should be kept (``True``) or discarded (``False``).
         """
-        return self.sector(self.parse_index(idx)[0])
-
-    def sectors_where(self, sector: Sector) -> int | None:
-        """Find the index `i` s.t. ``self.sectors[i] == sector``, or ``None`` if no such ``i`` exists."""
-        if self.is_dual:
-            # lookup dual(sector) in _non_dual_sectors instead.
-            # that lookup is (or will be?) optimized, since the _non_dual_sectors are sorted.
-            # plus, we do not need to form the self.sectors (taking *all* duals).
-            sector = self.symmetry.dual_sector(sector)
-        return self._non_dual_sectors_where(sector)
-
-    def _non_dual_sectors_where(self, sector: Sector) -> int | None:
-        """Find the index `i` s.t. ``self._non_dual_sectors[i] == sector``.
-
-        Or ``None`` if no such ``i`` exists.
-        """
-        # OPTIMIZE use that _non_dual_sectors is sorted to speed up lookup?
-        where = np.where(np.all(self._non_dual_sectors == sector, axis=1))[0]
-        if len(where) == 0:
-            return None
-        if len(where) == 1:
-            return where[0]
-        raise RuntimeError  # sectors should have unique entries, so this should not happen
-
-    def sector_multiplicity(self, sector: Sector) -> int:
-        """The multiplicity of the given sector.
-
-        Returns 0 if self does not have that sector.
-        """
-        idx = self.sectors_where(sector)
-        if idx is None:
-            return 0
-        return self.multiplicities[idx]
-
-    def _non_dual_sector_multiplicity(self, sector: Sector) -> int:
-        """The multiplicity of the given _non_dual_sector.
-
-        Returns 0 if self does not have that sector.
-        """
-        idx = self._non_dual_sectors_where(sector)
-        if idx is None:
-            return 0
-        return self.multiplicities[idx]
-
-    def __repr__(self):
-        # TODO include basis_perm?
-        # number of *entries* in sectors (num_sectors * num_charges) that triggers multiple lines
-        multiline_threshold = 4
-
-        is_dual_str = '.dual' if self.is_dual else ''
-        sectors = self._non_dual_sectors  # printing the non-dual space, eventually followed by .dual
-
-        if self.sectors.size < multiline_threshold:
-            elements = [
-                f'VectorSpace({self.symmetry!r}',
-                *(['is_real=True'] if self.is_real else []),
-                f'sectors={format_like_list(self.symmetry.sector_str(s) for s in sectors)}',
-                f'multiplicities={format_like_list(self.multiplicities)}){is_dual_str}',
-            ]
-            res = ', '.join(elements)
-            if len(res) <= printoptions.linewidth:
-                return res
-
-        indent = printoptions.indent * ' '
-        
-        # check if printing all sectors fits within linewidth
-        if 3 * self.sectors.size < printoptions.linewidth:  # otherwise there is no chance anyway
-            lines = [
-                f'VectorSpace({self.symmetry!r},{" is_real=True," if self.is_real else ""}',
-                f'{indent}sectors={format_like_list(self.symmetry.sector_str(s) for s in sectors)},',
-                f'{indent}multiplicities={format_like_list(self.multiplicities)}',
-                f'){is_dual_str}'
-            ]
-            if all(len(l) <= printoptions.linewidth for l in lines):
-                return '\n'.join(lines)
-
-        # add as many sectors as possible before linewidth is reached
-        # save most recent suggestion in variable res. if new suggestion is too long, return res.
-        res = f'VectorSpace({self.symmetry!r}, ...)'
-        if len(res) > printoptions.linewidth:
-            return 'VectorSpace(...)'
-        prio = self._sector_print_priorities()
-        lines = [
-            f'VectorSpace({self.symmetry!r},{" is_real=True," if self.is_real else ""}',
-            f'{indent}sectors=[...],',
-            f'{indent}multiplicities=[...]',
-            f'){is_dual_str}'
-        ]
-        for n in range(1, len(prio)):
-            # OPTIMIZE could optimize the search grid...
-            if any(len(l) > printoptions.linewidth for l in lines):
-                # this is the first time that printing all lines would be too long
-                return res
-            which = np.sort(prio[:n])
-            sectors = [self.symmetry.sector_str(s) for s in self.sectors[which]]
-            mults = list(self.multiplicities[which])
-            # insert '...' between non-consecutive sectors
-            jumps = np.where((which[1:] - which[:-1]) > 1)[0]
-            for j in reversed(jumps):
-                sectors[j + 1:j + 1] = ['...']
-                mults[j + 1:j + 1] = ['...']
-            lines[1] = f'{indent}sectors={format_like_list(sectors)},'
-            lines[2] = f'{indent}multiplicities={format_like_list(mults)}'
-            res = '\n'.join(lines)
-        return res
-
-    def __str__(self):
-        return self._debugging_str(use_private_sectors=False)
-
-    def _debugging_str(self, use_private_sectors: bool = True):
-        """Version of ``str(self)`` intended for debugging the internals of ``tenpy.linalg``.
-
-        Instead of the :attr:`sectors`, it shows the "private" :attr:`_non_dual_sectors`.
-        """
-        return '\n'.join(self._debugging_str_lines(use_private_sectors=use_private_sectors))
-
-    def _debugging_str_lines(self, use_private_sectors: bool = True):
-        """Part of :meth:`_debugging_str`"""
-        if use_private_sectors:
-            sectors = self._non_dual_sectors
-            mults = self.multiplicities
-        else:
-            sectors = self.sectors
-            mults = self.multiplicities
-        indent = printoptions.indent * ' '
-
-        basis_perm_header = 'basis_perm: '
-        if self._basis_perm is None:
-            basis_perm_str = 'None (no permutation)'
-        else:
-            basis_perm_str = join_as_many_as_possible(
-                [str(x) for x in self.basis_perm],
-                separator=' ',
-                max_len=printoptions.linewidth - len(basis_perm_header) - len(indent) - 2,  # -2 for the brackets
-            )
-            basis_perm_str = '[' + basis_perm_str + ']'
-        lines = [
-            'VectorSpace(',
-            *([f'{indent}is_real=True'] if self.is_real else []),
-            f'{indent}symmetry: {self.symmetry!s}',
-            f'{indent}dim: {self.dim}',
-            f'{indent}is_dual: {self.is_dual}',
-            f'{indent}{basis_perm_header}{basis_perm_str}',
-            f'{indent}num sectors: {self.num_sectors}',
-        ]
-        # determine sectors: list[str] and mults: list[str]
-        if len(lines) + self.num_sectors <= printoptions.maxlines_spaces:
-            sectors = [self.symmetry.sector_str(s) for s in sectors]
-            mults = [str(m) for m in mults]
-        else:
-            # not all sectors are shown. add how many there are
-            lines[4:4]= []
-            prio = self._sector_print_priorities()
-            which = []
-            jumps = []
-            for n in range(len(prio)):
-                _which = np.sort(prio[:n])
-                _jumps = np.where((_which[1:] - _which[:-1]) > 1)[0]
-                header = 1
-                if len(lines) + header + n + len(_jumps) > printoptions.maxlines_spaces:
-                    sectors = [self.symmetry.sector_str(s) for s in sectors[which]]
-                    mults = [str(m) for m in mults[which]]
-                    for j in reversed(jumps):
-                        sectors[j + 1:j + 1] = ['...']
-                        mults[j + 1:j + 1] = ['...']
-                    break
-                which = _which
-                jumps = _jumps
-            else:
-                raise RuntimeError  # break should have been reached
-        # done with sectors: list[str] and mults: list[str]
-        sector_col_width = max(len("sectors"), max(len(s) for s in sectors))
-        lines.append(f'{indent}{"sectors".ljust(sector_col_width)} | multiplicities')
-        lines.extend(f'{indent}{s.ljust(sector_col_width)} | {m}' for s, m in zip(sectors, mults))
-        lines.append(')')
-        return lines
-
-    def __eq__(self, other):
-        if not isinstance(other, VectorSpace):
-            return NotImplemented
-        if isinstance(other, ProductSpace):
-            # ProductSpace overrides __eq__, so self is not a ProductSpace
-            return False
-        return self.is_dual == other.is_dual and self.is_equal_or_dual(other)
-
-    @property
-    def dual(self):
-        res = copy.copy(self)  # shallow copy, works for subclasses as well and preserves metadata
-        res.is_dual = not self.is_dual
-        return res
-
-    def flip_is_dual(self, return_perm: bool = False) -> VectorSpace:
-        """Return a copy with opposite :attr:`is_dual` flag.
-
-        The result has the same :attr:`sectors` and :attr:`multiplicities` *up to permutation*,
-        such that they have the exact same :attr:`sectors_of_basis`.
-        Therefore, the result can replace `self` on a tensor without affecting the charge rule.
-        Note that this leg is neither equal to `self` nor can it be contracted with `self`.
-
-        Returns
-        -------
-        flipped : VectorSpace
-            The flipped space.
-        sector_sort : bool, optional
-            Only returned `if return_perm`.
-            The permutation that sorts the sectors after taking the duals.
-
-        """
-        return VectorSpace.from_sectors(
-            symmetry=self.symmetry, sectors=self.symmetry.dual_sectors(self._non_dual_sectors),
-            multiplicities=self.multiplicities, basis_perm=self._basis_perm, is_real=self.is_real,
-            return_perm=return_perm, _is_dual=not self.is_dual
-        )
-
-    def is_equal_or_dual(self, other: VectorSpace) -> bool:
-        """If another VectorSpace is equal to *or* dual of `self`."""
-        if not isinstance(other, VectorSpace):
-            return False
-        if isinstance(self, ProductSpace) != isinstance(other, ProductSpace):
-            return False
-        if self.is_real != other.is_real:
-            return False
-        if self.symmetry != other.symmetry:
-            return False
-        if self.num_sectors != other.num_sectors:
-            # now we may assume that checking all multiplicities of self is enough.
-            return False
-        if not np.all(self._non_dual_sectors == other._non_dual_sectors):
-            return False
-        if not np.all(self.multiplicities == other.multiplicities):
-            return False
-        if (self._basis_perm is not None) or (other._basis_perm is not None):
-            if not np.all(self.basis_perm == other.basis_perm):
-                return False
-        return True
-
-    def can_contract_with(self, other):
-        """If self can be contracted with other.
-
-        Equivalent to ``self == other.dual`` if `other` is a :class:`VectorSpace`.
-        """
-        if not isinstance(other, VectorSpace):
-            return False
-        if isinstance(other, ProductSpace):
-            # ProductSpace overrides can_contract_with, so self is not a ProductSpace
-            return False
-        return self.is_dual != other.is_dual and self.is_equal_or_dual(other)
-
-    @property
-    def basis_perm(self):
         if not self.symmetry.can_be_dropped:
-            msg = f'basis_perm is meaningless for {self.symmetry}.'
+            msg = f'take_slice is meaningless for {self.symmetry}.'
             raise SymmetryError(msg)
-        if self._basis_perm is None:
-            return np.arange(self.dim)
-        return self._basis_perm
+        blockmask = np.asarray(blockmask, dtype=bool)
+        if self._basis_perm is not None:
+            blockmask = blockmask[self._basis_perm]
+        sectors = []
+        mults = []
+        for a, d_a, slc in zip(self.sectors, self.sector_dims, self.slices):
+            sector_mask = blockmask[slice(*slc)]
+            per_basis_state = np.reshape(sector_mask, (-1, d_a))
+            if not np.all(per_basis_state == per_basis_state[:, 0, None]):
+                msg = 'Multiplets need to be kept or discarded as a whole.'
+                raise ValueError(msg)
+            num_kept = np.sum(sector_mask)
+            assert num_kept % d_a == 0  # should be guaranteed by check above already, but to be sure...
+            mult = num_kept // d_a
+            if mult > 0:
+                sectors.append(a)
+                mults.append(mult)
+        if len(sectors) == 0:
+            sectors = self.symmetry.empty_sector_array
+            mults = np.zeros(0, int)
+        # build basis_perm for small leg.
+        # it is determined by demanding
+        #    a) that the following diagram commutes
+        #
+        #        (self, public) ---- self.basis_perm ---->  (self, internal)
+        #         |                                           |
+        #         v public_blockmask                          v projection_internal
+        #         |                                           |
+        #        (res, public) ----- small_leg_perm ----->  (res, internal)
+        #
+        #    b) that projection_internal is also just a mask (i.e it preserves ordering)
+        #       which is given by public_blockmask[self.basis_perm]
+        #
+        # this allows us to internally (e.g. in the abelian backend) store only 1D boolean masks
+        # as blocks.
+        #
+        # note that we have already converted blockmask to public_blockmask[self.basis_perm] above
+        basis_perm = rank_data(self.basis_perm[blockmask])
+        return ElementarySpace(symmetry=self.symmetry, sectors=sectors, multiplicities=mults,
+                               is_dual=self.is_dual, basis_perm=basis_perm)
 
-    @property
-    def inverse_basis_perm(self):
-        if not self.symmetry.can_be_dropped:
-            msg = f'basis_perm is meaningless for {self.symmetry}.'
-            raise SymmetryError(msg)
-        if self._inverse_basis_perm is None:
-            return np.arange(self.dim)
-        return self._inverse_basis_perm
+    def with_opposite_duality(self):
+        """A space isomorphic to self with opposite ``is_dual`` attribute."""
+        return ElementarySpace(symmetry=self.symmetry, sectors=self.sectors,
+                               multiplicities=self.multiplicities, is_dual=not self.is_dual,
+                               basis_perm=self._basis_perm)
 
-    @property
-    def is_trivial(self) -> bool:
-        """Whether self is the trivial space.
-
-        The trivial space is the one-dimensional space which consists only of the trivial sector,
-        appearing exactly once. In a mathematical sense, the trivial sector _is_ the trivial space.
-
-        TODO name is maybe not ideal... the VectorSpace.null_space could also be called "trivial"
-             this space is the unit of fusion
-        """
-        if len(self._non_dual_sectors) != 1:
-            return False
-        # have already checked if there is more than 1 sector, so can assume self.multiplicities.shape == (1,)
-        if self.multiplicities[0] != 1:
-            return False
-        if not np.all(self._non_dual_sectors[0] == self.symmetry.trivial_sector):
-            return False
-        return True
-
-    @property
-    def num_parameters(self) -> int:
-        """The number of free parameters, i.e. the number of linearly independent symmetric tensors in this space."""
-        # the trivial sector is by definition self-dual, so we can search self._non_dual_sectors,
-        # even if self.is_dual is True. Also, its dimension must be 1.
-        # OPTIMIZE cache?
-        return self.sector_multiplicity(self.symmetry.trivial_sector)
-
-    def is_subspace_of(self, other: VectorSpace) -> bool:
-        """Whether self is a subspace of other.
-
-        This function considers both spaces purely as `VectorSpace`s and ignores a possible
-        `ProductSpace` structure.
-        Per convention, self is never a subspace of other, if the :attr:`is_dual` or the
-        :attr:`symmetry` are different.
-        The :attr:`basis_perm`s are not considered.
-        """
-        if self.is_dual != other.is_dual:
-            return False
-        if self.symmetry != other.symmetry:
-            return False
-        if self.num_sectors == 0:
-            return True
-        
-        # the _non_dual_sectors are lexsorted, so we can just iterate over both of them
-        n_self = 0
-        for other_sector, other_mult in zip(other._non_dual_sectors, other.multiplicities):
-            if np.all(self._non_dual_sectors[n_self] == other_sector):
-                if self.multiplicities[n_self] > other_mult:
-                    return False
-                n_self += 1
-            if n_self == self.num_sectors:
-                # have checked all sectors of self
-                return True
-        # reaching this line means self has sectors which other does not have
-        return False
-
-    def _sector_print_priorities(self):
-        """How to prioritize sectors if not all can be printed.
-
-        Used in `__repr__` and `__str__`.
-        Returns indices of either ``self._non_dual_sectors`` if `use_private_sectors`
-        or of ``self.sectors`` in order of priority"""
-        first = 0
-        last = self.num_sectors - 1
-        largest = np.argmax(self.multiplicities)
-        special = [first, last, largest, first + 1, last - 1, largest - 1, largest + 1]
-        which = []
-        for i in special:
-            if i not in which and 0 <= i < self.num_sectors:
-                which.append(i)
-        which.extend(i for i in range(self.num_sectors) if i not in which)
-        return np.array(which)
-
-    def direct_sum(self, *others: VectorSpace) -> VectorSpace:
-        """Form the direct sum (i.e. stacking).
-
-        The basis of the new space results from concatenating the individual bases.
-        
-        Spaces must have the same symmetry, is_dual and is_real.
-        The result is a space with the same symmetry, is_dual and is_real, whose sectors are those
-        that appear in any of the spaces and multiplicities are the sum of the multiplicities
-        in each of the spaces. Any ProductSpace structure is lost.
-        """
-        if not others:
-            return self.as_VectorSpace()
-
-        symmetry = self.symmetry
-        assert all(o.symmetry == symmetry for o in others)
-        is_real = self.is_real
-        assert all(o.is_real == is_real for o in others)
-        is_dual = self.is_dual
-        assert all(o.is_dual == is_dual for o in others)
+    def with_is_dual(self, is_dual: bool) -> ElementarySpace:
+        """A space isomorphic to self with given ``is_dual`` attribute."""
+        if is_dual == self.is_dual:
+            return self  # TODO copy?
+        return self.with_opposite_duality()
 
 
-        if symmetry.can_be_dropped:
-            offsets = np.cumsum([self.dim, *(o.dim for o in others)])
-            basis_perm = np.concatenate(
-                [self.basis_perm] + [o.basis_perm + n for o, n in zip(others, offsets)]
-            )
-        else:
-            basis_perm = None
-        sectors = np.concatenate([self._non_dual_sectors, *(o._non_dual_sectors for o in others)])
-        multiplicities = np.concatenate([self.multiplicities, *(o.multiplicities for o in others)])
-        res = VectorSpace.from_sectors(symmetry=symmetry, sectors=sectors,
-                                       multiplicities=multiplicities,basis_perm=basis_perm,
-                                       is_real=is_real)
-        res.is_dual = is_dual
-        return res
+class ProductSpace(Space):
+    r"""The tensor product of multiple spaces, which is itself a space.
 
+    Unlike for :class:`ElementarySpace`, we do not distinguish between bra and ket spaces.
+    This is indeed what makes the :class:`ElementarySpace` "elementary".
 
-class ProductSpace(VectorSpace):
-    r"""The product of multiple spaces.
+    The :class:`ProductSpace` introduces a basis transformation the *uncoupled* ("public") basis
+    is given by products of the individual (thus "uncoupled") basis elements.
+    E.g. for a product space :math:`P = V \otimes W \otimes \dots \otimes Z`, this basis consists
+    of elements of the form :math:`v_{i_1} \otimes w_{i_2} \otimes \dots \otimes z_{i_n}`.
+    The order is given in C-style (varying the last index, here :math:`i_n` the fastest) combination
+    of the *public* basis order of the factor :attr:`spaces`.
+    The *coupled* basis is given by the fusion outcomes, sorted and grouped by sector.
+    See :meth:`get_basis_transformation` for the explicit transformation.
+    Thus, a product space does not have a ``basis_perm`` attribute, unlike an
+    :class:`ElementarySpace`.
 
-    Since the product of graded spaces may not be associative, we fix a convention for the order
-    of pairwise fusions: "left to right".
-    This generates a fusion tree looking like this (or it's dual flipped upside down)::
-
-    |    spaces[0]
-    |         \   spaces[1]
-    |          \ /
-    |           Y   spaces[2]
-    |            \ /
-    |             Y
-    |              \
-    |             ...  spaces[-1]
-    |               \ /
-    |                Y
-    |                 \
-    |                 self
-
-    It is the product space of the individual `spaces`,
-    but with an associated basis change implied to allow preserving the symmetry.
-    TODO (JU) actually the product of graded spaces *is* associative up to a canonical isomorphism,
-         which is typically ignored. I think we can sweep this under the rug at this relatively
-         public level of docs...
-         As an implementation detail, it is useful to work with the trees, because you can then
-         build the basis transformation of an N-space fusion from the basis transformations of
-         successive pairwise fusions. If you want to use this strategy, again as an internal
-         implementation detail, not as a property of the product space, you should have a
-         canonical order of pairwise fusions, i.e. a tree.
-         I think the only thing people should be told at this level is that the order
-         of :attr:`spaces` has meaning and you should not mess with it. But since that determines
-         the :attr:`basis_perm` of the ProductSpace, this should be clear anyway.
-
-    TODO elaborate on basis transformation from uncoupled to coupled basis.
-
-    Attributes
-    ----------
-    basis_perm : ndarray
-        For `ProductSpace`s, this is always the trivial permutation ``[0, 1, 2, 3, ...]``.
-    _fusion_outcomes_sort : 1D array | None
-        Only available for abelian symmetries.
-        The permutation that ``np.lexsort( .T)``s the list of all possible fusion outcomes.
-        Note that that list contains duplicates.
-        Shape is ``(np.prod([sp.num_sectors for sp in self.spaces]))``.  (TODO this true for FusionTree?)
-    _fusion_outcomes_inverse_sort : 1D ndarray | None
-        Only available for abelian symmetries.
-        Inverse permutation of :attr:`_fusion_outcomes_sort`.
+    Backends may add :attr:`metadata` to ProductSpaces.
 
     Parameters
     ----------
-    spaces:
-        The factor spaces that multiply to this space.
-        The resulting product space can always be split back into these.
-    backend : Backend | None
-        If a backend is given, the backend-specific metadata will be set via ``backend._fuse_spaces``.
-    symmetry, is_real : optional
-        Like arguments to :meth:`VectorSpace.__init__`.
-        Required if ``len(spaces) == 0``. Ignored otherwise.
-    _is_dual : bool | None
-        Flag indicating wether the fusion space represents a dual (bra) space or a non-dual (ket) space.
-        Per default (``_is_dual=None``), ``spaces[0].is_dual`` is used, i.e. the ``ProductSpace``
-        will be a bra space if and only if its first factor is a bra space.
-        An empty product is not dual by default.
-        See notes on duality below.
-    _sectors, _multiplicities:
-        These inputs to VectorSpace.__init__ can optionally be passed to avoid recomputation.
-        _sectors need to be _non_dual_sectors and in particular are assumed to be sorted
-        (this is not checked!).
+    spaces, symmetry
+        Like the attributes of the same name
+    backend: Backend | None
+        The backend, used in :meth:`_fuse_spaces`, to add backend-specific :attr:`metadata`.
+    _sectors, _multiplicities, _metadata
+        Can optionally be passed to avoid recomputation.
 
-    Notes
-    -----
-    While mathematically the dual of the product :math:`(V \otimes W)^*` is the same as the
-    product of the duals :math:`V^* \otimes W^*`, we distinguish these two objects in the
-    implementation. This allows us to fulfill all of the following constraints
-    a) Have the same order of :attr:`_non_dual_sectors` for a space and its dual,
-        to make contractions easier.
-    b) Consistently view every ProductSpace as a VectorSpace, i.e. have proper subclass behavior
-        and in particular a well-behaved `is_dual` attribute.
-    c) A ProductSpace can always be split into its :attr:`spaces`.
-
-    As an example, consider two VectorSpaces ``V`` and ``W`` and the following four possible
-    products::
-
-        ==== ============================ ================== ========= ==================================
-             Mathematical Expression      .spaces            .is_dual  ._non_dual_sectors
-        ==== ============================ ================== ========= ==================================
-        P1   :math:`V \otimes W`          [V, W]             False     P1._non_dual_sectors
-        P2   :math:`(V \otimes W)^*`      [V.dual, W.dual]   True      P1._non_dual_sectors
-        P3   :math:`V^* \otimes W^*`      [V.dual, W.dual]   False     dual(P1._non_dual_sectors)
-        P4   :math:`(V^* \otimes W^*)^*`  [V, W]             True      dual(P1._non_dual_sectors)
-        ==== ============================ ================== ========= ==================================
-
-    They can be related to each other via the :attr:`dual` property or via :meth:`flip_is_dual`.
-    In this example we have `P1.dual == P2`` and ``P3.dual == P4``, as well as
-    ``P1.flip_is_dual() == P4`` and ``P2.flip_is_dual() == P3``.
-
-    The mutually dual spaces, e.g. ``P1`` and ``P2``, can be contracted with each other, as they
-    have opposite :attr:`is_dual` and matching :attr:`_non_dual_sectors`.
-    The spaces related by :meth:`flip_is_dual()`, e.g. ``P2`` and ``P3``, would be considered
-    the same space mathematically, but in this implementation we have ``P2 != P3`` due to the
-    different :attr:`is_dual` attribute. Since they represent the same space, they have the same
-    :attr:`sectors`.
-    This also means that ``P1.can_contract_with(P3) is False``.
-    The contraction can be done, however, by first converting ``P3.flip_is_dual() == P2``,
-    since then ``P1.can_contract_with(P2) is True``.
-    # TODO (JU) is there a corresponding function that does this on a tensor? -> reference it.
-
-    This convention has the downside that the mathematical notation :math:`P_2 = (V \otimes W)^*`
-    does not transcribe trivially into a single call of ``ProductSpace.__init__``, since
-    ``P2 = ProductSpace([V.dual, W.dual], _is_dual=True)``.
-    You can write ``P2 == ProductSpace([V, W]).dual``, though.
-
-    Note that the default behavior of the `_is_dual` argument guarantees that
-    `ProductSpace(some_space)` is contractible with `ProductSpace([s.dual for s in some_spaces])`.
+    Attributes
+    ----------
+    metadata: dict
+        Backend-specific additional data, added by :meth:`Backend._fuse_spaces`.
+        Metadata is considered optional and can be computed on-demand via :meth:`get_metadata`.
+        A common entry is accessible via the property :attr:`fusion_outcomes_sort`.
     """
-    def __init__(self, spaces: list[VectorSpace], backend: Backend = None,
-                 symmetry: Symmetry = None, is_real: bool = False, _is_dual: bool = None,
-                 _sectors: SectorArray = None, _multiplicities: ndarray = None):
-        if _is_dual is None:
-            if len(spaces) > 0:
-                _is_dual = spaces[0].is_dual
-            else:
-                _is_dual = False  # not dual by default.
-        self.spaces = spaces  # spaces can be themselves ProductSpaces
-        if len(spaces) == 0:
-            assert symmetry is not None, 'symmetry arg is required if spaces is empty'
-            assert is_real is not None, 'is_real arg is requires if spaces is empty'
-            # the empty product is the monoidal unit, i.e. the trivial sector.
-            _sectors = symmetry.trivial_sector[None, :]
-            _multiplicities = np.array([1])
-        else:
-            symmetry = spaces[0].symmetry
-            is_real = spaces[0].is_real
-            assert all(s.symmetry == symmetry for s in spaces)
-            assert all(space.is_real == is_real for space in spaces)
 
-        if _sectors is None:
-            assert _multiplicities is None
+    def __init__(self, spaces: list[Space], symmetry: Symmetry = None, backend: Backend = None,
+                 _sectors: SectorArray = UNSPECIFIED, _multiplicities: ndarray = UNSPECIFIED,
+                 _metadata: dict = UNSPECIFIED):
+        self.spaces = spaces[:]
+        self.num_spaces = len(spaces)
+        if symmetry is None:
+            if len(spaces) == 0:
+                raise ValueError('If spaces is empty, the symmetry arg is required.')
+            symmetry = spaces[0].symmetry
+        if not all(sp.symmetry == symmetry for sp in spaces):
+            raise SymmetryError('Incompatible symmetries.')
+        self.symmetry = symmetry
+        if (_sectors is UNSPECIFIED) or (_multiplicities is UNSPECIFIED):
+            _sectors, _multiplicities, _metadata = _fuse_spaces(
+                symmetry=symmetry, spaces=spaces, backend=backend
+            )
+        Space.__init__(self, symmetry=symmetry, sectors=_sectors,
+                       multiplicities=_multiplicities, is_bra_space=False)
+        if _metadata is UNSPECIFIED:
             if backend is None:
-                _sectors, _multiplicities, fusion_outcomes_sort, metadata = _fuse_spaces(
-                    symmetry=spaces[0].symmetry, spaces=spaces, _is_dual=_is_dual
-                )
+                _metadata = {}
             else:
-                _sectors, _multiplicities, fusion_outcomes_sort, metadata = backend._fuse_spaces(
-                    symmetry=spaces[0].symmetry, spaces=spaces, _is_dual=_is_dual
-                )
-            self._fusion_outcomes_sort = fusion_outcomes_sort
-            if fusion_outcomes_sort is None:
-                self._fusion_outcomes_inverse_sort = None
-            else:
-                self._fusion_outcomes_inverse_sort = inverse_permutation(fusion_outcomes_sort)
-            for key, val in metadata.items():
-                setattr(self, key, val)
-        else:
-            assert _multiplicities is not None
-        VectorSpace.__init__(self, symmetry=symmetry, sectors=_sectors, multiplicities=_multiplicities,
-                             is_real=is_real, _is_dual=_is_dual, basis_perm=None)
+                _metadata = backend.get_leg_metadata(self)
+        self.metadata = _metadata
 
     def test_sanity(self):
-        for s in self.spaces:
-            assert s.symmetry == self.symmetry
-            s.test_sanity()
-        assert self._basis_perm is None
-        return super().test_sanity()
+        assert isinstance(self.metadata, dict)
+        assert len(self.spaces) == self.num_spaces
+        for sp in self.spaces:
+            sp.test_sanity()
+        Space.test_sanity(self)
 
     @classmethod
-    def from_basis(cls, *a, **kw):
-        raise NotImplementedError('from_basis can not create ProductSpaces')
+    def from_partial_products(cls, *factors: ProductSpace, backend: Backend | None = None
+                              ) -> ProductSpace:
+        """Given multiple product spaces, create the flat product of all their :attr:`spaces`.
 
-    @classmethod
-    def from_independent_symmetries(cls, *a, **kw):
-        raise NotImplementedError('from_independent_symmetries can not create ProductSpaces')
-
-    @classmethod
-    def from_trivial_sector(cls, *a, **kw):
-        raise NotImplementedError('from_trivial_sector can not create ProductSpaces')
-
-    def as_VectorSpace(self):
-        """Forget about the substructure of the ProductSpace but view only as VectorSpace.
-        This is necessary before truncation, after which the product-space structure is no
-        longer necessarily given.
+        This is equivalent to ``ProductSpace([p_space.spaces for p_space in factors])``,
+        but avoids some of the computation of sectors.
         """
-        return VectorSpace(symmetry=self.symmetry,
-                           sectors=self._non_dual_sectors,
-                           multiplicities=self.multiplicities,
-                           is_real=self.is_real,
-                           basis_perm=None,
-                           _is_dual=self.is_dual,)
+        isomorphic = ProductSpace(factors, backend=backend)
+        return ProductSpace(
+            spaces=[sp for pr in factors for sp in pr.spaces], backend=backend,
+            _sectors=isomorphic.sectors, _multiplicities=isomorphic.multiplicities
+        )
 
-    def get_flat_spaces(self) -> list[VectorSpace]:
-        """Flatten the potential nesting of product structures.
+    @property
+    def dual(self) -> ProductSpace:
+        sectors, mults, _ = _sort_sectors(self.symmetry.dual_sectors(self.sectors), self.multiplicities)
+        return ProductSpace([sp.dual for sp in reversed(self.spaces)], symmetry=self.symmetry,
+                            _sectors=sectors, _multiplicities=mults)
+            
+    @property
+    def fusion_outcomes_sort(self):
+        fusion_outcomes_sort = self.metadata.get('fusion_outcomes_sort', None)
+        if fusion_outcomes_sort is None:
+            grid = np.indices(tuple(space.num_sectors for space in self.spaces), np.intp)
+            grid = grid.T.reshape(-1, len(self.spaces))
+            sectors = self.symmetry.multiple_fusion_broadcast(
+                *(sp.sectors[gr] for sp, gr in zip(self.spaces, grid.T))
+            )
+            multiplicities = np.prod([space.multiplicities[gr]
+                                      for space, gr in zip(self.spaces, grid.T)], axis=0)
+            _, _, fusion_outcomes_sort = _unique_sorted_sectors(sectors, multiplicities)
+            self.metadata['fusion_outcomes_sort'] = fusion_outcomes_sort
+        return fusion_outcomes_sort
 
-        Returns
-        -------
-        factor_spaces : list of :class:`VectorSpace`
-            A list of spaces which are not :class:`ProductSpace`.
-            Those are all the spaces that appear in ``self.spaces``, either directly or nested,
-            e.g. either as ``self.spaces[i]`` or ``self.spaces[j].spaces[k]`` etc.
-        """
-        factors_spaces = []
-        for space in self.spaces:
-            if isinstance(space, ProductSpace):
-                factors_spaces.extend(space.get_flat_spaces())
-            else:
-                factors_spaces.append(space)
-        return factors_spaces
-        
-    def as_flat_product(self) -> ProductSpace:
-        """Create a flat ProductSpace from potentially nested ProductSpace.
+    @property
+    def is_trivial(self) -> bool:
+        return all(s.is_trivial for s in self.spaces)
 
-        Transform a tree-like structure, where the :attr:`spaces` may themselves be ProductSpaces
-        to a flat structure where they are not.
-        """
-        return ProductSpace(self.get_flat_spaces(), _is_dual=self.is_dual,
-                            _sectors=self._non_dual_sectors, _multiplicities=self.multiplicities)
+    def get_metadata(self, key: str, backend: Backend = None):
+        if key not in self.metadata:
+            _, _, metadata = _fuse_spaces(self.symmetry, self.spaces, backend)
+            self.metadata.update(metadata)
+            if key not in self.metadata:
+                msg = f'Unable to find key or generate it using _fuse_spaces: {key}'
+                raise KeyError(msg)
+        return self.metadata[key]
+
+    def __len__(self):
+        return self.num_spaces
+
+    def _repr(self, show_symmetry: bool):
+        indent = printoptions.indent * ' '
+        lines = [f'ProductSpace(']
+        if show_symmetry:
+            lines.append(f'{indent}symmetry={self.symmetry!r},')
+        num_lines = len(lines) + 1  # already consider final line ')'
+        summarize = False
+        for sp in self.spaces:
+            sp_repr = sp._repr(show_symmetry=False)
+            if sp_repr is None:
+                summarize = True
+                break
+            next_space = indent + sp_repr.replace('\n', '\n' + indent) + ','
+            additional_lines = 1 + next_space.count('\n')
+            if num_lines + additional_lines > printoptions.maxlines_spaces:
+                summarize = True
+                break
+            lines.append(next_space)
+            num_lines += additional_lines
+        lines.append(')')
+        if not summarize:
+            return '\n'.join(lines)
+        # need to summarize
+        elements = [f'<ProductSpace']
+        if show_symmetry:
+            elements.append(f'symmetry={self.symmetry!r}')
+        elements.extend([
+            f'{self.num_spaces} spaces',
+            '>'
+        ])
+        one_line = ' '.join(elements)
+        if len(one_line) <= printoptions.linewidth:
+            return one_line
+        elements[1:-1] = [f'{indent}{line}' for line in elements]
+        if all(len(l) < printoptions.linewidth for l in elements) and len(elements) <= printoptions.maxlines_spaces:
+            return '\n'.join(elements)
+        return None
     
+    def __eq__(self, other):
+        if not isinstance(other, ProductSpace):
+            return NotImplemented
+        if self.num_spaces != other.num_spaces:
+            return False
+        return all(s1 == s2 for s1, s2 in zip(self.spaces, other.spaces))
+
+    def as_ElementarySpace(self, is_dual: bool = None) -> ElementarySpace:
+        res = ElementarySpace(symmetry=self.symmetry, sectors=self.sectors,
+                              multiplicities=self.multiplicities)
+        if is_dual is True:
+            res = res.as_bra_space()
+        return res
+
+    def change_symmetry(self, symmetry: Symmetry, sector_map: callable, backend: Backend = None
+                        ) -> ProductSpace:
+        sectors, multiplicities = _unique_sorted_sectors(
+            sector_map(self.sectors), self.multiplicities
+        )
+        # OPTIMIZE can we preserve the metadata?
+        return ProductSpace(
+            spaces=[sp.change_symmetry(symmetry, sector_map, backend) for sp in self.spaces],
+            symmetry=self.symmetry, backend=backend,
+            _sectors=sectors, _multiplicities=multiplicities
+        )
+
+    def drop_symmetry(self, which: int | list[int] = None):
+        which, remaining_symmetry = _parse_inputs_drop_symmetry(which, self.symmetry)
+        return ProductSpace(spaces=[sp.drop_symmetry(which) for sp in self.spaces],
+                            symmetry=remaining_symmetry)
+
+    def fuse_states(self, states: list[Block], backend: Backend) -> Block:
+        """TODO"""
+        if not self.symmetry.can_be_dropped:
+            raise SymmetryError
+        if self.symmetry.is_abelian:
+            # first kron then use get_basis_transformation_perm()
+            raise NotImplementedError  # TODO
+        # other wise contract get_basis_transformation() with the states
+        raise NotImplementedError
+
     def get_basis_transformation(self) -> np.ndarray:
         r"""Get the basis transformation from uncoupled to coupled basis.
 
@@ -1229,9 +981,13 @@ class ProductSpace(VectorSpace):
         is given by products of the individual ("uncoupled") basis elements, i.e. by elements of
         the form :math:`v_{i_1} \otimes w_{i_2} \otimes \dots \otimes z_{i_n}`.
         In particular, the order for the uncoupled basis does *not*
-        consider :attr:`VectorSpace.basis_perm`, i.e. it is in general not grouped by sectors.
-        The coupled basis is organized by sectors. See the :class:`ProductSpace` docstring for
-        details.
+        consider :attr:`ElementarySpace.basis_perm`, i.e. it is in general not grouped by sectors.
+        The coupled basis is grouped and sorted organized by sectors.
+        
+        For abelian groups, this is achieved simply by permuting basis elements, see
+        :meth:`get_basis_transformation_perm` for that permutation.
+        For general groups, this is a more general unitary basis transformation.
+        For non-group symmetries, this is not well defined.
 
         Returns
         -------
@@ -1242,14 +998,8 @@ class ProductSpace(VectorSpace):
             The entries are coefficients of the basis transformation such that
 
             .. math ::
-                \ket{c} = \sum_{i_1, \dots, i_N} \texttt{trafo[i1, ..., iN]}
+                \ket{c} = \sum_{i_1, \dots, i_N} \texttt{trafo[i1, ..., iN, c]}
                           \ket{i_1} \otimes \dots \otimes \ket{i_n}
-
-        See Also
-        --------
-        get_basis_transformation_perm
-            For abelian symmetries, the basis transformation, when reshaped to a square matrix,
-            is just a permutation matrix. This method directly returns the permutation.
 
         Examples
         --------
@@ -1273,16 +1023,13 @@ class ProductSpace(VectorSpace):
 
         Such that we get
 
-        TODO unskip the doctest
-
         .. testsetup :: get_basis_transformation
-            from tenpy.linalg import ProductSpace, VectorSpace, su2_symmetry
+            from tenpy.linalg import ProductSpace, ElementarySpace, su2_symmetry
 
         .. doctest :: get_basis_transformation
-            :options: +SKIP
 
             >>> spin_one_half = [1]  # sectors are labelled by 2*S
-            >>> site = VectorSpace(su2_symmetry, [spin_one_half])
+            >>> site = ElementarySpace(su2_symmetry, [spin_one_half])
             >>> prod_space = ProductSpace([site, site])
             >>> trafo = prod_space.get_basis_transformation()
             >>> trafo[:, :, 0]  # | s=0, m=0 >
@@ -1299,13 +1046,15 @@ class ProductSpace(VectorSpace):
                    [0., 0.]])
             
         """
+        if not self.symmetry.can_be_dropped:
+            raise SymmetryError
         if self.symmetry.is_abelian:
             transform = np.zeros((self.dim, self.dim), dtype=np.intp)
             perm = self.get_basis_transformation_perm()
             transform[np.ix_(perm, range(self.dim))] = 1.
             return np.reshape(transform, (*(s.dim for s in self.spaces), self.dim))
-        raise NotImplementedError  # TODO for FusionTree this is just fusion_tree.__array__, right?
-
+        raise NotImplementedError  # TODO
+        
     def get_basis_transformation_perm(self):
         r"""Get the permutation equivalent to :meth:`get_basis_transformation`.
 
@@ -1337,12 +1086,12 @@ class ProductSpace(VectorSpace):
 
         .. testsetup :: get_basis_transformation_perm
             import numpy as np
-            from tenpy.linalg import ProductSpace, VectorSpace, z2_symmetry
+            from tenpy.linalg import ProductSpace, ElementarySpace, z2_symmetry
 
         .. doctest :: get_basis_transformation_perm
 
             >>> even, odd = [0], [1]
-            >>> spin1 = VectorSpace.from_basis(z2_symmetry, [even, odd, even])
+            >>> spin1 = ElementarySpace.from_basis(z2_symmetry, [even, odd, even])
             >>> product_space = ProductSpace([spin1, spin1])
             >>> perm = product_space.get_basis_transformation_perm()
             >>> perm
@@ -1352,7 +1101,6 @@ class ProductSpace(VectorSpace):
             >>> np.all(product_space.get_basis_transformation() == transform.reshape((3, 3, 9)))
             True
         """
-        # TODO expand testing
         if not self.symmetry.is_abelian:
             raise SymmetryError('For non-abelian symmetries use get_basis_transformation instead.')
         # C-style for compatibility with e.g. numpy.reshape
@@ -1366,225 +1114,134 @@ class ProductSpace(VectorSpace):
 
         This permutation arises as follows:
         For each of the :attr:`spaces` consider all sectors by order of appearance in the internal
-        order, i.e. in :attr:`VectorSpace.sectors``. Take all combinations of sectors from all the
+        order, i.e. in :attr:`ElementarySpace.sectors``. Take all combinations of sectors from all the
         spaces in C-style order, i.e. varying those from the last space the fastest.
         For each combination, take all of its fusion outcomes (TODO define order for FusionTree).
         The target permutation np.lexsort( .T)s the resulting list of sectors.
         """
         # OPTIMIZE this probably not the most efficient way to do this, but it hurts my brain
         #  and i need to get this work, if only in an ugly way...
-        
+        fusion_outcomes_inverse_sort = inverse_permutation(self.fusion_outcomes_sort)
         # j : multi-index into the uncoupled private basis, i.e. into the C-style product of internal bases of the spaces
         # i : index of self.spaces
         # s : index of the list of all fusion outcomes / fusion channels
         dim_strides = make_stride([sp.dim for sp in self.spaces])  # (num_spaces,)
         sector_strides = make_stride([sp.num_sectors for sp in self.spaces])  # (num_spaces,)
         num_sector_combinations = np.prod([space.num_sectors for space in self.spaces])
-        
         # [i, j] :: position of the part of j in spaces[i] within its private basis
         idcs = unstridify(np.arange(self.dim), dim_strides).T
-        
         # [i, j] :: sector of the part of j in spaces[i] is spaces[i].sectors[sector_idcs[i, j]]
         #           sector_idcs[i, j] = bisect.bisect(spaces[i].slices[:, 0], idcs[i, j]) - 1
         sector_idcs = np.array(
             [[bisect.bisect(sp.slices[:, 0], idx) - 1 for idx in idx_col]
              for sp, idx_col in zip(self.spaces, idcs)]
         )  # OPTIMIZE can bisect.bisect be broadcast somehow? is there a numpy alternative?
-        
         # [i, j] :: the part of j in spaces[i] is the degeneracy_idcs[i, j]-th state within that sector
         #           degeneracy_idcs[i, j] = idcs[i, j] - spaces[i].slices[sector_idcs[i, j], 0]
         degeneracy_idcs = idcs - np.stack(
             [sp.slices[si_col, 0] for sp, si_col in zip(self.spaces, sector_idcs)]
         )
-        
         # [i, j] :: strides for combining degeneracy indices.
         #           degeneracy_strides[:, j] = make_stride([... mults with sector_idcs[:, j]])
         degeneracy_strides = np.array(
             [make_stride([sp.multiplicities[si] for sp, si in zip(self.spaces, si_row)])
              for si_row in sector_idcs.T]
         ).T  # OPTIMIZE make make_stride broadcast?
-        
         # [j] :: position of j in the unsorted list of fusion outcomes
         fusion_outcome = np.sum(sector_idcs * sector_strides[:, None], axis=0)
-
         # [i, s] :: sector combination s has spaces[i].sectors[all_sector_idcs[i, s]]
         all_sector_idcs = unstridify(np.arange(num_sector_combinations), sector_strides).T
-
         # [i, s] :: all_mults[i, s] = spaces[i].multiplicities[all_sector_idcs[i, s]]
         all_mults = np.array([sp.multiplicities[comb] for sp, comb in zip(self.spaces, all_sector_idcs)])
-
         # [s] : total multiplicity of the fusion channel
         fusion_outcome_multiplicities = np.prod(all_mults, axis=0)
-
         # [s] : !!shape == (L_s + 1,)!!  ; starts ([s]) and stops ([s + 1]) of fusion channels in the sorted list
         fusion_outcome_slices = np.concatenate(
-            [[0], np.cumsum(fusion_outcome_multiplicities[self._fusion_outcomes_sort])]
+            [[0], np.cumsum(fusion_outcome_multiplicities[self.fusion_outcomes_sort])]
         )
-
         # [j] : position of fusion channel after sorting
-        sorted_pos = self._fusion_outcomes_inverse_sort[fusion_outcome]
-
+        sorted_pos = fusion_outcomes_inverse_sort[fusion_outcome]
         # [j] :: contribution from the sector, i.e. start of all the js of the same fusion channel
         sector_part = fusion_outcome_slices[sorted_pos]
-        
         # [j] :: contribution from the multiplicities, i.e. position with all js of the same fusion channel
         degeneracy_part = np.sum(degeneracy_idcs * degeneracy_strides, axis=0)
-
         return inverse_permutation(sector_part + degeneracy_part)
 
-    def fuse_states(self, states: list[Block], backend: Backend) -> Block:
-        """TODO write docs"""
-        # if abelian first kron then use get_basis_transformation_perm()
-        # other wise contract get_basis_transformation() with the states
-        raise NotImplementedError  # TODO
+    def insert_multiply(self, other: Space, pos: int, backend: Backend | None = None
+                        ) -> ProductSpace:
+        """Insert an additional factor at given position.
 
-    def change_symmetry(self, symmetry: Symmetry, sector_map: callable,
-                         backend: Backend = None) -> ProductSpace:
-        spaces = [s.change_symmetry(symmetry=symmetry, sector_map=sector_map) for s in self.spaces]
-        return ProductSpace(spaces, backend=backend, _is_dual=self.is_dual)
+        Parameters
+        ----------
+        other: Space
+            The new factor to insert into :attr:`spaces`.
+        pos: int
+            The position of the new factor in the *result* :attr:`spaces`.
 
-    def drop_symmetry(self, which: int | list[int] = None, remaining_symmetry: Symmetry = None):
-        # TODO do we need the backend arg of ProductSpace.__init__?
-        if len(self.spaces) == 0:
-            return ProductSpace([], _is_dual=self.is_dual)
-        first = self.spaces[0].drop_symmetry(which, remaining_symmetry)
-        if remaining_symmetry is None:
-            remaining_symmetry = first.symmetry
-        rest = [space.drop_symmetry(which, remaining_symmetry) for space in self.spaces[1:]]
-        return ProductSpace([first] + rest, _is_dual=self.is_dual)
-
-    def flip_is_dual(self) -> ProductSpace:
-        """Return a ProductSpace isomorphic to self, which has the opposite is_dual attribute.
-
-        This realizes the isomorphism between ``V.dual * W.dual`` and ``(V * W).dual``
-        for `VectorSpace` ``V`` and ``W``.
-        Note that the returned space is equal to neither ``self`` nor ``self.dual``.
-        See docstring of :class:`ProductSpace` for details.
-
-        Backend-specific metadata may be lost.
-        TODO (JU) can we figure out how to keep it?
-                  alternatively: should we call backend.add_leg_metadata to add it again?
+        Returns
+        -------
+        A new product space, consisting of ``spaces[:pos] + [other] + spaces[pos:]``.
         """
-        sectors = self.symmetry.dual_sectors(self._non_dual_sectors)
-        sort = np.lexsort(sectors.T)
-        return ProductSpace(spaces=self.spaces,
-                            _is_dual=not self.is_dual,
-                            _sectors=sectors[sort],
-                            _multiplicities=self.multiplicities[sort])
-
-    def __len__(self):
-        return len(self.spaces)
-
-    def __iter__(self):
-        return iter(self.spaces)
-
-    def __repr__(self):
-        lines = [f'ProductSpace([']
-        indent = printoptions.indent * ' '
-        num_lines = 2  # first and last line
-        for s in self.spaces:
-            next_space = indent + repr(s).replace('\n', '\n' + indent) + ','
-            additional_lines = 1 + next_space.count('\n')
-            if num_lines + additional_lines > printoptions.maxlines_spaces:
-                break
-            lines.append(next_space)
-            num_lines += additional_lines
-        if self.is_dual:
-            lines.append(']).dual')
-        else:
-            lines.append(f'])')
-        return '\n'.join(lines)
-
-    def _debugging_str_lines(self, use_private_sectors: bool = True):
-        indent = printoptions.indent * ' '
-        lines = VectorSpace._debugging_str_lines(self, use_private_sectors=use_private_sectors)
-        lines[0] = 'ProductSpace('
-        offset = 1 if self.is_real else 0
-        lines[2 + offset] = f'{indent}dim: [{", ".join(str(s.dim) for s in self.spaces)}] -> {self.dim}'
-        lines[3 + offset] = f'{indent}is_dual: [{", ".join(str(s.is_dual) for s in self.spaces)}] -> {self.is_dual}'
-        lines[4 + offset] = f'{indent}num sectors: [{", ".join(str(s.num_sectors) for s in self.spaces)}] -> {self.num_sectors}'
-        return lines
-
-    def __eq__(self, other):
-        if not isinstance(other, VectorSpace):
-            return NotImplemented
-        if not isinstance(other, ProductSpace):
-            return False
-        if other.is_dual != self.is_dual:
-            return False
-        if len(other.spaces) != len(self.spaces):
-            return False
-        return all(s1 == s2 for s1, s2 in zip(self.spaces, other.spaces))
-
-    def is_equal_or_dual(self, other: ProductSpace) -> bool:
-        """If another ProductSpace is equal to *or* dual of `self`."""
-        if not isinstance(other, ProductSpace):
-            return False
-        if len(other.spaces) != len(self.spaces):
-            return False
-        return all(s1.is_equal_or_dual(s2) for s1, s2 in zip(self.spaces, other.spaces))
-
-    @property
-    def dual(self):
-        res = copy.copy(self)  # shallow copy, works for subclasses as well
-        res.is_dual = not self.is_dual
-        res.spaces = [s.dual for s in self.spaces]
-        return res
-
-    @property
-    def is_trivial(self) -> bool:
-        return all(s.is_trivial for s in self.spaces)
-
-    def can_contract_with(self, other):
-        if not isinstance(other, ProductSpace):
-            return False
-        if self.is_dual == other.is_dual:
-            return False
-        if len(self.spaces) != len(other.spaces):
-            return False
-        return all(s1.can_contract_with(s2) for s1, s2 in zip(self.spaces, other.spaces))
-
+        new_num_spaces = self.num_spaces + 1
+        assert -new_num_spaces <= pos < new_num_spaces
+        if pos < 0:
+            pos += new_num_spaces
+        isomorphic = ProductSpace([self, other])  # this space has the same sectors and mults
+        return ProductSpace(
+            spaces=self.spaces[:pos] + [other] + self.spaces[pos:],
+            symmetry=self.symmetry, backend=backend,
+            _sectors=isomorphic.sectors, _multiplicities=isomorphic.multiplicities
+        )
+        
     def iter_uncoupled(self) -> Iterator[tuple[Sector]]:
         """Iterate over all combinations of sectors"""
         return it.product(*(s.sectors for s in self.spaces))
-        
 
-def _fuse_spaces(symmetry: Symmetry, spaces: list[VectorSpace], _is_dual: bool
-                 ) -> tuple[SectorArray, ndarray, ndarray, dict]:
-    """This function is called as part of ProductSpace.__init__.
+    def left_multiply(self, other: Space, backend: Backend | None = None) -> ProductSpace:
+        """Add a new factor at the left / beginning of the spaces"""
+        return self.insert_multiply(other, 0, backend=backend)
+
+    def right_multiply(self, other: Space, backend: Backend | None = None) -> ProductSpace:
+        """Add a new factor at the right / end of the spaces"""
+        return self.insert_multiply(other, -1, backend=backend)
+
+
+def _fuse_spaces(symmetry: Symmetry, spaces: list[Space], backend: Backend | None = None):
+    """Helper function, called as part of ``ProductSpace.__init__``.
     
     It determines the sectors and multiplicities of the ProductSpace.
     There is also a version of this function in the backends, i.e.
-    :meth:`~tenpy.linalg.backends.abstract_backend.Backend._fuse_spaces:, which may
+    :meth:`~tenpy.linalg.backends.abstract_backend.Backend._fuse_spaces`, which may
     customize this behavior and in particular may return metadata, i.e. attributes to be added to
     the ProductSpace.
-    This default implementation returns empty metadata ``{}``.
+    This default implementation returns default metadata, with only ``fusion_outcomes_sort``
+    if the symmetry is abelian and empty metadata otherwise.
 
     Returns
     -------
     sectors : 2D array of int
-        The :attr:`VectorSpace._non_dual_sectors`.
+        The :attr:`ElementarySpace.sectors`.
     multiplicities : 1D array of int
-        the :attr:`VectorSpace.multiplicities`.
-    fusion_outcomes_sort
-        the :attr:`ProductSpace._fusion_outcomes_sort`.
+        the :attr:`ElementarySpace.multiplicities`.
     metadata : dict
         A dictionary with string keys and arbitrary values.
         These will be added as attributes of the ProductSpace
     """
-    if isinstance(symmetry, NoSymmetry):
-        sectors = symmetry.trivial_sector[None, :]
-        multiplicities = [np.prod([sp.dim for sp in spaces])]
-        return sectors, multiplicities, np.arange(1), {}
+    if symmetry is None:
+        if len(spaces) == 0:
+            raise ValueError('If spaces is empty, the symmetry arg is required.')
+        symmetry = spaces[0].symmetry
     
-    if _is_dual:
-        spaces = [s.dual for s in spaces] # directly fuse sectors of dual spaces.
-        # This yields overall dual `sectors` to return, which we directly save in
-        # self._non_dual_sectors, such that `self.sectors` (which takes a dual!) yields correct sectors
-        # Overall, this ensures consistent sorting/order of sectors between dual ProductSpace!
+    if backend is not None:
+        try:
+            return backend._fuse_spaces(symmetry=symmetry, spaces=spaces)
+        except NotImplementedError:
+            pass
 
     if symmetry.is_abelian:
-        # copying parts from AbelianBackend._fuse_spaces here...
+        if len(spaces) == 0:
+            metadata = dict(fusion_outcomes_sort=np.array([0], dtype=int))
+            return symmetry.trivial_sector[None, :], [1], metadata
         grid = np.indices(tuple(space.num_sectors for space in spaces), np.intp)
         grid = grid.T.reshape(-1, len(spaces))
         sectors = symmetry.multiple_fusion_broadcast(
@@ -1593,45 +1250,39 @@ def _fuse_spaces(symmetry: Symmetry, spaces: list[VectorSpace], _is_dual: bool
         multiplicities = np.prod([space.multiplicities[gr] for space, gr in zip(spaces, grid.T)],
                                   axis=0)
         sectors, multiplicities, fusion_outcomes_sort = _unique_sorted_sectors(sectors, multiplicities)
-        return sectors, multiplicities, fusion_outcomes_sort, {}
+        metadata = dict(fusion_outcomes_sort=fusion_outcomes_sort)
+        return sectors, multiplicities, metadata
 
     # define recursively. base cases:
     if len(spaces) == 0:
-        return symmetry.empty_sector_array, [], None, {}
+        return symmetry.trivial_sector[None, :], [1], {}
 
     if len(spaces) == 1:
-        sectors = spaces[0].sectors
-        mults = spaces[0].multiplicities
-        order = np.lexsort(sectors.T)
-        return sectors[order, :], mults[order], None, {}
+        return spaces[0].sectors, spaces[0].multiplicities, {}
 
-    # _is_dual is already accounted for.
-    sectors_1, mults_1, _, _ = _fuse_spaces(symmetry, spaces[:-1], _is_dual=False)
-    sectors_2 = spaces[-1].sectors
-    mults_2 = spaces[-1].multiplicities
+    sectors_1, mults_1, _ = _fuse_spaces(symmetry, spaces[:-1])
 
-    sector_contributions = []
-    mult_contributions = []
-    for s2, m2 in zip(sectors_2, mults_2):
+    sector_arrays = []
+    mult_arrays = []
+    for s2, m2 in zip(spaces[-1].sectors, spaces[-1].multiplicities):
         for s1, m1 in zip(sectors_1, mults_1):
-            sects = symmetry.fusion_outcomes(s1, s2)
-            sector_contributions.append(sects)
-            if symmetry.fusion_style is FusionStyle.general:
-                mult_contributions.append(
-                    m1 * m2 * np.array([symmetry._n_symbol(s1, s2, c) for c in sects], dtype=int)
-                )
+            new_sects = symmetry.fusion_outcomes(s1, s2)
+            sector_arrays.append(new_sects)
+            if symmetry.fusion_style <= FusionStyle.multiple_unique:
+                new_mults = m1 * m2 * np.ones(len(new_sects), dtype=int)
             else:
-                mult_contributions.append(m1 * m2 * np.ones((len(sects),), dtype=int))
-                
+                # OPTIMIZE support batched N symbol?
+                new_mults = m1 * m2 * np.array([symmetry._n_symbol(s1, s2, c) for c in new_sects], dtype=int)
+            mult_arrays.append(new_mults)
     sectors, multiplicities, _ = _unique_sorted_sectors(
-        np.concatenate(sector_contributions, axis=0),
-        np.concatenate(mult_contributions, axis=0)
+        np.concatenate(sector_arrays, axis=0),
+        np.concatenate(mult_arrays, axis=0)
     )
-    return sectors, multiplicities, None, {}
+    return sectors, multiplicities, {}
 
 
 def _unique_sorted_sectors(unsorted_sectors: SectorArray, unsorted_multiplicities: np.ndarray):
-    """Helper function for _fuse_spaces
+    """Sort sectors and merge duplicates.
 
     Given unsorted sectors which may contain duplicates,
     return a sorted list of unique sectors and corresponding *aggregate* multiplicities
@@ -1646,12 +1297,59 @@ def _unique_sorted_sectors(unsorted_sectors: SectorArray, unsorted_multiplicitie
     perm
         The permutation that sorts the input, i.e. ``np.lexsort(unsorted_sectors.T)``.
     """
-    perm = np.lexsort(unsorted_sectors.T)
-    sectors = unsorted_sectors[perm]
-    multiplicities = unsorted_multiplicities[perm]
+    sectors, multiplicities, perm = _sort_sectors(unsorted_sectors, unsorted_multiplicities)
     slices = np.concatenate([[0], np.cumsum(multiplicities)], axis=0)
     diffs = find_row_differences(sectors, include_len=True)
     slices = slices[diffs]
     multiplicities = slices[1:] - slices[:-1]
     sectors = sectors[diffs[:-1]]
     return sectors, multiplicities, perm
+
+
+def _sort_sectors(sectors: SectorArray, multiplicities: np.ndarray):
+    perm = np.lexsort(sectors.T)
+    return sectors[perm], multiplicities[perm], perm
+
+
+def _parse_inputs_drop_symmetry(which: int | list[int] | None, symmetry: Symmetry
+                                ) -> tuple[list[int] | None, Symmetry]:
+    """Input parsing for :meth:`Space.drop_symmetry`.
+
+    Returns
+    -------
+    which : None | list of int
+        Which symmetries to drop, as integers in ``range(len(symmetries.factors))``.
+        ``None`` indicates to drop all.
+    remaining_symmetry : Symmetry
+        The symmetry that remains.
+    """
+    if which is None or which == []:
+        pass
+    elif isinstance(symmetry, ProductSymmetry):
+        which = to_iterable(which)
+        num_factors = len(symmetry.factors)
+        # normalize negative indices to be in range(num_factors)
+        for i, w in enumerate(which):
+            if not -num_factors <= w < num_factors:
+                raise ValueError(f'which entry {w} out of bounds for {num_factors} symmetries.')
+            if w < 0:
+                which[i] += num_factors
+        if len(which) == num_factors:
+            which = None
+    elif which == 0 or which == [0]:
+        which = None
+    else:
+        msg = f'Can not drop which={which} for a single (non-ProductSymmetry) symmetry.'
+        raise ValueError(msg)
+
+    if which is None:
+        remaining_symmetry = no_symmetry
+    else:
+        factors = [f for i, f in enumerate(symmetry.factors) if i not in which]
+        if len(factors) == 1:
+            remaining_symmetry = factors[0]
+        else:
+            remaining_symmetry = ProductSymmetry(factors)
+
+    return which, remaining_symmetry
+    

--- a/tenpy/linalg/spaces.py
+++ b/tenpy/linalg/spaces.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Sequence, Iterator
 from .dummy_config import printoptions
 from .symmetries import (Sector, SectorArray, Symmetry, ProductSymmetry, no_symmetry, FusionStyle,
                          SymmetryError)
-from .misc import make_stride, find_row_differences, unstridify, join_as_many_as_possible, UNSPECIFIED
+from .misc import make_stride, find_row_differences, unstridify, UNSPECIFIED
 from ..tools.misc import inverse_permutation, rank_data, to_iterable
 from ..tools.string import format_like_list
 

--- a/tenpy/linalg/spaces.py
+++ b/tenpy/linalg/spaces.py
@@ -114,6 +114,11 @@ class Space(metaclass=ABCMeta):
     def dual(self):
         ...
 
+    @property
+    @abstractmethod
+    def is_trivial(self):
+        ...
+
     @abstractmethod
     def __eq__(self, other):
         ...

--- a/tenpy/linalg/spaces.py
+++ b/tenpy/linalg/spaces.py
@@ -836,6 +836,8 @@ class ProductSpace(Space):
             else:
                 _metadata = backend.get_leg_metadata(self)
         self.metadata = _metadata
+        self._basis_perm = None
+        self._inverse_basis_perm = None
 
     def test_sanity(self):
         assert isinstance(self.metadata, dict)

--- a/tenpy/linalg/sparse.py
+++ b/tenpy/linalg/sparse.py
@@ -542,7 +542,7 @@ class NumpyArrayLinearOperator(ScipyLinearOperator):
             )
             res = tens.split_legs(0)
         else:
-            tens = ChargedTensor.from_flat_block_single_sector(
+            tens = ChargedTensor.from_dense_block_single_sector(
                 leg=self.domain, block=self.backend.block_from_numpy(vec), sector=self._charge_sector,
                 backend=self.backend
             )
@@ -563,7 +563,7 @@ class NumpyArrayLinearOperator(ScipyLinearOperator):
             res = res.to_dense_block_trivial_sector()
         else:
             res = tens.combine_legs(list(range(tens.num_legs)), product_spaces=[self.domain])
-            res = res.to_flat_block_single_sector()
+            res = res.to_dense_block_single_sector()
         res = self.backend.block_to_numpy(res)
         assert res.shape == (self.shape[0],)
         return res

--- a/tenpy/linalg/sparse.py
+++ b/tenpy/linalg/sparse.py
@@ -681,5 +681,5 @@ def gram_schmidt(vecs: list[Tensor], rcond=1.e-14) -> list[Tensor]:
             vec = vec - ov * other
         n = vec.norm()
         if n > rcond:
-            res.append(vec._mul_scalar(1. / n))
+            res.append(vec.multiply_scalar(1. / n))
     return res

--- a/tenpy/linalg/sparse.py
+++ b/tenpy/linalg/sparse.py
@@ -17,7 +17,7 @@ from typing import Literal
 import numpy as np
 from scipy.sparse.linalg import LinearOperator as ScipyLinearOperator, ArpackNoConvergence
 
-from .spaces import VectorSpace, ProductSpace, Sector
+from .spaces import Space, ElementarySpace, ProductSpace, Sector
 from .tensors import Tensor, Shape, BlockDiagonalTensor, ChargedTensor, tdot, eye_like, zero_like
 from .backends.abstract_backend import Backend
 from .dtypes import Dtype
@@ -327,7 +327,7 @@ class NumpyArrayLinearOperator(ScipyLinearOperator):
         Function with signature ``tenpy_matvec(vec: Tensor) -> Tensor`.
         Has to return a tensor with the same legs and has to be linear.
         Unless `labels` are given, the leg order of the output must be the same as for the input.
-    legs : list of :class:`~tenpy.linalg.spaces.VectorSpace`
+    legs : list of :class:`~tenpy.linalg.spaces.ElementarySpace`
         The legs of a Tensor that `tenpy_matvec` can act on.
     backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
         The backend for self
@@ -344,7 +344,7 @@ class NumpyArrayLinearOperator(ScipyLinearOperator):
     ----------
     tenpy_matvec : callable
         Function with signature ``tenpy_matvec(vec: Tensor) -> Tensor`.
-    legs : list of :class:`~tenpy.linalg.spaces.VectorSpace`
+    legs : list of :class:`~tenpy.linalg.spaces.Space`
         The legs of a Tensor that `tenpy_matvec` can act on.
     backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
         The backend for self
@@ -368,7 +368,7 @@ class NumpyArrayLinearOperator(ScipyLinearOperator):
     shape : (int, int)
         The shape of self as an operator on 1D numpy arrays
     """
-    def __init__(self, tenpy_matvec, legs: list[VectorSpace], backend: Backend, dtype,
+    def __init__(self, tenpy_matvec, legs: list[Space], backend: Backend, dtype,
                  labels: list[str] = None,
                  charge_sector: None | Sector | Literal['trivial'] = 'trivial'):
         self.tenpy_matvec = tenpy_matvec

--- a/tenpy/linalg/symmetries.py
+++ b/tenpy/linalg/symmetries.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from abc import abstractmethod, ABCMeta
 from enum import Enum
-from functools import reduce
+from functools import reduce, total_ordering
 from itertools import product
 
 from numpy import typing as npt
@@ -52,6 +52,7 @@ A 2D array of int with axis [s, q] and shape ``(num_sectors, sector_ind_len)``.
 _DO_FUSION_INPUT_CHECKS = True
 
 
+@total_ordering
 class FusionStyle(Enum):
     """Describes properties of fusion, i.e. of the tensor product.
 
@@ -70,7 +71,13 @@ class FusionStyle(Enum):
     multiple_unique = 10  # every sector appears at most once in pairwise fusion, N^{ab}_c \in {0,1}
     general = 20  # no assumptions N^{ab}_c = 0, 1, 2, ...
 
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
 
+
+@total_ordering
 class BraidingStyle(Enum):
     """Describes properties of braiding.
 
@@ -91,6 +98,11 @@ class BraidingStyle(Enum):
     fermionic = 10  # symmetric braiding with non-trivial twist; v ⊗ w ↦ (-1)^p(v,w) w ⊗ v
     anyonic = 20  # non-symmetric braiding
     no_braiding = 30  # braiding is not defined
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
 
 
 class Symmetry(metaclass=ABCMeta):

--- a/tenpy/linalg/tensors.py
+++ b/tenpy/linalg/tensors.py
@@ -1282,7 +1282,7 @@ class DiagonalTensor(SymmetricTensor):
         return self
 
     def diagonal_as_block(self, dtype: Dtype = None) -> Block:
-        res = self.backend.diagonal_to_block(self)
+        res = self.backend.diagonal_tensor_to_block(self)
         if dtype is not None:
             res = self.backend.block_to_dtype(res, dtype)
         return res
@@ -1511,7 +1511,7 @@ class Mask(Tensor):
         return self.small_leg.dim > 0
 
     def as_block_mask(self) -> Block:
-        return self.backend.diagonal_to_block(self)
+        return self.backend.diagonal_tensor_to_block(self)
 
     def as_numpy_mask(self) -> np.ndarray:
         return self.backend.block_to_numpy(self.as_block_mask(), numpy_dtype=bool)

--- a/tenpy/linalg/tensors.py
+++ b/tenpy/linalg/tensors.py
@@ -25,6 +25,36 @@ density matrices as "vectorization".
 Similarly, we can view any tensor, i.e. elements of tensor product spaces as linear maps.
 TODO elaborate.
 
+
+.. _conj_and_transpose
+
+Conjugation and Transposition
+-----------------------------
+
+TODO should this be here or in the docstrings of the respective functions?
+
+TODO elaborate on the differences between dagger and conj etc.
+
+Note that only dagger is independent of partition of the legs into (co)domain.
+
+    ==============  ====================  ====================  ============================
+    tensor          domain                codomain              legs
+    ==============  ====================  ====================  ============================
+    A               [V1, V2]              [W1, W2]              [W1, W2, V2.dual, V1.dual]
+    --------------  --------------------  --------------------  ----------------------------
+    dagger(A)       [W1, W2]              [V1, V2]              [V1, V2, W2.dual, W1.dual]
+    --------------  --------------------  --------------------  ----------------------------
+    transpose(A)    [W2.dual, W1.dual]    [V2.dual, V1.dual]    [V2.dual, V1.dual, W1, W2]
+    --------------  --------------------  --------------------  ----------------------------
+    conj(A)         [V2.dual, V1.dual]    [W2.dual, W1.dual]    [W2.dual, W1.dual, V1, V2]
+    ==============  ====================  ====================  ============================
+
+Consider now a matrix ``A`` with signature ``[V] -> [W]``, i.e. with legs ``[W, V.dual]``.
+The dagger ``dagger(A)`` has legs signature ``[W] -> [V]`` and legs ``[V, W.dual]``, i.e.
+it can be directly contracted with ``A``.
+
+
+
 """
 # Copyright (C) TeNPy Developers, GNU GPLv3
 
@@ -32,7 +62,7 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 import operator
 from types import EllipsisType
-from typing import TypeVar, Sequence, NoReturn
+from typing import TypeVar, Sequence
 from numbers import Number, Integral
 import numpy as np
 import warnings
@@ -40,211 +70,375 @@ import functools
 import logging
 logger = logging.getLogger(__name__)
 
-from .dummy_config import printoptions
-from .misc import duplicate_entries, join_as_many_as_possible
-from .dummy_config import config
-from .symmetries import AbelianGroup, Symmetry, SymmetryError
-from .spaces import Space, ElementarySpace, ProductSpace, Sector, SectorArray
+from .misc import duplicate_entries
+from .symmetries import SymmetryError
+from .spaces import Space, ElementarySpace, ProductSpace, Sector
 from .backends.backend_factory import get_backend
 from .backends.abstract_backend import Block, Backend
 from .dtypes import Dtype
-from ..tools.misc import to_iterable, to_iterable_of_len
-from ..tools.docs import amend_parent_docstring
-
-__all__ = ['Shape', 'Tensor', 'SymmetricTensor', 'BlockDiagonalTensor', 'ChargedTensor',
-           'DiagonalTensor', 'Mask', 'add_trivial_leg', 'almost_equal', 'combine_legs', 'conj',
-           'detect_sectors_from_block', 'entropy', 'flip_leg_duality', 'hconj', 'inner',
-           'is_scalar', 'norm', 'outer', 'permute_legs', 'split_legs', 'squeeze_legs', 'tdot',
-           'trace', 'zero_like', 'eye_like', 'angle', 'real', 'imag', 'real_if_close', 'sqrt',
-           'get_same_backend', 'tensor_from_block']
-
-# svd, qr, eigen, exp, log, ... are implemented in matrix_operations.py
+from ..tools.misc import to_iterable
 
 
-# TODO where to put this? where to doc it?
-BOTH = object()  # sentinel value for the default behavior of DiagonalTensor.apply_mask
-KEEP_OLD_LABEL = object()  # sentinel value, e.g. for apply_mask
-
-
-class Shape:
-    """An object storing the legs and labels of a tensor.
-    When iterated or indexed, it behaves like a sequence of integers, the dimension of the legs.
-    Can be indexed by integer (leg position) or string (leg label).
-    """
-
-    def __init__(self, legs: list[Space], num_domain_legs: int, labels: list[str | None] = None):
-        self.legs = legs
-        if labels is None:
-            labels = [None] * len(legs)
-        else:
-            labels = labels[:]
-        self._labels = labels
-        self._labelmap = {label: leg_num for leg_num, label in enumerate(self.labels) if label is not None}
-        self.num_legs = len(legs)
-        self.dims = [l.dim for l in legs]
-        self.num_domain_legs = num_domain_legs
-
-    def test_sanity(self):
-        assert not duplicate_entries(self._labels, ignore=[None])
-        assert 0 <= self.num_domain_legs <= self.num_legs
-
-    def __iter__(self):
-        return iter(self.dims)
-
-    def __len__(self):
-        return self.num_legs
-
-    def __getitem__(self, key):
-        if isinstance(key, str):
-            try:
-                key = self.label_to_legnum(key)
-            except ValueError:
-                raise IndexError(f'No leg with label {key}.') from None
-        return self.dims[key]
-
-    def __eq__(self, other):
-        if isinstance(other, Shape):
-            return self.legs == other.legs and self._labels == other._labels
-        return False
-
-    def set_labels(self, labels: list[str | None]):
-        assert not duplicate_entries(labels, ignore=[None])
-        assert len(labels) == self.num_legs
-        self._labels = labels[:]
-        self._labelmap = {label: leg_num for leg_num, label in enumerate(self.labels) if label is not None}
-
-    @property
-    def labels(self) -> list[str | None]:
-        return self._labels[:]
-
-    @labels.setter
-    def labels(self, value):
-        self.set_labels(value)
-
-    @property
-    def is_fully_labelled(self) -> bool:
-        return None not in self._labels
-
-    def label_to_legnum(self, label: str) -> int:
-        num = self._labelmap.get(label, None)
-        if num is None:
-            raise ValueError(f'No leg with label {label}. Labels are {self.labels}')
-        return num
-
-    def relabel(self, mapping: dict[str, str]) -> None:
-        """Apply mapping to labels. In-place."""
-        self.set_labels([mapping.get(l, l) for l in self._labels])
-
-    def __str__(self):
-        entries = [str(dim) if label is None else f'{label}:{dim:d}'
-                   for label, dim in zip(self._labels, self.dims)]
-        return '(' + ', '.join(entries[:self.num_domain_legs]) + ' ; ' \
-            + ', '.join(entries[self.num_domain_legs:]) + ')'
-
-    def __repr__(self) -> str:
-        dims = ', '.join((f"{lbl}:{d:d}" if lbl is not None else str(d))
-                         for lbl, d in zip(self._labels, self.dims))
-        return f'Shape({dims}, num_domain_legs={self.num_domain_legs})'
-
-
-# ##################################
-# tensor classes
-# ##################################
+__all__ = ['Tensor', 'SymmetricTensor', 'DiagonalTensor', 'ChargedTensor', 'Mask',
+           'add_trivial_leg', 'almost_equal', 'angle', 'apply_mask', 'bend_legs', 'combine_legs',
+           'conj', 'dagger', 'dot', 'entropy', 'imag', 'inner', 'is_scalar', 'item', 'move_leg',
+           'norm', 'outer', 'permute_legs', 'real', 'real_if_close', 'set_as_slice', 'split_legs',
+           'sqrt', 'squeeze_legs', 'tdot', 'trace', 'transpose', 'zero_like', 'get_same_backend',
+           'check_same_legs']
 
 
 class Tensor(metaclass=ABCMeta):
-    """Common abstract base class for tensors.
+    """Common base class for tensors.
 
-    .. note ::
-        TODO write clean text about ElementarySpace.basis_perm and how it affects internal storage.
+    TODO elaborate
+
+    The legs of the tensor (spaces of the domain or codomain) can be referred to either via
+    string labels (see :ref:`tensor_leg_labels` and the :attr:`labels` attribute) or via integer
+    positional indices. Both allow you to be ignorant of the distinction between domain and codomain
+    (see :ref:`tensors_as_maps`). For the integer indices, we refer to the position of a given legs
+    in the :attr:`Tensor.legs`. E.g. if ``codomain == [V, W, Z]`` and ``domain == [X, Y]``,
+    we have ``legs == [V, W, Z, Y.dual, X.dual]`` and indices ``1`` and ``-4`` both refer to the
+    ``W`` leg in the codomain, while indices ``3`` and ``-2`` both refer to the ``X`` leg in the
+    domain.
+
+    Attributes
+    ----------
+    codomain, domain : ProductSpace
+        The domain and codomain of the tensor. See also :attr:`legs` and :ref:`tensors_as_maps`.
+    backend : Backend
+        The backend of the tensor.
+    symmetry : Symmetry
+        The symmetry of the tensor.
+    num_legs : int
+        The total number of legs in the domain and codomain.
+    dtype : Dtype
+        The dtype of tensor entries. Note that a real dtype does not necessarily imply that
+        the result of :meth:`to_dense_block` is real.
+    shape: tuple of int
+        The dimension of each of the :attr:`legs`.
 
     Parameters
     ----------
-    legs : list[Space]
-        The legs of the Tensor
-    backend: :class:`~tenpy.linalg.backends.abstract_backend.Backend`, optional
-        The backend for the Tensor
-    labels : list[str | None] | None
-        Labels for the legs. If None, translates to ``[None, None, ...]`` of appropriate length
+    codomain : ProductSpace | list[Space]
+        The codomain.
+    domain : ProductSpace | list[Space] | None
+        The domain. ``None`` is equivalent to ``[]``, i.e. no legs in the domain.
+    backend : Backend
+        The backend of the tensor.
+    labels: list[list[str | None]] | list[str | None] | None
+        Specify the labels for the legs.
+        Can either give two lists, one for the codomain, one for the domain.
+        Or a single flat list for all legs in the order of the :attr:`legs`,
+        such that ``[codomain_labels, domain_labels]`` is equivalent
+        to ``[*codomain_legs, *reversed(domain_legs)]``.
+    dtype : Dtype
+        The dtype of tensor entries.
     """
-    def __init__(self, legs: list[Space], backend: Backend, labels: list[str | None] | None,
-                 dtype: Dtype, num_domain_legs: int):
-        if backend is None:
-            self.backend = backend = get_backend(legs[0].symmetry)
-        else:
-            self.backend = backend
-        self.legs = legs = legs[:]  # FIXME rm ok?
-        self.shape = Shape(legs=legs, num_domain_legs=num_domain_legs, labels=labels)
-        self.num_legs = len(legs)
-        self.symmetry = legs[0].symmetry
+    _forbidden_dtypes = [Dtype.bool]
+    
+    def __init__(self,
+                 codomain: ProductSpace | list[Space],
+                 domain: ProductSpace | list[Space] | None,
+                 backend: Backend | None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None,
+                 dtype: Dtype):
+        codomain, domain, backend, symmetry = self._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        #
+        self.codomain = codomain
+        self.domain = domain
+        self.backend = backend
+        self.symmetry = symmetry
+        codomain_num_legs = codomain.num_spaces
+        domain_num_legs = domain.num_spaces
+        self.num_legs = codomain_num_legs + domain_num_legs
         self.dtype = dtype
+        self.shape = tuple(sp.dim for sp in codomain.spaces) + tuple(sp.dim for sp in reversed(domain.spaces))
+        self._labels = labels = self._init_parse_labels(labels, codomain=codomain, domain=domain)
+        self._labelmap = {label: legnum
+                          for legnum, label in enumerate(labels)
+                          if label is not None}
 
-    def test_sanity(self) -> None:
-        assert self.backend.supports_symmetry(self.symmetry)
-        assert all(l.symmetry == self.symmetry for l in self.legs)
-        assert len(self.legs) == self.shape.num_legs == self.num_legs > 0
-        for leg in self.legs:
-            self.backend.test_leg_sanity(leg)
-        self.shape.test_sanity()
+    @staticmethod
+    def _init_parse_args(codomain: ProductSpace | list[Space],
+                         domain: ProductSpace | list[Space] | None,
+                         backend: Backend | None):
+        """Common input parsing for ``__init__`` methods of tensor classes.
 
-    # ----------------------------------
-    # Concrete Implementations
-    # ----------------------------------
+        Also checks if they are compatible.
+
+        Returns
+        -------
+        codomain, domain: ProductSpace
+            The codomain and domain, converted to ProductSpace if needed.
+        backend: Backend
+            The given backend, or the default backend compatible with `symmetry`.
+        symmetry: Symmetry
+            The symmetry of the domain and codomain
+        """
+        # Extract the symmetry from codomain or domain. Note that either may be empty, but not both.
+        if isinstance(codomain, ProductSpace):
+            symmetry = codomain.symmetry
+        elif len(codomain) > 0:
+            symmetry = codomain[0].symmetry
+        elif isinstance(domain, ProductSpace):
+            symmetry = domain.symmetry
+        elif len(domain) > 0:
+            symmetry = domain[0].symmetry
+        else:
+            raise ValueError('domain and codomain can not both be empty')
+
+        # Make sure backend is compatible with symmetry
+        if backend is None:
+            backend = get_backend(symmetry=symmetry)
+        else:
+            assert backend.supports_symmetry(symmetry)
+
+        # Bring (co-)domain to ProductSpace form
+        if not isinstance(codomain, ProductSpace):
+            codomain = ProductSpace(codomain, symmetry=symmetry, backend=backend)
+        assert codomain.symmetry == symmetry
+        if domain is None:
+            domain = []
+        if not isinstance(domain, ProductSpace):
+            domain = ProductSpace(domain, symmetry=symmetry, backend=backend)
+        assert domain.symmetry == symmetry
+        return codomain, domain, backend, symmetry
+
+    @staticmethod
+    def _init_parse_labels(labels: Sequence[list[str | None] | None] | list[str | None] | None,
+                           codomain: ProductSpace, domain: ProductSpace,
+                           is_endomorphism: bool = False):
+        """Parse the various allowed input formats for labels to the format of :attr:`labels`.
+
+        Also supports a special case for input formats of endomorphisms (maps where domain
+        and codomain coincide), where a flat list of labels for the codomain can be given,
+        and the domain labels are auto-filled with the respective dual labels.
+        """
+        # TODO improve errors on illegal formats
+        num_legs = codomain.num_spaces + domain.num_spaces
+        if is_endomorphism:
+            assert codomain.num_spaces == domain.num_spaces
+
+        # case 1: None
+        if labels is None:
+            return [None] * num_legs
+
+        # case 2: two lists, one each for codomain and domain
+        if not (isinstance(labels[0], str) or labels[0] is None):
+            # expect nested lists
+            codomain_labels, domain_labels = labels
+            if codomain_labels is None:
+                if is_endomorphism and domain_labels is not None:
+                    codomain_labels = [_dual_leg_label(l) for l in domain_labels]
+                else:
+                    codomain_labels = [None] * codomain.num_spaces
+            assert len(codomain_labels) == codomain.num_spaces
+            if domain_labels is None:
+                if is_endomorphism:
+                    domain_labels = [_dual_leg_label(l) for l in codomain_labels]
+                else:
+                    domain_labels = [None] * domain.num_spaces
+            assert len(domain_labels) == domain.num_spaces
+            return [*codomain_labels, *reversed(domain_labels)]
+
+        # case 3a: (only if is_endomorphism) a flat list for the codomain
+        if is_endomorphism and len(labels) == codomain.num_spaces:
+            return [*labels, *(_dual_leg_label(l) for l in reversed(labels))]
+
+        # case 3: a flat list for the legs
+        assert len(labels) == num_legs
+        return labels[:]
+
+    def test_sanity(self):
+        assert all(_is_valid_leg_label(l) for l in self._labels)
+        assert not duplicate_entries(self._labels, ignore=[None])
+        assert not duplicate_entries(list(self._labelmap.values()))
+        self.backend.test_leg_sanity(self.domain)
+        self.backend.test_leg_sanity(self.codomain)
+        assert self.dtype not in self._forbidden_dtypes
+
+    @abstractmethod
+    def as_SymmetricTensor(self) -> SymmetricTensor:
+        ...
+
+    @abstractmethod
+    def copy(self, deep=True) -> Tensor:
+        ...
+
+    @abstractmethod
+    def to_dense_block(self, leg_order: list[int | str] = None, dtype: Dtype = None) -> Block:
+        """Convert to a dense block of the backend, if possible.
+
+        This corresponds to "forgetting" the symmetry structure and is only possible if the
+        symmetry :attr:`Symmetry.can_be_dropped`.
+        The result is a backend-specific block, e.g. a numpy array if the backend is a
+        :class:`NumpyBlockBackend` or a torch Tensor if the backend is a :class:`TorchBlockBackend`.
+
+        Parameters
+        ----------
+        leg_order: list of (int | str), optional
+            If given, the leg of the resulting block are permuted to match this leg order.
+        dtype: Dtype, optional
+            If given, the result is converted to this dtype. Per default it has the :attr:`dtype`
+            of the tensor.
+        """
+        ...
 
     @property
+    def codomain_labels(self) -> list[str | None]:
+        """The labels that refer to legs in the codomain."""
+        return self._labels[:self.num_codomain_legs]
+
+    @property
+    def domain_labels(self) -> list[str | None]:
+        """The labels that refer to legs in the domain."""
+        return self._labels[self.num_codomain_legs:][::-1]
+        
+    @property
     def is_fully_labelled(self) -> bool:
-        return self.shape.is_fully_labelled
+        return (None not in self._labels)
 
     @property
     def labels(self) -> list[str | None]:
-        return self.shape.labels
+        """The labels that refer to the :attr:`legs`.
+
+        Thus, ``labels[:K]`` are the ``codomain_labels`` and ``labels[K:][::-1]`` are the
+        ``domain_labels`` where ``K == num_codomain_legs``.
+        """
+        return self._labels[:]
 
     @labels.setter
-    def labels(self, value):
-        self.shape.set_labels(value)
+    def labels(self, labels):
+        assert not duplicate_entries(labels, ignore=[None])
+        assert len(labels) == self.num_legs
+        self._labels = labels[:]
+        self._labelmap = {label: legnum for legnum, label in enumerate(labels) if label is not None}
 
-    @property
-    def num_domain_legs(self) -> int:
-        """How many of the legs are in the domain. See :ref:`tensors_as_maps`."""
-        return self.shape.num_domain_legs
+    @functools.cached_property
+    def legs(self) -> list[Space]:
+        """All legs of the tensor.
+        
+        These the spaces of the codomain, followed by the duals of the domain spaces
+        *in reverse order*.
+        If we permute all legs to the codomain, we would get these spaces, i.e.::
+
+            tensor.legs == tensor.permute_legs(codomain=range(tensor.num_legs)).codomain.spaces
+
+        See :ref:`tensors_as_maps`.
+        """
+        return [*self.codomain.spaces, *(sp.dual for sp in reversed(self.domain.spaces))]
 
     @property
     def num_codomain_legs(self) -> int:
         """How many of the legs are in the codomain. See :ref:`tensors_as_maps`."""
-        return self.num_legs - self.num_domain_legs
+        return self.codomain.num_spaces
+
+    @property
+    def num_domain_legs(self) -> int:
+        """How many of the legs are in the domain. See :ref:`tensors_as_maps`."""
+        return self.domain.num_spaces
 
     @property
     def num_parameters(self) -> int:
-        """The number of free parameters, i.e. the dimension of the space of symmetry-preserving
-        tensors with the same legs"""
+        """The number of free parameters for the given legs.
+
+        This is the dimension of the space of symmetry-preserving tensors with the given legs.
+        """
+        # TODO / OPTIMIZE could also compute this from codomain.sectors and domain.sectors.
+        #           get min(codomain.sector_multiplicity(c), domain.sector_multiplicity(c))
+        #           free parameters from each coupled sector c.
         return self.parent_space.num_parameters
 
     @functools.cached_property
     def parent_space(self) -> ProductSpace:
-        """The space that the tensor lives in"""
-        return ProductSpace(self.legs, backend=self.backend)
+        """The space that the tensor lives in. This is the product of the :attr:`legs`."""
+        return ProductSpace.from_partial_products(self.codomain, self.domain.dual, backend=self.backend)
 
     @property
     def size(self) -> int:
-        """The total number of entries, i.e. the dimension of the space of tensors on the same space
-        if symmetries were ignored"""
+        """The number of entries of a dense block representation of self.
+
+        This is only defined if ``self.symmetry.can_be_dropped``.
+        In that case, it is the number of entries of :func:`to_dense_block`.
+        """
+        if not self.symmetry.can_be_dropped:
+            raise SymmetryError(f'Tensor.size is not defined for symmetry {self.symmetry}')
         return self.parent_space.dim
 
-    def flip_leg_duality(self, which_leg: int | str, *more: int | str) -> Tensor:
-        """See :func:`tensors.flip_leg_duality`"""
-        which_legs = self.get_leg_idcs([which_leg, *more])
-        flipped_legs = []
-        perms = []
-        for i in which_legs:
-            flipped, perm = self.legs[i].flip_is_dual(return_perm=True)
-            flipped_legs.append(flipped)
-            perms.append(perm)
-        res = self.copy(deep=False)
-        res.data = self.backend.flip_leg_duality(self, which_legs=which_legs,
-                                                 flipped_legs=flipped_legs, perms=perms)
-        for i, leg in zip(which_legs, flipped_legs):
-            res.legs[i] = leg
-        return res
+    def __eq__(self, other):
+        msg = f'{self.__class__.__name__} does not support == comparison. Use tenpy.almost_equal instead.'
+        raise TypeError(msg)
+
+    def _parse_leg_idx(self, idx: int | str) -> tuple[bool, int, int]:
+        """Parse a leg index or a leg label.
+
+        Parameters
+        ----------
+        idx: int | str
+            An index referring to one of the :attr:`legs` *or* a label.
+
+        Returns
+        -------
+        in_domain: bool
+            If the leg is in the domain.
+        co_domain_idx: int
+            The index of the leg in the (co-)domain
+        legs_idx: int
+            The index of the leg in :attr:`legs`. Same as input ``idx``, except
+            it is guaranteed to be in ``range(num_legs)``.
+        """
+        if isinstance(idx, str):
+            idx = self._labelmap.get(idx, None)
+            if idx is None:
+                msg = f'No leg with label {idx}. Labels are {self._labels}'
+                raise ValueError(msg)
+        idx = _normalize_idx(idx, self.num_legs)
+        in_domain = (idx >= len(self.codomain))
+        if in_domain:
+            co_domain_idx = self.num_legs - 1 - idx
+        else:
+            co_domain_idx = idx
+        return in_domain, co_domain_idx, idx
+
+    def get_leg(self, which_leg: int | str | list[int | str]) -> Space | list[Space]:
+        """Basically ``self.legs[which_leg]``, but allows labels and multiple indices.
+
+        TODO elaborate
+        """
+        if not isinstance(which_leg, (Integral, str)):
+            # which_leg is a list
+            return list(map(self.get_leg, which_leg))
+        in_domain, co_domain_idx, _ = self._parse_leg_idx(which_leg)
+        if in_domain:
+            return self.domain.spaces[co_domain_idx].dual
+        return self.codomain.spaces[co_domain_idx]
+
+    def get_leg_idcs(self, idcs: Sequence[int | str]) -> list[int]:
+        """Parse leg-idcs of leg-labels to leg-idcs (i.e. indices of :attr:`legs`)."""
+        return [self._parse_leg_idx(i) for i in idcs]
+
+    def has_label(self, label: str, *more: str) -> bool:
+        return (label in self._labels) and all(l in self._labels for l in more)
+    
+    def labels_are(self, *labels: str) -> bool:
+        """If the given labels and the :attr:`labels` are the same, up to permutation."""
+        if not self.is_fully_labelled:
+            return False
+        if len(labels) != self.num_legs:
+            return False
+        # have checked same length, so comparing the unique labels via set is enough.
+        return set(labels) == set(self._labels)
+
+    def relabel(self, mapping: dict[str, str]) -> None:
+        """Apply mapping to labels. In-place."""
+        self.labels = [mapping.get(l, l) for l in self._labels]
+
+    def to_numpy(self, leg_order: list[int | str] = None, numpy_dtype=None) -> np.ndarray:
+        """Convert to a numpy array"""
+        block = self.to_dense_block(leg_order=leg_order)
+        return self.backend.block_to_numpy(block, numpy_dtype=numpy_dtype)
 
     def with_legs(self, *legs: int | str) -> _TensorIndexHelper:
         """This method allows indexing a tensor "by label".
@@ -258,701 +452,130 @@ class Tensor(metaclass=ABCMeta):
         """
         return _TensorIndexHelper(self, legs)
 
-    def hconj(self, legs1: int | str | list[int | str] = -1,
-              legs2: int | str | list[int | str] = None) -> Tensor:
-        """See :func:`tensors.hconj`"""
-        legs1 = np.array(self.get_leg_idcs(legs1))
-        if legs2 is None:
-            # TODO match by labels instead?
-            legs2 = [n for n in range(self.num_legs) if n not in legs1]
-        else:
-            legs2 = np.array(self.get_leg_idcs(legs2))
-        assert not duplicate_entries(legs1 + legs2)
-        assert len(legs1) == len(legs2) == self.num_legs // 2
-        labels = self.labels
-        permutation = np.zeros((self.num_legs,), dtype=int)
-        for i1, i2 in zip(legs1, legs2):
-            assert self.legs[i1] == self.legs[i2].dual
-            assert labels[i1] == _dual_leg_label(labels[i2])  # accepts None as well
-            permutation[i1] = i2
-            permutation[i2] = i1
-        return self.conj().permute_legs(permutation)
-
-    def has_label(self, label: str, *more: str) -> bool:
-        return label in self.shape._labels and all(l in self.shape._labels for l in more)
-
-    def labels_are(self, *labels: str) -> bool:
-        if not self.is_fully_labelled:
-            return False
-        if len(labels) != len(self.shape._labels):
-            return False
-        return set(labels) == set(self.shape._labels)
-
-    def relabel(self, mapping: dict[str, str | None], inplace=True) -> Tensor:
-        """Re-label by applying a mapping to the labels."""
-        if not inplace:
-            return self.copy(deep=False).relabel(mapping, inplace=True)
-        self.shape.relabel(mapping)
-        return self
-
-    def set_labels(self, labels: list[str | None]) -> None:
-        self.shape.set_labels(labels)
-
-    def get_leg_idx(self, which_leg: int | str) -> int:
-        if isinstance(which_leg, str):
-            which_leg = self.shape.label_to_legnum(which_leg)
-        if isinstance(which_leg, Integral):
-            if which_leg < 0:
-                which_leg = which_leg + self.num_legs
-            if not 0 <= which_leg < self.num_legs:
-                raise ValueError(f'Leg index out of bounds: {which_leg}.') from None
-            return which_leg
-        else:
-            raise TypeError(f'Expected int or str. Got {type(which_leg)}')
-
-    def get_leg_idcs(self, which_legs: int | str | list[int | str]) -> list[int]:
-        if isinstance(which_legs, (Integral, str)):
-            return [self.get_leg_idx(which_legs)]
-        else:
-            return list(map(self.get_leg_idx, which_legs))
-
-    def get_leg(self, which_leg: int | str) -> Space:
-        """Get a single leg of the tensor
-
-        Parameters
-        ----------
-        which_leg : int | str
-            Either the position (``int``) or label (``str``) of the desired leg.
-
-        See Also
-        --------
-        get_legs
-        """
-        return self.legs[self.get_leg_idx(which_leg)]
-
-    def get_legs(self, which_legs: int | str | list[int | str]) -> list[Space]:
-        """Get a number of legs of the tensor
-
-        Parameters
-        ----------
-        which_legs : int | str | list of int | list of str
-            For every desired leg, either the position (``int``) or label (``str``).
-
-        See Also
-        --------
-        get_leg
-        """
-        return [self.legs[idx] for idx in self.get_leg_idcs(which_legs)]
-
-    def to_numpy(self, leg_order: list[int | str] = None, numpy_dtype=None) -> np.ndarray:
-        """Convert to a numpy array"""
-        block = self.to_dense_block(leg_order=leg_order)
-        return self.backend.block_to_numpy(block, numpy_dtype=numpy_dtype)
-
-    # ----------------------------------
-    # Private and Dunder methods
-    # ----------------------------------
-
-    def _repr_leg_components(self, max_len: int) -> list[str]:
-        """A summary of the components of legs, used in repr"""
-        components_strs = []
-        for leg, label in zip(self.legs, self.labels):
-            if isinstance(leg, ProductSpace):
-                sublabels = [f'?{n}' if l is None else l
-                             for n, l in enumerate(_split_leg_label(label, num=len(leg.spaces)))]
-                prefix = 'ProductSpace: '
-                components = prefix + join_as_many_as_possible(
-                    [f'({l}: {s.dim})' for l, s in zip(sublabels, leg.spaces)],
-                    separator=' ⊗ ',
-                    priorities=[s.dim for s in leg.spaces],
-                    max_len=max_len - len(prefix)
-                )
-            else:
-                components = join_as_many_as_possible(
-                    [f'({mult} * {leg.symmetry.sector_str(sect)})'
-                     for mult, sect in zip(leg.multiplicities, leg.sectors)],
-                    separator=' ⊕ ',
-                    priorities=leg.multiplicities,
-                    max_len=max_len
-                )
-            components_strs.append(components)
-        return components_strs
-
-    def _repr_header_lines(self, indent: str) -> list[str]:
-        # vertical table for the legs
-        labels = ['label'] + [str(l) for l in self.labels]
-        dims = ['    dim'] + [str(leg.dim) for leg in self.legs]
-        sector_nums = ['is_dual'] + [{True: 'yes', False: ' no'}[leg.is_dual] for leg in self.legs]
-        col_widths = [max(len(l), len(d), len(n)) for l, d, n in zip(labels, dims, sector_nums)]
-
-        # put '|' between legs and '||' between domain and codomain
-        n = self.num_domain_legs + 1  # +1 since there is a first header column
-        labels_row = ' | '.join(x.rjust(w) for x, w in zip(labels[:n], col_widths[:n]))
-        labels_row += ' || ' + ' | '.join(x.rjust(w) for x, w in zip(labels[n:], col_widths[n:]))
-        dims_row = ' | '.join(x.rjust(w) for x, w in zip(dims[:n], col_widths[:n]))
-        dims_row += ' || ' + ' | '.join(x.rjust(w) for x, w in zip(dims[n:], col_widths[n:]))
-        sectors_nums_row = ' | '.join(x.rjust(w) for x, w in zip(sector_nums[:n], col_widths[:n]))
-        sectors_nums_row += ' || ' + ' | '.join(x.rjust(w) for x, w in zip(sector_nums[n:], col_widths[n:]))
-        if self.num_domain_legs == self.num_legs:
-            labels_row += ' ||'
-            dims_row += ' ||'
-            sectors_nums_row += ' ||'
-        
-        lines = [
-            f'{indent}* Backend: {self.backend}',
-            f'{indent}* Symmetry: {self.symmetry}',
-            f'{indent}* Legs: {labels_row}',
-            f'{indent}        {dims_row}',
-            f'{indent}        {sectors_nums_row}',
-        ]
-        return lines
-
-    def _getitem_apply_masks(self, masks: list[Mask], legs: list[int]) -> Tensor:
-        """Helper function for __getitem__ to index self with masks.
-        Subclasses may override this implementation."""
-        res = self
-        for mask, leg in zip(masks, legs):
-            res = res.apply_mask(mask, leg)
-        return res
-
-    def _input_checks_inner(self, other: Tensor, do_conj: bool, legs1: list[int | str] | None,
-                            legs2: list[int | str] | None) -> list[int] | None:
-        """Check if inputs to inner are valid.
-
-        Returns
-        -------
-        leg_order_2 : (list of int) or None
-            The order of legs on other, such that they match the legs of self.
-            None is returned instead of the trivial order ``[0, 1, 2, ...]``.
-        """
-        if self.num_legs != other.num_legs:
-            raise ValueError('Tensors need to have the same number of legs')
-        # determine leg_order_2
-        if legs1 is None and legs2 is None:
-            leg_order_2 = _match_leg_order(self, other)
-        else:
-            if legs1 is None:
-                legs1 = np.arange(self.num_legs, dtype=int)
-            else:
-                legs1 = np.array(self.get_leg_idcs(legs1), dtype=int)
-            if legs2 is None:
-                legs2 = np.arange(self.num_legs, dtype=int)
-            else:
-                legs2 = np.array(other.get_leg_idcs(legs2), dtype=int)
-            if np.all(legs1 == legs2):
-                leg_order_2 = None
-            else:
-                leg_order_2 = np.argsort(legs1)[legs2]
-        if leg_order_2 is None:
-            other_legs_ordered = other.legs
-        else:
-            other_legs_ordered = (other.legs[leg_order_2[n]] for n in range(self.num_legs))
-        if do_conj:
-            are_compatible = all(l1 == l2 for l1, l2 in zip(self.legs, other_legs_ordered))
-        else:
-            are_compatible = all(l1.can_contract_with(l2) for l1, l2 in zip(self.legs, other_legs_ordered))
-        if not are_compatible:
-            raise ValueError('Incompatible legs')
-        return leg_order_2
-
-    def _input_checks_same_legs(self, other: Tensor) -> list[int] | None:
-        """Common input checks for functions that expect two tensors with the same set of legs.
-
-        Returns
-        -------
-        other_order : (list of int) or None
-            The order of legs on other, such that they match the legs of self.
-            None is equivalent to ``list(range(other.num_legs)`` and indicates that no permutation is needed.
-        """
-        other_order = _match_leg_order(self, other)
-        for n in range(self.num_legs):
-            leg_self = self.legs[n]
-            leg_other = other.legs[n] if other_order is None else other.legs[other_order[n]]
-            if leg_self != leg_other:
-                self_label = self.shape._labels[n]
-                self_label = '' if self_label is None else self_label + ': '
-                other_label = other.shape._labels[n]
-                other_label = '' if other_label is None else other_label + ': '
-                msg = '\n'.join([
-                    'Incompatible legs:',
-                    self_label + str(leg_self),
-                    other_label + str(leg_other)
-                ])
-                raise ValueError(msg)
-        return other_order
-
-    def _input_checks_tdot(self, other: Tensor, legs1: int | str | list[int | str], legs2: int | str | list[int | str]
-                           ) -> tuple[list[int], list[int]]:
-        _legs1 = to_iterable(legs1)
-        _legs2 = to_iterable(legs2)
-        legs1 = list(map(self.get_leg_idx, _legs1))
-        legs2 = list(map(other.get_leg_idx, _legs2))
-        if duplicate_entries(legs1) or duplicate_entries(legs2):
-            raise ValueError('legs may not contain duplicates')
-        if len(legs1) != len(legs2):
-            raise ValueError('Mismatching number of legs')
-        incompatible = []
-        for _l1, _l2, l1, l2 in zip(_legs1, _legs2, legs1, legs2):
-            if not self.legs[l1].can_contract_with(other.legs[l2]):
-                incompatible.append((_l1, _l2))
-        if incompatible:
-            msg = f'{len(incompatible)} incompatible leg pairs: {", ".join(map(str, incompatible))}'
-            raise ValueError(msg)
-        return legs1, legs2
-
-    def __repr__(self):
-        indent = printoptions.indent * ' '
-        lines = [f'{self.__class__.__name__}(']
-        lines.extend(self._repr_header_lines(indent=indent))
-        if not printoptions.skip_data:
-            lines.extend(self._data_repr_lines(indent=indent, max_lines=printoptions.maxlines_tensors - len(lines) - 1))
-        lines.append(')')
-        return "\n".join(lines)
-
-    def _data_repr_lines(self, indent: str, max_lines: int) -> list[str]:
-        return self.backend._data_repr_lines(
-            self, indent=indent, max_width=printoptions.linewidth, max_lines=max_lines
-        )
-
-    def _parse_integer_indices(self, idcs):
-        if not all(isinstance(idx, int) for idx in idcs[1:]):
-            msg = 'Invalid index type. If tensors are indexed by integer, all legs need to be indexed by an integer.'
-            raise IndexError(msg)
-        for leg_num, idx in enumerate(idcs):
-            leg = self.legs[leg_num]
-            if not -leg.dim <= idx < leg.dim:
-                msg = f'Index {idx} is out of bounds for leg {leg_num} with label {self.labels[leg_num]} ' \
-                        f'and dimension {leg.dim}'
-                raise IndexError(msg)
-            if idx < 0:
-                idx = idx + leg.dim
-            if leg._inverse_basis_perm is not None:
-                idx = leg._inverse_basis_perm[idx]
-            idcs[leg_num] = idx
-        return idcs
-        
-    def __getitem__(self, idcs):
-        """
-        TODO eventually we should document this at some high-level place, e.g. in one of the rst files
-        Collecting snippets here for now
-
-        We support two modes of indexing tensors for __getitem__:
-        - Getting single entries, i.e. giving one integer per leg
-        - Getting a "masked" Tensor, i.e. giving a Mask for some or all legs.
-          Legs not to be masked can be indicated via ``slice(None, None, None)``, i.e. typing ``:``,
-          or ``Ellipsis``, i.e. typing ``...``.
-
-        For ``DiagonalTensor`` and ``Mask`` we additionally support indexing by a single integer `i`.
-        For ``DiagonalTensor``, this returns the diagonal element, i.e. ``diag[i] == diag[i, i]``.
-        For ``Mask``, this is the boolean entry that indicates if the ``i-th`` index is preserved
-        or projected out by the mask, i.e. ``mask[i] == mask[i, j_i]`` where loosely ``j_i = sum(mask[:i])``.
-        """
-        idcs = _parse_idcs(idcs, length=self.num_legs)
-        if isinstance(idcs[0], int):
-            idcs = self._parse_integer_indices(idcs)
-            return self._get_element(idcs)
-        else:
-            mask_legs = []
-            masks = []
-            for leg_num, idx in enumerate(idcs):
-                if isinstance(idx, Mask):
-                    masks.append(idx)
-                    mask_legs.append(leg_num)
-                elif isinstance(idx, slice):
-                    if idx != slice(None, None, None):
-                        raise IndexError('Non-trivial slices are not supported.')
-                else:
-                    raise IndexError(f'Invalid index type: {type(idx)}')
-            return self._getitem_apply_masks(masks=masks, legs=mask_legs)
-
-    def __setitem__(self, idcs, value):
-        idcs = _parse_idcs(idcs, length=self.num_legs)
-        if not isinstance(idcs[0], int):
-            raise IndexError('Can only set single entries')
-        idcs = self._parse_integer_indices(idcs)
-        value = self.dtype.convert_python_scalar(value)
-        self._set_element(idcs, value)
-
-    def __neg__(self):
-        return self._mul_scalar(-1)
-
-    def __pos__(self):
-        return self
-
-    def __eq__(self, other):
-        msg = f'{type(self)} does not support == comparison. Use tenpy.almost_equal instead.'
-        raise TypeError(msg)
-
-    def __add__(self, other):
-        if isinstance(other, Tensor):
-            return self._add_tensor(other)
-        return NotImplemented
-
-    def __sub__(self, other):
-        if isinstance(other, Tensor):
-            return self.__add__(other._mul_scalar(-1))
-        return NotImplemented
-
-    def __mul__(self, other):
-        if isinstance(other, Number):
-            return self._mul_scalar(other)
-        raise TypeError(f'Tensors can only be multiplied with scalars, not {type(other)}.') from None
-
-    def __rmul__(self, other):
-        # all allowed multiplication is commutative
-        return self.__mul__(other)
-
-    def __truediv__(self, other):
-        if not isinstance(other, Number):
-            raise TypeError(f'Tensors can only be divided by scalars, not {type(other)}.') from None
-        try:
-            other_inv = 1. / other
-        except Exception:
-            raise ValueError(f'Tensors can only be divided by invertible scalars.') from None
-        return self._mul_scalar(1. / other)
-
-    def __float__(self):
-        if not self.dtype.is_real:
-            warnings.warn("converting complex to real, only return real part!", stacklevel=2)
-        return self.item().real
-
-    def __complex__(self):
-        return complex(self.item())
-
-    # ----------------------------------
-    # Abstract methods
-    # ----------------------------------
-
-    @classmethod
-    @abstractmethod
-    def zero(cls, legs: Space | list[Space], backend=None, labels: list[str | None] = None,
-             dtype: Dtype = Dtype.float64) -> Tensor:
-        """A zero tensor"""
-        ...
-
-    @abstractmethod
-    def add_trivial_leg(self, label: str = None, is_dual: bool = False, pos: int = -1,
-                        to_domain: bool = None) -> Tensor:
-        """See tensors.add_trivial_leg"""
-        ...
-
-    @abstractmethod
-    def apply_mask(self, mask: Mask, leg: int | str) -> Tensor:
-        """Apply a mask to one of the legs, projecting to a smaller leg.
-
-        If the masked leg is a :class:`ProductSpace`, the product structure is dropped while masking
-        and the masked leg will be only a :class:`ElementarySpace`, not a :class:`ProductSpace`.
-        See notes below.
-
-        Parameters
-        ==========
-        mask : Mask
-            The mask to be applied
-        leg : int | str
-            Which leg to apply to
-
-        Notes
-        =====
-        It would be possible to implement Mask-application in a way that keeps the product structure.
-        TODO (JU) is this even true for non-abelian?
-        That would, however, make `split_legs` more complicated, thus we keep it simple.
-        If you really want to project and split afterwards, use the following work-around,
-        which is for example used in :class:`~tenpy.algorithms.exact_diagonalization`:
-
-        1) Save the unprojected ProductSpace separately.
-        2) Apply the mask, yielding a tensor with a non-ProductSpace leg
-        3) [... do calculations ...]
-        4) To split the 'projected ProductSpace' of `A`, create an zero Tensor `B` with the legs of A,
-           but replace the projected leg by the full ProductSpace. Set `A` as a slice of `B`.
-           Finally split the ProductSpace leg.
-        """
-        ...
-
-    @abstractmethod
-    def as_Tensor(self) -> BlockDiagonalTensor:
-        """Convert to Tensor."""
-        ...
-
-    @abstractmethod
-    def combine_legs(self,
-                     *legs: list[int | str],
-                     product_spaces: list[ProductSpace] = None,
-                     product_spaces_dual: list[bool] = None,
-                     new_axes: list[int] = None,
-                     new_labels: list[str | None] = None) -> Tensor:
-        """See :func:`tenpy.linalg.tensors.combine_legs`."""
-        ...
-
-    @abstractmethod
-    def conj(self) -> Tensor:
-        """See :func:`tensors.conj`"""
-        ...
-
-    @abstractmethod
-    def copy(self, deep=True) -> Tensor:
-        ...
-
-    @abstractmethod
-    def item(self) -> bool | float | complex:
-        """If the tensor is a scalar (i.e. has only one entry), return that scalar as a float or complex.
-        Otherwise raise a ValueError"""
-        ...
-
-    @abstractmethod
-    def norm(self, order=None) -> float:
-        """See tensors.norm"""
-        ...
-
-    @abstractmethod
-    def permute_legs(self, permutation: list[int] = None, num_domain_legs: int = None) -> Tensor:
-        """See tensors.permute_legs"""
-        ...
-
-    @abstractmethod
-    def split_legs(self, legs: list[int | str] = None) -> Tensor:
-        """See tensors.split_legs"""
-        ...
-
-    @abstractmethod
-    def squeeze_legs(self, legs: int | str | list[int | str] = None) -> Tensor:
-        """See tensors.squeeze_legs"""
-        ...
-
-    @abstractmethod
-    def to_dense_block(self, leg_order: list[int | str] = None) -> Block:
-        """Convert tensor to a dense (i.e. no longer exploiting the symmetry structure) block,
-        i.e. a numpy ndarray if the backend is a NumpyBlockBackend, or a torch Tensor of
-        the backend is a TorchBlockBackend"""
-        ...
-
-    @abstractmethod
-    def trace(self, legs1: int | str | list[int | str] = -2, legs2: int | str | list[int | str] = -1
-              ) -> Tensor | float | complex:
-        """See tensors.trace"""
-        ...
-
-    @abstractmethod
-    def _get_element(self, idcs: list[int]) -> bool | float | complex:
-        """Helper function for __getitem__ to index self with integers
-
-        Parameters
-        ----------
-        idcs
-            Indices which are partially pre-processed, i.e. there is one integer index per leg
-            and it is in the correct range, i.e. `0 <= idx < leg.dim`.
-            Indices are w.r.t. to the internal basis order, i.e. `basis_perm` is already accounted
-            for, but `sector_perm` is not.
-        """
-        ...
-
-    @abstractmethod
-    def _mul_scalar(self, other: complex) -> Tensor:
-        ...
-
-    @abstractmethod
-    def _set_element(self, idcs: list[int], value: bool | float | complex) -> None:
-        """Helper function for __setitem__ after arguments were parsed.
-        Can assume that idcs has correct length and entries are valid & non-negative (0 <= idx < dim).
-        Indices are w.r.t. to the internal basis order, i.e. `basis_perm` is already accounted
-        for, but `sector_perm` is not.
-        Modifies self in-place with a modified copy of the underlying data.
-        """
-        ...
-
-    # ----------------------------------
-    # Abstract binary tensor methods
-    # ----------------------------------
-    #  -> concrete implementations need to distinguish type of `other`
-
-    @abstractmethod
-    def almost_equal(self, other: Tensor, atol: float = 1e-5, rtol: float = 1e-8,
-                     allow_different_types: bool = False) -> bool:
-        """See tensors.almost_equal"""
-        ...
-
-    @abstractmethod
-    def inner(self, other: Tensor, do_conj: bool = True,
-              legs1: list[int | str] = None, legs2: list[int | str]  = None) -> float | complex:
-        """See tensors.inner"""
-        ...
-
-    @abstractmethod
-    def outer(self, other: Tensor, relabel1: dict[str, str] = None,
-              relabel2: dict[str, str] = None) -> Tensor:
-        """See tensors.outer"""
-        ...
-
-    @abstractmethod
-    def tdot(self, other: Tensor, legs1: int | str | list[int | str] = -1,
-             legs2: int | str | list[int | str] = 0, relabel1: dict[str, str] = None,
-             relabel2: dict[str, str] = None) -> Tensor | float | complex:
-        """See tensors.tdot"""
-        ...
-
-    @abstractmethod
-    def _add_tensor(self, other: Tensor) -> Tensor:
-        ...
-
 
 class SymmetricTensor(Tensor):
-    """Common base class for tensors which are symmetric (i.e. not charged)"""
-    pass
+    """A tensor that is symmetric, i.e. invariant under the symmetry.
 
+    .. note ::
+        The constructor is not particularly user friendly.
+        Consider using the various classmethods instead.
 
-class BlockDiagonalTensor(SymmetricTensor):
-    """
+    TODO elaborate
+
+    Parameters
+    ----------
+    codomain : ProductSpace | list[Space]
+        The codomain.
+    domain : ProductSpace | list[Space] | None
+        The domain. ``None`` (the default) is equivalent to ``[]``, i.e. no legs in the domain.
+    backend : Backend
+        The backend of the tensor.
+    labels: list[list[str | None]] | list[str | None] | None
+        Specify the labels for the legs.
+        Can either give two lists, one for the codomain, one for the domain.
+        Or a single flat list for all legs in the order of the :attr:`legs`,
+        such that ``[codomain_labels, domain_labels]`` is equivalent
+        to ``[*codomain_legs, *reversed(domain_legs)]``.
+    dtype : Dtype
+        The dtype of tensor entries.
 
     Attributes
     ----------
-    data
-        backend-specific data structure that contains the numerical data, i.e. the free parameters
+    data:
+        Backend-specific data structure that contains the numerical data, i.e. the free parameters
         of tensors with the given symmetry.
-        data about the symmetry is contained in the legs.
-    backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-    legs : list of :class:`~tenpy.linalg.spaces.Space`
-    labels : list of {``None``, str}
     """
-
-    def __init__(self, data, legs: list[Space], num_domain_legs: int, backend=None,
-                 labels: list[str | None] | None = None):
-        """
-        This constructor is not user-friendly.
-        Use as_tensor instead.
-        Inputs are not checked for consistency.
-
-        Parameters
-        ----------
-        data
-            The numerical data ("free parameters") comprising the tensor. type is backend-specific
-        legs : list[Space]
-            The legs of the Tensor
-        num_domain_legs : int
-            How many of the legs are in the domain. See :ref:`tensors_as_maps`.
-        backend: :class:`~tenpy.linalg.backends.abstract_backend.Backend`, optional
-            The backend for the Tensor
-        labels : list[str | None] | None
-            Labels for the legs. If None, translates to ``[None, None, ...]`` of appropriate length
-        """
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        dtype = backend.get_dtype_from_data(data)
-        Tensor.__init__(self, backend=backend, legs=legs, labels=labels, dtype=dtype,
-                        num_domain_legs=num_domain_legs)
-        self.data = data
+    def __init__(self,
+                 data,
+                 codomain: ProductSpace | list[Space],
+                 domain: ProductSpace | list[Space] | None = None,
+                 backend: Backend | None = None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
+        codomain, domain, backend, _ = self._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        Tensor.__init__(self, codomain=codomain, domain=domain, backend=backend, labels=labels,
+                        dtype=backend.get_dtype_from_data(data))
         assert isinstance(data, self.backend.DataCls)
+        self.data = data
 
-    def test_sanity(self) -> None:
+    def test_sanity(self):
         super().test_sanity()
-        self.backend.test_data_sanity(self, is_diagonal=False)
-        assert self.dtype != Dtype.bool
-
-    # --------------------------------------------
-    # Additional methods (not in Tensor)
-    # --------------------------------------------
+        self.backend.test_data_sanity(self, is_diagonal=isinstance(self, DiagonalTensor))
 
     @classmethod
-    def eye(cls, legs: Space | list[Space], backend=None,
-            labels: list[str | None] = None, dtype: Dtype = Dtype.float64) -> BlockDiagonalTensor:
-        """The identity map on a group of legs, as a tensor with twice as many legs.
+    def from_block_func(cls, func,
+                        codomain: ProductSpace | list[Space],
+                        domain: ProductSpace | list[Space] | None = None,
+                        backend: Backend | None = None,
+                        labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                        func_kwargs: dict = None,
+                        shape_kw: str = None,
+                        dtype: Dtype = None,
+                        ):
+        """Initialize a :class:`SymmetricTensor` by generating its blocks from a function.
 
-        For a single leg, this is the identity matrix.
-        Note the leg order. E.g. for two legs ``p, q`` we have
-        ``eye([p, q]).legs == [p, q, q.dual, p.dual]``, where the duals are in *reverse order*.
+        Here "the blocks of a tensor" are the backend-specific blocks that contain the free
+        parameters of the tensor in the :attr:`data`. The concrete meaning of these blocks depends
+        on the backend.
 
         Parameters
         ----------
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend for the Tensor
-        legs : (list of) Space
-            *Half* of the legs of the result.
-            The result has legs ``[*legs, *(l.dual for l in reversed(legs))]``,
-            the given `legs` followed by their respective duals in reverse order.
-        labels : list[str | None], optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-            Can either give one label for each of the `legs`, and the second half will be the
-            respective dual labels, or give twice as many and specify them all.
-        dtype : Dtype, optional
-            The data type of the Tensor entries.
-        """
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        legs = to_iterable(legs)
-        half_leg_num = len(legs)
-        # legs = [backend.add_leg_metadata(leg) for leg in legs]  # FIXME
-        data = backend.eye_data(legs=legs, dtype=dtype)
-        legs = legs + [leg.dual for leg in reversed(legs)]
-        if labels is None:
-            labels = [None] * (2 * half_leg_num)
-        if len(labels) == half_leg_num:
-            labels = labels + [_dual_leg_label(l) for l in reversed(labels)]
-        if len(labels) != 2 * half_leg_num:
-            msg = f'Wrong number of labels. Expected {half_leg_num} or {2 * half_leg_num}. Got {len(labels)}.'
-            raise ValueError(msg)
-        return cls(data=data, backend=backend, legs=legs, num_domain_legs=half_leg_num, labels=labels)
+        func: callable
+            A function with two possible signatures. If `shape_kw` is given, we expect::
 
-    @classmethod
-    def from_block_func(cls, func, legs: list[Space], backend=None,
-                        labels: list[str | None] = None, func_kwargs={},
-                        shape_kw: str = None, dtype: Dtype = None, num_domain_legs: int = 0
-                        ) -> BlockDiagonalTensor:
-        """Create a Tensor from a block function.
+                ``func(*, shape_kw: tuple[int, ...], **kwargs) -> BlockLike``
 
-        This function creates a tensor by filling the blocks, i.e. the free parameters of the tensors
-        using `func`, which is a function returning backend-specific blocks.
+            Otherwise::
 
-        Parameters
-        ----------
-        func : callable
-            A callable object which is called to generate the blocks.
-            We expect that `func` returns a backend-specific block of the given `shape`.
-            If no `shape_kw` is given, it is called as ``func(shape, **func_kwargs)``,
-            otherwise as ``func(**{shape_kw: shape}, **func_kwargs)``,
-            where `shape` is a tuple of int.
-        legs : list of Space
-            The legs of the result.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend for the tensor
-        labels : list[str | None], optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-        func_kwargs : dict
-            Additional keyword arguments given to `func`.
-        shape_kw : None | str
-            If given, the keyword with which shape is given to `func`.
-        dtype : None | Dtype
-            If given, the results of `func` are converted to this dtype
-        num_domain_legs : int
-            How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
+                ``func(shape: tuple[int, ...], **kwargs) -> BlockLike``
+
+            Where ``shape`` is the shape of the block to be generate and `func_kwargs` are passed
+            as ``kwargs``. The output is converted to backend-specific blocks
+            via ``backend.as_block``.
+        codomain, domain, backend, labels
+            Arguments for constructor of :class:`SymmetricTensor`.
+        func_kwargs: dict, optional
+            Additional keyword arguments to be passed to ``func``.
+        shape_kw: str
+            If given, the shape is passed to `func` as a kwarg with this keyword.
+        dtype: Dtype, None
+            If given, the resulting blocks from `func` are converted to this dtype.
 
         See Also
         --------
-        from_numpy_func
+        from_sector_block_func
+            Allows the `func` to take the current coupled sectors as an argument.
         """
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        # legs = [backend.add_leg_metadata(leg) for leg in legs]  # FIXME
-
-        if shape_kw is not None:
-            def block_func(shape):
-                block = func(**{shape_kw: shape}, **func_kwargs)
-                if dtype is not None:
-                    block = backend.block_to_dtype(block, dtype)
-                return block
-        else:
-            def block_func(shape):
+        codomain, domain, backend, symmetry = cls._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        # wrap func to consider func_kwargs, shape_kw, dtype
+        if func_kwargs is None:
+            func_kwargs = {}
+        
+        def block_func(shape, coupled):
+            # use same backend function as from_sector_block_func, so we include the coupled arg
+            # but just ignore it.
+            if shape_kw is None:
                 block = func(shape, **func_kwargs)
-                if dtype is not None:
-                    block = backend.block_to_dtype(block, dtype)
-                return block
+            else:
+                block = func(**{shape_kw: shape}, **func_kwargs)
+            return backend.as_block(block, dtype)
 
-        data = backend.from_block_func(block_func, legs, num_domain_legs)
-        res = cls(data=data, backend=backend, legs=legs, num_domain_legs=num_domain_legs, labels=labels)
-        res.test_sanity()  # this catches e.g. errors where the block_func returns blocks of wrong shape
+        data = backend.from_sector_block_func(block_func, codomain=codomain, domain=domain)
+        res = cls(data, codomain=codomain, domain=domain, backend=backend, labels=labels)
+        res.test_sanity()  # OPTIMIZE remove?
         return res
 
     @classmethod
-    def from_dense_block(cls, block, legs: list[Space], backend=None, dtype: Dtype=None,
-                         labels: list[str | None] = None, tol: float = 1e-8,
-                         num_domain_legs: int = 0) -> BlockDiagonalTensor:
+    def from_dense_block(cls, block,
+                         codomain: ProductSpace | list[Space],
+                         domain: ProductSpace | list[Space] | None = None,
+                         backend: Backend | None = None,
+                         labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                         dtype: Dtype = None,
+                         tol: float = 1e-6):
         """Convert a dense block of the backend to a Tensor.
 
         Parameters
@@ -961,1565 +584,525 @@ class BlockDiagonalTensor(SymmetricTensor):
             The data to be converted to a Tensor as a backend-specific block or some data that
             can be converted using :meth:`BlockBackend.as_block`.
             This includes e.g. nested python iterables or numpy arrays.
+            The order of axes should match the :attr:`Tensor.legs`, i.e. first the codomain legs,
+            then the domain leg *in reverse order*.
             The block should be given in the "public" basis order of the `legs`, e.g.
             according to :attr:`ElementarySpace.sectors_of_basis`.
-        legs : list of :class:`~tenpy.linalg.spaces.Space`, optional
-            The vectorspaces associated with legs of the tensors. This specifies the symmetry.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`, optional
-            The backend for the Tensor
-        dtype : ``np.dtype``, optional
-            The data type of the Tensor entries. Defaults to dtype of `block`
-        labels : list of {str | None}, optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-        tol : float or None
-            By default, we check if the block is symmetric according to
-            ``norm(block - symmetric_components) < tol * norm(block)``.
-            This can be disabled by setting ``tol=None``, such that we always just return the
-            symmetric components of ``block``.
-        num_domain_legs : int
-            How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
+        codomain, domain, backend, labels
+            Arguments, like for constructor of :class:`SymmetricTensor`.
+        dtype: Dtype, optional
+            If given, the block is converted to that dtype and the resulting tensor will have that
+            dtype. By default, we detect the dtype from the block.
         """
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        block = backend.as_block(block)
-        if dtype is not None:
-            block = backend.block_to_dtype(block, dtype)
-        data = backend.from_dense_block(block, legs=legs, tol=tol, num_domain_legs=num_domain_legs)
-        return cls(data=data, backend=backend, legs=legs, num_domain_legs=num_domain_legs, labels=labels)
+        codomain, domain, backend, symmetry = cls._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        block, dtype = backend.as_block(block, dtype, return_dtype=True)
+        data = backend.from_dense_block(block, codomain=codomain, domain=domain, tol=tol)
+        return cls(data, codomain=codomain, domain=domain, backend=backend, labels=labels)
 
     @classmethod
-    def from_flat_block_trivial_sector(cls, leg: Space, block: Block, backend: Backend,
-                                       label: str = None) -> BlockDiagonalTensor:
-        """Create a single-leg `Tensor` from the *part of* the coefficients in the trivial sector.
+    def from_eye(cls, co_domain: list[Space] | ProductSpace,
+                 backend: Backend | None = None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                 dtype: Dtype = Dtype.complex128
+                 ) -> SymmetricTensor:
+        """The identity map as a SymmetricTensor.
 
         Parameters
         ----------
-        leg : :class:`~tenpy.linalg.spaces.Space`
-            The single leg of the resulting tensor
-        block : backend-specific Block
-            The block of shape ``(M,)`` where ``M`` is the multiplicity of the trivial sector in `leg`.
-            This is a slice of ``result.to_dense_block()``.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend of the resulting tensor
-        label : str | None
-            The label for the single leg
-
-        See Also
-        --------
-        to_flat_block_trivial_sector
+        co_domain
+            The domain *and* codomain of the resulting tensor.
+        labels
+            Can either specify the labels for all legs of the resulting tensor, like
+            in the constructor of :class:`SymmetricTensor`.
+            Alternatively, can give labels only for the codomain (one list), and the domain labels
+            are constructed as their dual labels i.e. ``'p' <-> 'p*'``.
+        backend: Backend, optional
+            The backend of the tensor.
+        dtype: Dtype
+            The dtype of the tensor.
         """
-        return cls(data=backend.from_flat_block_trivial_sector(block, leg=leg), backend=backend,
-                   legs=[leg], num_domain_legs=0, labels=[label])
+        co_domain, _, backend, _ = cls._init_parse_args(
+            codomain=co_domain, domain=co_domain, backend=backend
+        )
+        labels = cls._init_parse_labels(labels, codomain=co_domain, domain=co_domain,
+                                        is_endomorphism=True)
+        data = backend.eye_data(co_domain=co_domain, dtype=dtype)
+        return cls(data, codomain=co_domain, domain=co_domain, backend=backend, labels=labels)
 
     @classmethod
-    def from_numpy_func(cls, func, legs: list[Space], backend=None,
-                        labels: list[str | None] = None, func_kwargs={},
-                        shape_kw: str = None, dtype: Dtype = None, num_domain_legs: int = 0
-                        ) -> BlockDiagonalTensor:
-        """Create a Tensor from a numpy function.
+    def from_random_normal(cls, codomain: ProductSpace | list[Space],
+                           domain: ProductSpace | list[Space] | None = None,
+                           mean: SymmetricTensor | None = None,
+                           sigma: float = 1.,
+                           backend: Backend | None = None,
+                           labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                           dtype: Dtype = Dtype.complex128):
+        r"""Generate a sample from the complex normal distribution.
 
-        This function creates a tensor by filling the blocks, i.e. the free parameters of the tensors
-        using `func`, which is a function returning numpy arrays, e.g. ``np.ones`` or
-        ``np.random.standard_normal``
+        The probability density is
+
+        .. math ::
+            p(T) \propto \mathrm{exp}\left[
+                \frac{1}{2 \sigma^2} \mathrm{Tr} (T - \mathtt{mean}) (T - \mathtt{mean})^\dagger
+            \right]
+
+        TODO make sure we actually generate from that distribution in the non-abelian or anyonic case!
 
         Parameters
         ----------
-        func : callable
-            A callable object which is called to generate the blocks.
-            We expect that `func` returns a numpy ndarray of the given `shape`.
-            If no `shape_kw` is given, it is called as ``func(shape, **func_kwargs)``,
-            otherwise as ``func(**{shape_kw: shape}, **func_kwargs)``,
-            where `shape` is a tuple of int.
-        legs : list of Space
-            The legs of the result.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend for the tensor
-        labels : list[str | None], optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-        func_kwargs : dict
-            Additional keyword arguments given to `func`.
-        shape_kw : None | str
-            If given, the keyword with which shape is given to `func`.
-        dtype : None | Dtype
-            If given, the results of `func` are converted to this dtype
-        num_domain_legs : int
-            How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
+        codomain, domain, backend, labels
+            Arguments, like for constructor of :class:`SymmetricTensor`.
+            If `mean` is given, all of them are optional and the respective attributes of
+            `mean` are used.
+        dtype: Dtype
+            The dtype.
+        mean: SymmetricTensor, optional
+            The mean of the distribution. ``None`` is equivalent to zero mean.
+        sigma: float
+            The standard deviation of the distribution
+        """
+        assert dtype.is_complex
+        assert sigma > 0.
+        if mean is not None:
+            if codomain is None:
+                codomain = mean.codomain
+            else:
+                assert mean.codomain == codomain
+            if domain is None:
+                domain = mean.domain
+            else:
+                assert mean.domain == domain
+            if backend is None:
+                backend = mean.backend
+            else:
+                assert mean.backend == backend
+            if labels is None:
+                labels = mean.labels
+            else:
+                assert mean.labels == cls._init_parse_labels(labels, codomain=codomain, domain=domain)
+            if dtype is None:
+                dtype = mean.dtype
+            else:
+                assert mean.dtype == dtype
+        else:
+            if codomain is None:
+                raise ValueError('Must specify the codomain if mean is not given.')
+            codomain, domain, backend, _ = cls._init_parse_args(
+                codomain=codomain, domain=domain, backend=backend
+            )
+        with_zero_mean = cls(
+            data=backend.from_random_normal(codomain, domain, sigma=sigma, dtype=dtype),
+            codomain=codomain, domain=domain, backend=backend, labels=labels
+        )
+        if mean is not None:
+            return mean + with_zero_mean
+        return with_zero_mean
+
+    @classmethod
+    def from_random_uniform(cls, codomain: ProductSpace | list[Space],
+                            domain: ProductSpace | list[Space] | None = None,
+                            backend: Backend | None = None,
+                            labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                            dtype: Dtype = Dtype.complex128):
+        """Generate a tensor with uniformly random block-entries.
+
+        The block entries, i.e. the free parameters of the tensor are drawn independently and
+        uniformly. If dtype is a real type, they are drawn from [-1, 1], if it is complex, real and
+        imaginary part are drawn independently from [-1, 1].
+
+        .. note ::
+            This is not a well defined probability distribution on the space of symmetric tensors,
+            since the meaning of the uniformly drawn numbers depends on both the choice of the
+            basis and on the backend.
+
+        Parameters
+        ----------
+        codomain, domain, backend, labels
+            Arguments, like for constructor of :class:`SymmetricTensor`.
+        dtype: Dtype
+            The dtype for the tensor.
+        """
+        codomain, domain, backend, symmetry = cls._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        return cls.from_block_func(
+            func=backend.block_random_uniform,
+            codomain=codomain, domain=domain, backend=backend, labels=labels,
+            func_kwargs=dict(dtype=dtype), dtype=dtype
+        )
+
+    @classmethod
+    def from_sector_block_func(cls, func,
+                               codomain: ProductSpace | list[Space],
+                               domain: ProductSpace | list[Space] | None = None,
+                               backend: Backend | None = None,
+                               labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                               func_kwargs: dict = None,
+                               dtype: Dtype = None,
+                               ):
+        """Initialize a :class:`SymmetricTensor` by generating its blocks from a function.
+
+        Here "the blocks of a tensor" are the backend-specific blocks that contain the free
+        parameters of the tensor in the :attr:`data`. The concrete meaning of these blocks depends
+        on the backend.
+
+        Unlike :meth:`from_block_func`, this classmethod supports a `func` that takes the current
+        coupled sector as an argument. The tensor, as a map from its domain to its codomain is
+        block-diagonal in the coupled sectors, i.e. in the ``domain.sectors``.
+        Thus, the free parameters of a tensor are associated with one of block of this structure,
+        and thus with a given coupled sector. A value of ``coupled`` indicates that the generated
+        block is (part of) the components that maps from ``coupled`` in the domain to ``coupled``
+        in the codomain.
+
+        Parameters
+        ----------
+        func: callable
+            A function with the following signature::
+
+                ``func(shape: tuple[int, ...], coupled: Sector, **kwargs) -> BlockLike``
+
+            Where ``shape`` is the shape of the block to be generated, ``coupled`` is the current
+            coupled sector and `func_kwargs` are passed as ``kwargs``.
+            The output is converted to backend-specific blocks via ``backend.as_block``.
+        codomain, domain, backend, labels
+            Arguments, like for constructor of :class:`SymmetricTensor`.
+        func_kwargs: dict, optional
+            Additional keyword arguments to be passed to ``func``.
+        shape_kw: str
+            If given, the shape is passed to `func` as a kwarg with this keyword.
+        dtype: Dtype, None
+            If given, the resulting blocks from `func` are converted to this dtype.
 
         See Also
         --------
         from_block_func
         """
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        # FIXME have removed add_metadata. that ok?
+        codomain, domain, backend, symmetry = cls._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        # wrap func to consider func_kwargs and dtype
+        if func_kwargs is None:
+            func_kwargs = {}
 
-        if shape_kw is not None:
-            def block_func(shape):
-                arr = func(**{shape_kw: shape}, **func_kwargs)
-                block = backend.block_from_numpy(arr, dtype)
-                return block
-        else:
-            def block_func(shape):
-                arr = func(shape, **func_kwargs)
-                block = backend.block_from_numpy(arr, dtype)
-                return block
+        def block_func(shape, coupled):
+            block = func(shape, coupled, **func_kwargs)
+            return backend.as_block(block, dtype)
 
-        data = backend.from_block_func(block_func, legs, num_domain_legs)
-        return cls(data=data, backend=backend, legs=legs, num_domain_legs=num_domain_legs,
-                   labels=labels)
+        data = backend.from_sector_block_func(block_func, codomain=codomain, domain=domain)
+        res = cls(data, codomain=codomain, domain=domain, backend=backend, labels=labels)
+        res.test_sanity()
+        return res
 
     @classmethod
-    def random_normal(cls, legs: Space | list[Space] = None,
-                      mean: BlockDiagonalTensor | None = None, sigma: float = 1.,
-                      backend=None, labels: list[str | None] = None, dtype: Dtype = None,
-                      num_domain_legs: int = 0) -> BlockDiagonalTensor:
-        r"""Generate a tensor from the normal distribution.
-
-        The probability density is
-
-        .. math ::
-            p(T) \propto \mathrm{exp}\left[ \frac{(T - \mathtt{mean})^2}{2 \mathtt{sigma}^2} \right]
-
-        .. note ::
-            The tensors legs, backend and labels can be specified either via the `mean` or via
-            explicit parameters, but not both.
-            If `mean` is given, the explicit parameters are ignored.
+    def from_zero(cls, codomain: ProductSpace | list[Space],
+                  domain: ProductSpace | list[Space] | None = None,
+                  backend: Backend | None = None,
+                  labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                  dtype: Dtype = Dtype.complex128):
+        """A zero tensor.
 
         Parameters
         ----------
-        legs : (list of) Space
-            If `mean` is given, this argument is ignored and legs are the same as those of `mean`.
-            Otherwise, the legs of the result.
-        mean : Tensor | None
-            The mean of the distribution. By default (`mean=None`) the mean is zero.
-        sigma : float
-            The standard deviation of the distribution
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            If `mean` is given, this argument is ignored and the backend is the same as of `mean`.
-            Otherwise, the backend for the tensor
-        labels : list[str | None], optional
-            If `mean` is given, this argument is ignored and labels are the same as those of `mean`.
-            Otherwise, labels associated with each leg, ``None`` for unnamed legs.
-        dtype : Dtype
-            The dtype for the tensor. If not given, use the dtype of `mean`. If `mean` is not given,
-            default to `Dtype.float64`.
-        num_domain_legs : int
-            How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
-            If `mean` is given, use its :attr:`Tensor.num_domain_legs` attribute instead.
+        codomain, domain, backend, labels:
+            Arguments, like for constructor of :class:`SymmetricTensor`.
+        dtype: Dtype
+            The dtype for the entries.
         """
-        if mean is not None:
-            for name, val in zip(['legs', 'backend', 'labels'], [legs, backend, labels]):
-                if val is not None:
-                    warnings.warn(f'{name} argument to Tensor.random_normal was ignored, because mean was given.')
+        codomain, domain, backend, symmetry = cls._init_parse_args(
+            codomain=codomain, domain=domain, backend=backend
+        )
+        return cls(
+            data=backend.zero_data(codomain=codomain, domain=domain, dtype=dtype),
+            codomain=codomain, domain=domain, backend=backend, labels=labels
+        )
 
-            if dtype is None:
-                dtype = mean.dtype
-            return mean + cls.random_normal(legs=mean.legs, mean=None, sigma=sigma, backend=mean.backend,
-                                            labels=mean.labels, dtype=dtype, num_domain_legs=mean.num_domain_legs)
+    def as_SymmetricTensor(self) -> SymmetricTensor:
+        return self.copy()
 
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        if dtype is None:
-            dtype = Dtype.float64
-        # legs = [backend.add_leg_metadata(leg) for leg in legs]  # FIXME
-        kwargs = dict(dtype=dtype, sigma=sigma)
-        data = backend.from_block_func(backend.block_random_normal, legs, num_domain_legs, kwargs)
-        return cls(data=data, backend=backend, legs=legs, num_domain_legs=num_domain_legs,
-                   labels=labels)
-
-    @classmethod
-    def random_uniform(cls, legs: Space | list[Space], backend=None,
-                       labels: list[str | None] = None, dtype: Dtype = Dtype.float64,
-                       num_domain_legs: int = 0) -> BlockDiagonalTensor:
-        """Generate a tensor whose block-entries (i.e. the free parameters of tensors compatible with
-        the symmetry) are drawn independently and uniformly.
-        If dtype is a real type, they are drawn from [-1, 1], if it is complex, real and imaginary part
-        are drawn independently from [-1, 1].
-
-        .. note ::
-            This is not a well defined probability distribution on the space of symmetric tensors,
-            since it depends on a choice of basis that defines what the individual uniformly drawn
-            numbers mean.
-
-        Parameters
-        ----------
-        legs : (list of) Space
-            The legs of the result.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend for the tensor
-        labels : list[str | None], optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-        dtype : Dtype
-            The dtype for the tensor
-        num_domain_legs : int
-            How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
-        """
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        # legs = [backend.add_leg_metadata(leg) for leg in legs]  # FIXME
-        data = backend.from_block_func(backend.block_random_uniform, legs, num_domain_legs,
-                                       func_kwargs=dict(dtype=dtype))
-        return cls(data=data, backend=backend, legs=legs, num_domain_legs=num_domain_legs, labels=labels)
-
-    def diagonal(self) -> DiagonalTensor:
-        return DiagonalTensor.from_tensor(self, check_offdiagonal=False)
-
-    def idcs_fulfill_charge_rule(self, idcs: list[int]) -> bool:
-        """Whether the given indices fulfill the charge rule.
-
-        This is equivalent to asking if `self.to_dense_block()[idcs]` can *in principle*
-        be non-zero, i.e. if the symmetry allows a non-zero entry at this position.
-
-        Parameters
-        ----------
-        idcs : list of int
-            One index per leg, each in the range ``0 <= idx < leg.dim``.
-        """
-        if not self.symmetry.can_be_dropped:
-            msg = f'Tensors with {self.symmetry} do not allow access to individual tensor entries'
-            raise SymmetryError(msg)
-
-        sectors = [leg.idx_to_sector(idx) for idx, leg in zip(idcs, self.legs)]
-        if len(idcs) == 0:
-            return True
-
-        if len(idcs) == 1:
-            coupled = sectors
-        elif isinstance(self.symmetry, AbelianGroup):
-            coupled = self.symmetry.fusion_outcomes(*sectors[2:])
-            for s in sectors[2:]:
-                # note: AbelianGroup allows us to assume that len(coupled) == 1, and continue with
-                #       the unique fusion channel coupled[0]
-                coupled = self.symmetry.fusion_outcomes(coupled[0], s)
+    def copy(self, deep=True) -> SymmetricTensor:
+        if deep:
+            data = self.backend.copy_data(self)
         else:
-            # will do this when there is a general implementation of fusion trees
-            raise NotImplementedError
+            data = self.data
+        return SymmetricTensor(data=data, codomain=self.codomain, domain=self.domain,
+                               backend=self.backend, labels=self.labels)
 
-        return np.any(np.all(coupled == self.symmetry.trivial_sector[None, :], axis=1))
+    def diagonal(self, check_offdiagonal=False) -> DiagonalTensor:
+        """The diagonal part as a :class:`DiagonalTensor`.
 
-    def to_flat_block_trivial_sector(self) -> Block:
+        Parameters
+        ----------
+        check_offdiagonal: bool
+            If we should check that the off-diagonal parts vanish.
+        """
+        return DiagonalTensor.from_tensor(self, check_offdiagonal=check_offdiagonal)
+
+    def to_dense_block(self, leg_order: list[int | str] = None, dtype: Dtype = None) -> Block:
+        block = self.backend.to_dense_block(self)
+        if dtype is not None:
+            block = self.backend.block_to_dtype(block, dtype)
+        if leg_order is not None:
+            block = self.backend.block_permute_axes(block, self.get_leg_idcs(leg_order))
+        return block
+
+    def to_dense_block_trivial_sector(self) -> Block:
         """Assumes self is a single-leg tensor and returns its components in the trivial sector.
 
+        TODO elaborate.
+        TODO better name?
+
         See Also
         --------
-        from_flat_block_trivial_sector
+        from_dense_block_trivial_sector
         """
         assert self.num_legs == 1
-        return self.backend.to_flat_block_trivial_sector(self)
-
-    # --------------------------------------------
-    # Overriding methods from Tensor
-    # --------------------------------------------
-
-    # --------------------------------------------
-    # Implementing abstractmethods
-    # --------------------------------------------
-    
-    @classmethod
-    def zero(cls, legs: Space | list[Space],
-             backend=None, labels: list[str | None] = None,
-             dtype: Dtype = Dtype.float64, num_domain_legs: int = 0) -> BlockDiagonalTensor:
-        """Empty Tensor with zero entries (not stored explicitly in most backends).
-
-        Parameters
-        ----------
-        legs : (list of) Space
-            The legs of the Tensor.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend for the Tensor.
-        labels : list[str | None], optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-        dtype : Dtype, optional
-            The data type of the Tensor entries.
-        num_domain_legs : int
-            How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
-
-        """
-        # legs = [backend.add_leg_metadata(leg) for leg in legs]    # FIXME
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        data = backend.zero_data(legs=legs, dtype=dtype, num_domain_legs=num_domain_legs)
-        return cls(data=data, backend=backend, legs=legs, num_domain_legs=num_domain_legs, labels=labels)
-
-
-    def add_trivial_leg(self, label: str = None, is_dual: bool = False, pos: int = -1,
-                        to_domain: bool = None) -> BlockDiagonalTensor:
-        res_num_legs = self.num_legs + 1
-        if pos < 0:
-            pos = pos + res_num_legs
-        assert 0 <= pos < res_num_legs
-        if pos < self.num_domain_legs:
-            assert to_domain is not False
-            to_domain = True
-        if pos == self.num_domain_legs and to_domain is None:
-            to_domain = False  # add to codomain by default
-        if pos > self.num_domain_legs:
-            assert to_domain is not True
-            to_domain = False
-        data = self.backend.add_trivial_leg(self, pos=pos, to_domain=to_domain)
-        new_leg = ElementarySpace.from_trivial_sector(1, symmetry=self.symmetry, is_dual=is_dual)
-        legs = self.legs[:pos] + [new_leg] + self.legs[pos:]
-        labels = self.labels[:pos] + [label] + self.labels[pos:]
-        res = BlockDiagonalTensor(
-            data=data, legs=legs, num_domain_legs=self.num_domain_legs + int(to_domain),
-            backend=self.backend, labels=labels
-        )
-        return res
-
-    def apply_mask(self, mask: Mask, leg: int | str, new_label: str = KEEP_OLD_LABEL) -> BlockDiagonalTensor:
-        leg_idx = self.get_leg_idx(leg)
-        assert self.legs[leg_idx].is_equal_or_dual(mask.large_leg)
-        projected_leg = mask.small_leg
-        if self.legs[leg_idx].is_dual != projected_leg.is_dual:
-            projected_leg = projected_leg.dual
-        legs = self.legs[:]
-        legs[leg_idx] = projected_leg
-        labels = self.labels[:]
-        if new_label is not KEEP_OLD_LABEL:
-            labels[leg_idx] = new_label
-        return BlockDiagonalTensor(
-            data=self.backend.apply_mask_to_Tensor(self, mask, leg_idx),
-            legs=legs, num_domain_legs=self.num_domain_legs, backend=self.backend, labels=labels
-        )
-
-    def as_Tensor(self) -> BlockDiagonalTensor:
-        return self
-
-    def combine_legs(self,
-                     *legs: list[int | str],
-                     product_spaces: list[ProductSpace] = None,
-                     product_spaces_dual: list[bool] = None,
-                     new_axes: list[int] = None,
-                     new_labels: list[str | None] = None) -> BlockDiagonalTensor:
-        """See :func:`tenpy.linalg.tensors.combine_legs`."""
-        combine_leg_idcs = [self.get_leg_idcs(ll) for ll in legs]
-        for leg_idcs in combine_leg_idcs:
-            assert len(leg_idcs) > 0, "empty `legs` entry"
-
-        product_spaces = self._combine_legs_make_ProductSpace(combine_leg_idcs, product_spaces, product_spaces_dual)
-        combine_slices, new_axes, transp, perm_args = self._combine_legs_new_axes(combine_leg_idcs, new_axes)
-        product_spaces = [product_spaces[p] for p in perm_args]  # permuted args such that new_axes is ascending
-
-        if transp != tuple(range(len(transp))):
-            res = self.permute_legs(transp)
-        else:
-            res = self.copy(deep=False)
-
-        res_labels = list(res.labels)
-        res_legs = list(res.legs)
-        for n in reversed(range(len(product_spaces))):
-            b, e = combine_slices[n]
-            if new_labels is None:
-                res_labels[b:e] = [_combine_leg_labels(res_labels[b:e])]
-            else:
-                res_labels[b:e] = [new_labels[n]]
-            res_legs[b:e] = [product_spaces[n]]
-        res_data = self.backend.combine_legs(res, combine_slices, product_spaces, new_axes, res_legs)
-        # TODO num_domain_legs is a dummy!
-        return BlockDiagonalTensor(res_data, backend=self.backend, legs=res_legs, 
-                                   num_domain_legs=0, labels=res_labels)
-
-    def conj(self) -> BlockDiagonalTensor:
-        """See tensors.conj"""
-        return BlockDiagonalTensor(
-            self.backend.conj(self),
-            legs=[l.dual for l in self.legs], num_domain_legs=self.num_domain_legs,
-            backend=self.backend, labels=[_dual_leg_label(l) for l in self.shape._labels]
-        )
-
-    def copy(self, deep=True) -> BlockDiagonalTensor:
-        if deep:
-            return BlockDiagonalTensor(data=self.backend.copy_data(self.data),
-                                       backend=self.backend,
-                                       legs=self.legs[:],
-                                       num_domain_legs=self.num_domain_legs,
-                                       labels=self.labels[:])
-        return BlockDiagonalTensor(data=self.data,
-                                   backend=self.backend,
-                                   legs=self.legs,
-                                   num_domain_legs=self.num_domain_legs,
-                                   labels=self.labels)
-
-    def item(self) -> float | complex:
-        if all(leg.dim == 1 for leg in self.legs):
-            return self.backend.item(self)
-        else:
-            raise ValueError('Not a scalar')
-
-    def norm(self, order=None) -> float:
-        """See tensors.norm"""
-        if order is None:
-            order = 2
-        return self.backend.norm(self, order=order)
-
-    def permute_legs(self, permutation: list[int | str] = None, num_domain_legs: int = None
-                     ) -> BlockDiagonalTensor:
-        if permutation is None:
-            legs = self.legs[:]
-            labels = self.shape._labels[:]
-        if permutation is not None:
-            permutation = self.get_leg_idcs(permutation)
-            assert len(permutation) == self.num_legs
-            assert set(permutation) == set(range(self.num_legs))
-            legs = [self.legs[n] for n in permutation]
-            labels = [self.shape._labels[n] for n in permutation]
-        res_data = self.backend.permute_legs(self, permutation, num_domain_legs)
-        if num_domain_legs is None:
-            num_domain_legs = self.num_domain_legs
-        return BlockDiagonalTensor(res_data, legs=legs, num_domain_legs=num_domain_legs,
-                                   backend=self.backend, labels=labels)
-
-    def split_legs(self, *legs: int | str) -> BlockDiagonalTensor:
-        """See tensors.split_legs"""
-        if len(legs) == 0:
-            leg_idcs = [i for i, leg in enumerate(self.legs) if isinstance(leg, ProductSpace)]
-        else:
-            leg_idcs = sorted(self.get_leg_idcs(legs))
-            for i in leg_idcs:
-                if not isinstance(self.legs[i], ProductSpace):
-                    raise ValueError(f'Leg {i} is not a ProductSpace.')
-        old_legs = self.legs
-        old_labels = self.labels
-        new_legs = []
-        new_labels = []
-        start = 0
-        num_domain_legs = self.num_domain_legs
-        for i in leg_idcs:
-            if i < self.num_domain_legs:
-                # -1, since the old productspace was counted already
-                num_domain_legs += len(old_legs[i].spaces) - 1
-            new_legs.extend(old_legs[start:i])
-            new_legs.extend(old_legs[i].spaces)
-            new_labels.extend(old_labels[start:i])
-            new_labels.extend(_split_leg_label(old_labels[i], num=len(old_legs[i].spaces)))
-            start = i + 1
-        new_legs.extend(old_legs[start:])
-        new_labels.extend(old_labels[start:])
-        res_data = self.backend.split_legs(self, leg_idcs, new_legs)
-        return BlockDiagonalTensor(res_data, backend=self.backend, legs=new_legs,
-                                   num_domain_legs=num_domain_legs, labels=new_labels)
-
-    def squeeze_legs(self, legs: int | str | list[int | str] = None) -> BlockDiagonalTensor:
-        """See tensors.squeeze_legs"""
-        if legs is None:
-            leg_idcs = [n for n, l in enumerate(self.legs) if l.is_trivial]
-        else:
-            leg_idcs = self.get_leg_idcs(legs)
-            if not all(self.legs[idx].is_trivial for idx in leg_idcs):
-                raise ValueError('Tried to squeeze non-trivial legs.')
-        res_legs = [l for idx, l in enumerate(self.legs) if idx not in leg_idcs]
-        if len(res_legs) == 0:
-            raise ValueError("squeeze_legs() with no leg left. Use item instead.")
-        res_labels = [label for idx, label in enumerate(self.labels) if idx not in leg_idcs]
-        res_data = self.backend.squeeze_legs(self, leg_idcs)
-        num_domain_legs = self.num_domain_legs - sum(squeezed < self.num_domain_legs for squeezed in leg_idcs)
-        return BlockDiagonalTensor(res_data, backend=self.backend, legs=res_legs,
-                                   num_domain_legs=num_domain_legs, labels=res_labels)
-
-    def to_dense_block(self, leg_order: list[int | str] = None) -> Block:
-        block = self.backend.to_dense_block(self)
-        if leg_order is not None:
-            block = self.backend.block_permute_axes(block, self.get_leg_idcs(leg_order))
-        return block
-
-    def trace(self, legs1: int | str | list[int | str] = -2, legs2: int | str | list[int | str] = -1
-              ) -> BlockDiagonalTensor | float | complex:
-        leg_idcs1 = self.get_leg_idcs(legs1)
-        leg_idcs2 = self.get_leg_idcs(legs2)
-        if len(leg_idcs1) != len(leg_idcs2):
-            raise ValueError('Must specify same number of legs')
-        remaining_leg_idcs = [n for n in range(self.num_legs) if n not in leg_idcs1 and n not in leg_idcs2]
-        if len(remaining_leg_idcs) == 0:
-            return self.backend.trace_full(self, leg_idcs1, leg_idcs2)
-        else:
-            return BlockDiagonalTensor(
-                self.backend.trace_partial(self, leg_idcs1, leg_idcs2, remaining_leg_idcs),
-                legs=[self.legs[n] for n in remaining_leg_idcs],
-                num_domain_legs=sum(n < self.num_domain_legs for n in remaining_leg_idcs),
-                backend=self.backend,
-                labels=[self.labels[n] for n in remaining_leg_idcs]
-            )
-
-    def _get_element(self, idcs: list[int]) -> float | complex:
-        if not self.idcs_fulfill_charge_rule(idcs):
-            return self.dtype.zero_scalar
-        return self.backend.get_element(self, idcs)
-
-    def _mul_scalar(self, other: complex) -> BlockDiagonalTensor:
-        return BlockDiagonalTensor(
-            self.backend.mul(other, self), legs=self.legs, num_domain_legs=self.num_domain_legs,
-            backend=self.backend, labels=self.labels
-        )
-
-    def _set_element(self, idcs: list[int], value: float | complex) -> None:
-        if not self.idcs_fulfill_charge_rule(idcs):
-            msg = f'Can not set element at indices {idcs}. They do not fulfill the charge rule.'
-            raise ValueError(msg)
-        self.data = self.backend.set_element(self, idcs=idcs, value=value)
-
-    # --------------------------------------------
-    # Implementing binary tensor methods
-    # --------------------------------------------
-
-    def almost_equal(self, other: Tensor, atol: float = 1e-5, rtol: float = 1e-8,
-                     allow_different_types: bool = False) -> bool:
-        if not isinstance(other, BlockDiagonalTensor):
-            if not allow_different_types:
-                raise TypeError(f'Different types: {type(self)} and {type(other)}.')
-            if isinstance(other, DiagonalTensor):
-                other = other.as_Tensor()
-            elif isinstance(other, ChargedTensor):
-                try:
-                    other = other.as_Tensor()
-                except ValueError:
-                    other, original_other = other.project_to_invariant(), other
-                    if not other.almost_equal(original_other, atol, rtol):
-                        return False
-                # remains to check self.almost_equal(other, ...), which is done below
-            else:
-                raise TypeError(f'almost_equal not supported for types {type(self)} and {type(other)}.')
-        # can now assume that other is a Tensor
-        other_order = self._input_checks_same_legs(other)
-        if other_order is not None:
-            other = other.permute_legs(other_order)
-        return get_same_backend(self, other).almost_equal(self, other, atol=atol, rtol=rtol)
-
-    def inner(self, other: Tensor, do_conj: bool = True, legs1: list[int | str] = None,
-              legs2: list[int | str]  = None) -> float | complex:
-        leg_order_2 = self._input_checks_inner(other, do_conj=do_conj, legs1=legs1, legs2=legs2)
-        if isinstance(other, BlockDiagonalTensor):
-            return get_same_backend(self, other).inner(self, other, do_conj=do_conj, axs2=leg_order_2)
-        if isinstance(other, ChargedTensor):
-            # self is not charged and thus lives in the trivial sector of the parent space.
-            # thus, only the components of other in the trivial sector contribute to the overlap.
-            other = other._project_to_invariant()
-            if other is None:
-                # other has no part in the trivial sector
-                return Dtype.common(self.dtype, other.dtype).zero_scalar
-            # other is now a Tensor -> redirect to isinstance(other, Tensor) case
-        if isinstance(other, DiagonalTensor):
-            t1 = self.conj() if do_conj else self
-            return t1.tdot(other, legs1=[0, 1], legs2=leg_order_2)
-        if isinstance(other, Mask):
-            # use that leg_order_2 is either [0, 1] or [1, 0]
-            # -> the leg to mask n is the one where leg_order_2[n] == 0, i.e. leg_order_2[0]
-            return self.apply_mask(other, leg=leg_order_2[0]).trace()
-        raise TypeError(f'inner not supported for {type(self)} and {type(other)}')
-
-    def outer(self, other: Tensor, relabel1: dict[str, str] = None,
-              relabel2: dict[str, str] = None) -> Tensor:
-        if isinstance(other, DiagonalTensor):
-            # OPTIMIZE this could be done more efficiently in the backend...
-            other = other.as_Tensor()
-        if isinstance(other, BlockDiagonalTensor):
-            backend = get_same_backend(self, other)
-            return BlockDiagonalTensor(
-                backend.outer(self, other),
-                legs=self.legs + other.legs,
-                num_domain_legs=self.num_domain_legs + other.num_domain_legs,
-                backend=backend,
-                labels=_get_result_labels(self.labels, other.labels, relabel1, relabel2)
-            )
-        if isinstance(other, ChargedTensor):
-            assert relabel2 is None or other.invariant_part.labels[-1] not in relabel2
-            return ChargedTensor(
-                invariant_part=self.outer(other.invariant_part, relabel1=relabel1, relabel2=relabel2),
-                dummy_leg_state=other.dummy_leg_state
-            )
-        raise TypeError(f'outer not supported for {type(self)} and {type(other)}')
-
-    def tdot(self, other: Tensor, legs1: int | str | list[int | str] = -1,
-             legs2: int | str | list[int | str] = 0, relabel1: dict[str, str] = None,
-             relabel2: dict[str, str] = None) -> Tensor | float | complex:
-        if isinstance(other, ChargedTensor):
-            legs2 = other.get_leg_idcs(legs2)  # make sure we reference w.r.t. other, not other.invariant_part
-            assert relabel2 is None or other.invariant_part.labels[-1] not in relabel2
-            invariant_part = self.tdot(other.invariant_part, legs1=legs1, legs2=legs2,
-                                       relabel1=relabel1, relabel2=relabel2)
-            return ChargedTensor(invariant_part=invariant_part, dummy_leg_state=other.dummy_leg_state)
-        leg_idcs1, leg_idcs2 = self._input_checks_tdot(other, legs1, legs2)
-        open_legs1 = [leg for idx, leg in enumerate(self.legs) if idx not in leg_idcs1]
-        open_legs2 = [leg for idx, leg in enumerate(other.legs) if idx not in leg_idcs2]
-        open_labels1 = [leg for idx, leg in enumerate(self.labels) if idx not in leg_idcs1]
-        open_labels2 = [leg for idx, leg in enumerate(other.labels) if idx not in leg_idcs2]
-        # special case: outer()
-        if len(leg_idcs1) == 0:
-            return self.outer(other, relabel1, relabel2)
-        backend = get_same_backend(self, other)
-        if isinstance(other, Mask):
-            if len(leg_idcs1) == 1:
-                new_label = other.labels[1]
-                if relabel2 is not None:
-                    new_label = relabel2.get(new_label, new_label)
-                res = self.apply_mask(other, leg_idcs1[0], new_label=new_label)
-                res = res.permute_legs([n for n in range(self.num_legs) if n != leg_idcs1[0]] + leg_idcs1)
-                if relabel2 is not None:
-                    res.set_labels([relabel2.get(l, l) for l in res.labels[:-1]] + [res.labels[-1]])
-                return res
-            if len(leg_idcs1) == 2:
-                # leg_idcs2 is [0, 1] or [1, 0]. we determine leg_idcs2[large_leg_idx] == 0
-                large_leg_idx = leg_idcs2[0]
-                res = self.apply_mask(other, leg_idcs1[large_leg_idx])
-                res = res.trace(*leg_idcs1)
-                if relabel2 is not None:
-                    res.set_labels([relabel2.get(l, l) for l in res.labels])
-                return res
-            raise RuntimeError  # should have caught all other cases already
-        if isinstance(other, DiagonalTensor):
-            if len(leg_idcs1) == 2:
-                # first contract leg that appears later in self.legs
-                #  -> legs_idcs1[which_second] stays where it is
-                which_first, which_second = (1, 0) if leg_idcs1[0] < leg_idcs1[1] else (0, 1)
-                res = self.tdot(other, leg_idcs1[which_first], leg_idcs2[which_first],
-                                relabel1=relabel1, relabel2=relabel2)
-                return res.trace(leg_idcs1[which_second], -1)
-            assert len(leg_idcs1) == 1 # have already excluded all other possibilities
-            res = BlockDiagonalTensor(
-                data=backend.scale_axis(self, other, leg=leg_idcs1[0]),
-                legs=self.legs[:leg_idcs1[0]] + [other.legs[1 - leg_idcs2[0]]] + self.legs[leg_idcs1[0] + 1:],
-                num_domain_legs=self.num_domain_legs,  # TODO this correct?
-                backend=backend,
-                labels=self.labels[:leg_idcs1[0]] + [other.labels[1 - leg_idcs2[0]]] + self.labels[leg_idcs1[0] + 1:]
-            )
-            # move scaled leg to the back
-            perm = list(range(leg_idcs1[0])) + list(range(leg_idcs1[0] + 1, res.num_legs)) + [leg_idcs1[0]]
-            return res.permute_legs(perm)
-        if isinstance(other, BlockDiagonalTensor):
-            # special case: inner()
-            if len(open_legs1) == 0 and len(open_legs2) == 0:
-                return self.inner(other, do_conj=False, legs1=leg_idcs1, legs2=leg_idcs2)
-            # have already checked special cases outer() and inner(), so backend does not have to do that.
-            # remaining case: actual tensordot with non-trivial contraction and with open indices
-            res_labels = _get_result_labels(open_labels1, open_labels2, relabel1, relabel2)
-            res_data = backend.tdot(self, other, leg_idcs1, leg_idcs2)  # most of the work
-            res_legs = open_legs1 + open_legs2
-            if len(res_legs) == 0:
-                return backend.data_item(res_data)
-            else:
-                num_domain_legs = \
-                    self.num_domain_legs \
-                    + other.num_domain_legs \
-                    - sum(contr < self.num_domain_legs for contr in leg_idcs1) \
-                    - sum(contr < other.num_domain_legs for contr in leg_idcs2)  # TODO this correct?
-                return BlockDiagonalTensor(res_data, backend=backend, legs=res_legs,
-                                           num_domain_legs=num_domain_legs, labels=res_labels)
-        raise TypeError(f'tdot not supported for {type(self)} and {type(other)}')
-
-    def _add_tensor(self, other: Tensor) -> Tensor:
-        if isinstance(other, DiagonalTensor):
-            # OPTIMIZE ?
-            other = other.as_Tensor()
-        if isinstance(other, BlockDiagonalTensor):
-            backend = get_same_backend(self, other)
-            other_order = self._input_checks_same_legs(other)
-            if other_order is not None:
-                other = permute_legs(other, other_order)
-            res_data = backend.add(self, other)
-            return BlockDiagonalTensor(res_data, backend=backend, legs=self.legs,
-                                       num_domain_legs=self.num_domain_legs, labels=self.labels)
-        raise TypeError(f"unsupported operand type(s) for +: 'Tensor' and '{type(other)}'")
-
-    # --------------------------------------------
-    # Internal utility methods
-    # --------------------------------------------
-
-    def make_ProductSpace(self, legs: int | str | list[int | str], _is_dual=None) -> ProductSpace:
-        # FIXME is_dual ???
-        # FIXME is this really needed??
-        return ProductSpace(self.get_legs(legs), backend=self.backend)
-
-    def _combine_legs_make_ProductSpace(self, combine_leg_idcs, product_spaces, product_spaces_dual):
-        """Argument parsing for :meth:`combine_legs`: make missing ProductSpace legs.
-
-        """
-        n_comb = len(combine_leg_idcs)
-        if product_spaces is None:
-            product_spaces = [None] * n_comb
-        elif len(product_spaces) != n_comb:
-            raise ValueError("wrong len of `product_spaces`")
-        else:
-            product_spaces = list(product_spaces)
-        product_spaces_dual = to_iterable_of_len(product_spaces_dual, n_comb)
-        # make pipes as necessary
-        for i, (leg_idcs, product_space) in enumerate(zip(combine_leg_idcs, product_spaces)):
-            if product_space is None:
-                product_spaces[i] = self.make_ProductSpace(leg_idcs, _is_dual=product_spaces_dual[i])
-            else:
-                # add metadata in-place if it is missing. if it already exists, this does nothing.
-                self.backend.add_leg_metadata(product_spaces[i])
-                # test for compatibility
-                legs = [self.legs[a] for a in leg_idcs]
-                if len(legs) != len(product_space.spaces):
-                    raise ValueError("passed ProductSpace has wrong number of legs")
-                # FIXME tmp rmed check
-                # if legs[0].is_dual != product_space.spaces[0].is_dual:
-                #     # TODO: should we just implicitly flip?
-                #     raise ValueError("Wrong `is_dual` flag of ProductSpace")
-                for self_leg, given_space in zip(legs, product_space.factors):
-                    if self_leg != given_space:
-                        msg = f'`product_spaces[{i:d}]` is incompatible with the legs to be combined'
-                        raise ValueError(msg)
-        return product_spaces
-
-    def _combine_legs_new_axes(self, combine_leg_idcs, new_axes):
-        """Figure out new_axes and how legs have to be transposed."""
-        all_combine_leg_idcs = np.concatenate(combine_leg_idcs)
-        non_combined_legs = np.array([a for a in range(self.num_legs) if a not in all_combine_leg_idcs])
-        if new_axes is None:  # figure out default product_spaces
-            first_cl = np.array([cl[0] for cl in combine_leg_idcs])
-            new_axes = [(np.sum(non_combined_legs < a) + np.sum(first_cl < a)) for a in first_cl]
-        else:  # test compatibility
-            if len(new_axes) != len(combine_leg_idcs):
-                raise ValueError("wrong len of `new_axes`")
-            new_axes = list(new_axes)
-            new_rank = len(combine_leg_idcs) + len(non_combined_legs)
-            for i, a in enumerate(new_axes):
-                if a < 0:
-                    new_axes[i] = a + new_rank
-                elif a >= new_rank:
-                    raise ValueError("new_axis larger than the new number of legs")
-        # construct transpose
-        transpose = [[a] for a in non_combined_legs]
-        perm_args = np.argsort(new_axes)
-        cumsum = 0  # TODO @jhauschild this is not used?
-        for s in perm_args:
-            transpose.insert(new_axes[s], list(combine_leg_idcs[s]))
-        new_axes = [new_axes[s] for s in perm_args]
-        transposed_slices = [0] + list(np.cumsum([len(c) for c in transpose]))
-        combine_slices = [(transposed_slices[a], transposed_slices[a+1]) for a in new_axes]
-        transpose = sum(transpose, [])  # flatten: [a] + [b] = [a, b]
-        return combine_slices, new_axes, tuple(transpose), perm_args
-
-
-class ChargedTensor(Tensor):
-    r"""Tensors which transform non-trivially under a symmetry.
-
-    This class represents two related but distinct concepts, which functionally behave
-    the same and thus share an implementation.
-    The first is the concept of a "charged tensor", which only makes sense if the symmetry
-    :attr:`~tenpy.linalg.symmetries.Symmetry.can_be_dropped`.
-    The second concept is that of a "hidden leg", which can be later retrieved.
-
-    The concept of a "charged tensor" arises in the context of group symmetries. A charged tensor,
-    unlike :class:`SymmetricTensor`s, transforms non-trivially under the symmetry group.
-    For concrete examples, consider on-site operators that change the charge sector of a state when
-    applied, such as e.g. a boson creation operator if boson number is conserved or a spin raising
-    operator if magnetization is conserved.
-    We represent such charged tensors as a composite object consisting of an invariant
-    :class:`SymmetricTensor` with a designated dummy leg and a state that this leg is to be
-    contracted with. The interface is designed such that this implementation detail is hidden from
-    the user and the `ChargedTensor` is a valid :class:`Tensor` (which does *not* have the dummy
-    leg in its :attr:`legs`). The contraction with the :attr:`dummy_leg_state` (which is not
-    symmetric and hence not a tensor!) is kept track of only symbolically, i.e.
-    the :attr:`invariant_part` is kept separately until e.g. :meth:`item` is called.
-
-    Contracting two `ChargedTensor`s via :meth:`tdot` can result in a `Tensor` if the dummy legs
-    allow it. This would occur e.g. when forming the boson occupation number :math:`b^\dagger b`,
-    which is a `SymmetricTensor` from `ChargedTensor`s.
-    TODO revise if this should happen automatically, or if an explicit as_Tensor call should be made
-
-    The second concept of a "hidden leg" also uses an invariant :class:`SymmetricTensor` with an
-    additional "dummy" leg, but does not specify a state on that leg.
-    Thus, it is a well-defined concept for all symmetries.
-    In essence, it allows the dummy leg to be hidden from functions/algorithms and be retrieved
-    later. This allows, for example, to evaluate correlation functions of more general operators,
-    such as e.g. simulating :math:`\langle S_i^x(t) S_j^x(0) \rangle` with :math:`S^z` conservation.
-    The :math:`S^x` operator, when using :math:`S^z` conservation, is a `ChargedTensor` with a
-    two-dimensional dummy leg. But, for the correlation function, we do not actually need a state
-    for that leg, we just need to contract it with the dummy leg of the other :math:`S^x`, after
-    having time-evolved :math:`S_j^x(0) \ket{\psi_0}`.
-    TODO revisit this paragraph, do we actually support doing that?
-
-    Parameters
-    ----------
-    invariant_part:
-        The symmetry-invariant part. the dummy leg is the last of its legs.
-    dummy_leg_state: block | None
-        Either ``None`` to signal that the dummy leg is just a hidden leg.
-        Or a backend-specific block of shape ``(dummy_leg.dim,)``, defining a charged tensor
-        which transforms non-trivially under the symmetry (see notes above); only allowed for
-        group symmetries.
-
-    Notes
-    -----
-    We always put the dummy leg as the last leg, and we always put it in the codomain.
-    """
-    _DUMMY_LABEL = '!'  # canonical label for the dummy leg
-
-    def __init__(self, invariant_part: BlockDiagonalTensor, dummy_leg_state: Block | None):
-        assert invariant_part.num_codomain_legs > 0  # dummy leg must be in codomain
-        if dummy_leg_state is None:
-            dtype = invariant_part.dtype
-        else:
-            assert len(dummy_leg_state) == invariant_part.legs[-1].dim
-            if not invariant_part.symmetry.can_be_dropped:
-                msg = f'ChargedTensor with dummy_leg_state is not well-defined for this symmetry.'
-                raise SymmetryError(msg)
-            dtype = Dtype.common(invariant_part.dtype,
-                                 invariant_part.backend.block_dtype(dummy_leg_state))
-        if invariant_part.labels[-1] is None:
-            invariant_part = invariant_part.copy(deep=False)
-            invariant_part.set_labels(invariant_part.labels[:-1] + [self._DUMMY_LABEL])
-        else:
-            assert invariant_part.labels[-1] == self._DUMMY_LABEL
-        Tensor.__init__(self, backend=invariant_part.backend, legs=invariant_part.legs[:-1],
-                        labels=invariant_part.labels[:-1], dtype=dtype,
-                        num_domain_legs=invariant_part.num_domain_legs)
-        self.invariant_part = invariant_part
-        self.dummy_leg = invariant_part.legs[-1]
-        self.dummy_leg_state = dummy_leg_state
-
-    def test_sanity(self):
-        super().test_sanity()
-        self.invariant_part.test_sanity()
-        if self.dummy_leg_state is not None:
-            assert self.backend.block_shape(self.dummy_leg_state) == (self.dummy_leg.dim,)
-        assert self.dtype != Dtype.bool
-
-    # --------------------------------------------
-    # Additional methods (not in Tensor)
-    # --------------------------------------------
-
-    @classmethod
-    def from_block_func(cls, func, legs: Space | list[Space], charge: Space | Sector,
-                        backend=None, labels: list[str | None] = None, func_kwargs={},
-                        shape_kw: str = None, dtype: Dtype = None, num_domain_legs: int = 0,
-                        dummy_leg_state=None
-                        ) -> ChargedTensor:
-        assert 0 <= num_domain_legs <= len(legs)
-        dummy_leg = cls._dummy_leg_from_charge(charge, symmetry=legs[0].symmetry)
-        inv = BlockDiagonalTensor.from_block_func(func=func, legs=legs + [dummy_leg], backend=backend,
-                                     labels=labels + [cls._DUMMY_LABEL], func_kwargs=func_kwargs,
-                                     shape_kw=shape_kw, dtype=dtype, num_domain_legs=num_domain_legs)
-        return ChargedTensor(invariant_part=inv, dummy_leg_state=dummy_leg_state)
-
-    @classmethod
-    def from_dense_block(cls, block, legs: list[Space], backend=None, dtype: Dtype=None,
-                         labels: list[str | None] = None, tol: float = 1e-8,
-                         charge: Space | Sector = None, dummy_leg_state=None,
-                         num_domain_legs: int = 0) -> ChargedTensor:
-        """Convert a dense block of the backend to a ChargedTensor, if possible.
-
-        TODO doc how and when it could fail
-
-        Parameters
-        ----------
-        block :
-            The data to be converted, a backend-specific block or some data that
-            can be converted using :meth:`BlockBackend.as_block`. This includes e.g.
-            nested python iterables or numpy arrays.
-        legs : list of :class:`~tenpy.linalg.spaces.Space`, optional
-            The vectorspaces associated with legs of the tensors. Contains symmetry data.
-            Does not contain the dummy leg.
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`, optional
-            The backend for the ChargedTensor.
-        dtype : Dtype, optional
-            The data type for the ChargedTensor. By default, this is inferred from the block.
-        labels : list of {str | None}, optional
-            Labels associated with each leg, ``None`` for unnamed legs.
-            Does not contain a label for the dummy leg.
-        tol : float
-            Tolerance for checking if a block is symmetric. We check if
-            ``norm(block - symmetric_components) < tol * norm(block)``.
-        charge : Space or Sector, optional
-            The charge, specified either via the dummy leg of the :class:`ChargedTensor` or
-            via the sector that the tensor should live in.
-            As such, a sector is equivalent to `ElementarySpace(symmetry, sectors=[charge]).dual`.
-            Note the `.dual`! The charge-rule for the invariant part then forces the composite
-            ChargedTensor to be in the specified sector.
-            If not given, it is inferred from the largest (by magnitude) entry of the block.
-        dummy_leg_state : block
-            The state on the dummy leg. May be ``None`` ("unspecified").
-        num_domain_legs : int
-            Only meaningful for FusionTree backend.
-        """
-        assert 0 <= num_domain_legs <= len(legs)
-        if backend is None:
-            backend = get_backend(legs[0].symmetry)
-        if labels is None:
-            labels = [None] * len(legs)
-        block = backend.as_block(block)
-        if dtype is not None:
-            block = backend.block_to_dtype(block, dtype)
-        # add 1-dim axis for the dummy leg
-        block = backend.block_add_axis(block, -1)
-        if charge is None:
-            dummy_leg = backend.infer_leg(block, legs + [None])
-        else:
-            dummy_leg = cls._dummy_leg_from_charge(charge, symmetry=legs[0].symmetry)
-        invariant_part = BlockDiagonalTensor.from_dense_block(
-            block, legs=legs + [dummy_leg], backend=backend, dtype=dtype,
-            labels=labels + [cls._DUMMY_LABEL], tol=tol, num_domain_legs=num_domain_legs
-        )
-        return cls(invariant_part, dummy_leg_state=dummy_leg_state)
-
-    @classmethod
-    def from_flat_block_single_sector(cls, leg: Space, block: Block, sector: Sector,
-                                      backend: Backend, label: str = None) -> ChargedTensor:
-        """Create a single-leg `ChargedTensor` from the *part of* the coefficients in the given sector.
-
-        The resulting dummy leg will have the (dual of the) given sector with multiplicity 1 and
-        be in the codomain.
-
-        Parameters
-        ----------
-        leg : :class:`~tenpy.linalg.spaces.Space`
-            The single leg of the resulting tensor.
-        block : backend-specific Block
-            The block of shape ``(D * M,)`` where ``M`` is the multiplicity of the given `sector`
-            in `leg` and ``D`` is its dimension.
-            This is a slice of ``result.to_dense_block()``.
-        sector : Sector
-            The charge of the resulting ChargedTensor, i.e. the sector it lives in
-        backend : :class:`~tenpy.linalg.backends.abstract_backend.Backend`
-            The backend of the resulting tensor
-        label : str | None
-            The label for the single leg
-
-        See Also
-        --------
-        to_flat_block_single_sector
-        """
-        if leg.symmetry.sector_dim(sector) > 1:
-            # TODO how to handle multi-dim sectors? which dummy leg state to give?
-            raise NotImplementedError
-        dummy_leg = cls._dummy_leg_from_charge(sector, symmetry=leg.symmetry)
-        inv_part = BlockDiagonalTensor(
-            data=backend.inv_part_from_flat_block_single_sector(block=block, leg=leg, dummy_leg=dummy_leg),
-            legs=[leg, dummy_leg], num_domain_legs=0, backend=backend, labels=[label, cls._DUMMY_LABEL]
-        )
-        return cls(inv_part, dummy_leg_state=inv_part.backend.as_block([1]))
-
-    @classmethod
-    def from_numpy_func(cls, func, legs: Space | list[Space], charge: Space | Sector,
-                        backend=None, labels: list[str | None] = None, func_kwargs={},
-                        shape_kw: str = None, dtype: Dtype = None, num_domain_legs: int = 0
-                        ) -> ChargedTensor:
-        assert 0 <= num_domain_legs <= len(legs)
-        legs = to_iterable(legs)
-        dummy_leg = cls._dummy_leg_from_charge(charge, symmetry=legs[0].symmetry)
-        inv = BlockDiagonalTensor.from_numpy_func(func=func, legs=legs + [dummy_leg], backend=backend,
-                                     labels=labels + [cls._DUMMY_LABEL], func_kwargs=func_kwargs,
-                                     shape_kw=shape_kw, dtype=dtype, num_domain_legs=num_domain_legs)
-        shape = (dummy_leg.dim,)
-        if shape_kw is not None:
-            arr = func(**{shape_kw: shape}, **func_kwargs)
-        else:
-            arr = func(shape, **func_kwargs)
-        block = inv.backend.block_from_numpy(arr, dtype)
-        # TODO allow to specify dummy_leg_state?
-        return ChargedTensor(invariant_part=inv, dummy_leg_state=block)
-
-    @classmethod
-    def from_tensor(cls, tens: BlockDiagonalTensor) -> ChargedTensor:
-        return ChargedTensor(
-            invariant_part=add_trivial_leg(tens, pos=-1),
-            dummy_leg_state=tens.backend.ones_block((1,), dtype=tens.dtype)
-        )
-
-    @classmethod
-    def from_two_dummy_legs(cls, invariant_part: BlockDiagonalTensor, leg1: int, state1: Block | None, leg2: int,
-                            state2: Block | None, convert_to_tensor_if_possible: bool = False
-                            ) -> ChargedTensor | BlockDiagonalTensor:
-        leg1 = invariant_part.get_leg_idx(leg1)
-        leg2 = invariant_part.get_leg_idx(leg2)
-        first = min(leg1, leg2)
-        second = max(leg1, leg2)
-        other_legs = list(range(first)) \
-                     + list(range(first + 1, second)) \
-                     + list(range(second + 1, invariant_part.num_legs))
-        invariant_part = invariant_part.permute_legs(other_legs + [leg1, leg2])  # TODO make sure they end up in the codomain
-        invariant_part = invariant_part.combine_legs(-2, -1)
-        product_space: ProductSpace = invariant_part.legs[-1]
-        if state1 is not None and state2 is not None:
-            state = product_space.fuse_states([state1, state2], backend=invariant_part.backend)
-        elif state1 is None and state2 is None:
-            state = None
-        elif state1 is None and leg1.dim == 1:  # state1 ~= [1.]
-            state = state2
-        elif state2 is None and leg2.dim == 1:  # state2 ~= [1.]
-            state = state1
-        else:
-            raise ValueError('Can not fuse a specified state with an unspecified state')
-        res = ChargedTensor(invariant_part=invariant_part, dummy_leg_state=state)
-        if convert_to_tensor_if_possible:
-            try:
-                res = res.as_Tensor()
-            except ValueError:
-                pass  # if its not possible to convert to Tensor, just leave it as ChargedTensor
-        return res
-    
-    @classmethod
-    def random_uniform(cls, legs: Space | list[Space], charge: Space | Sector,
-                       backend=None, labels: list[str | None] = None, dtype: Dtype = Dtype.float64,
-                       dummy_leg_state=None, num_domain_legs: int = 0) -> ChargedTensor:
-        legs = to_iterable(legs)
-        dummy_leg = cls._dummy_leg_from_charge(charge, symmetry=legs[0].symmetry)
-        if labels is None:
-            labels = [None] * len(legs)
-        inv = BlockDiagonalTensor.random_uniform(
-            legs=legs + [dummy_leg], backend=backend, labels=labels + [cls._DUMMY_LABEL],
-            dtype=dtype, num_domain_legs=num_domain_legs
-        )
-        if dummy_leg_state is not None:
-            dummy_leg_state = inv.backend.as_block(dummy_leg_state)
-        return ChargedTensor(invariant_part=inv, dummy_leg_state=dummy_leg_state)
-
-    @classmethod
-    def random_normal(cls) -> ChargedTensor:
-        raise NotImplementedError  # TODO
-
-    def flip_dummy_leg_duality(self) -> ChargedTensor:
-        """Like :func:`flip_leg_duality` but for the dummy leg"""
-        # TODO does this conj the dummy_leg_state ?
-        inv = self.invariant_part.flip_leg_duality(-1).relabel({'!*': '!'})
-        return ChargedTensor(invariant_part=inv, dummy_leg_state=self.dummy_leg_state)
-
-    def project_to_invariant(self) -> BlockDiagonalTensor:
-        """Project self into the invariant subspace of the parent space.
-
-        These are the contributions from trivial sectors in the dummy leg.
-
-        See Also
-        --------
-        :meth:`_project_to_invariant`
-        """
-        res = self._project_to_invariant()
-        if res is None:
-            res = BlockDiagonalTensor.zero(legs=self.legs, backend=self.backend, labels=self.labels, dtype=self.dtype)
-        return res
-
-    def _project_to_invariant(self) -> BlockDiagonalTensor | None:
-        """Internal version of :meth:`project_to_invariant`.
-
-        If the dummy leg does not contain the trivial sector of the symmetry,
-        the result is known to vanish exactly and ``None`` is returned.
-        The "public" version :meth:`project_to_invariant` (no underscore!) instead returns a
-        zero `Tensor` in this case.
-        """
-        raise NotImplementedError  # TODO
-
-    def as_Tensor(self) -> BlockDiagonalTensor:
-        """If possible, convert self to a Tensor. Otherwise raise a SymmetryError.
-
-        It is possible to convert a ChargedTensor to a Tensor if and only if the dummy leg only
-        contains the trivial sector.
-
-        See Also
-        --------
-        project_to_invariant
-        """
-        if not np.all(self.dummy_leg.sectors[:] == self.symmetry.trivial_sector[None, :]):
-            raise ValueError('ChargedTensor with non-trivial charge could not be converted to Tensor.')
-        if self.dummy_leg_state is None:
-            msg = 'Can not convert to Tensor. dummy_leg_state is unspecified.'
-            raise SymmetryError(msg)
-        if self.dummy_leg.dim == 1:
-            factor = self.backend.block_item(self.dummy_leg_state)
-            return factor * self.invariant_part.squeeze_legs(-1)
-        state = BlockDiagonalTensor.from_dense_block(self.dummy_leg_state, legs=[self.dummy_leg], backend=self.backend)
-        return self.invariant_part.tdot(state, -1, 0)
-
-    def to_flat_block_single_sector(self) -> Block:
-        """Assumes a single-leg tensor living in a single sector and returns its components within
-        that sector.
-
-        See Also
-        --------
-        from_flat_block_single_sector
-        """
-        if self.dummy_leg_state is None:
-            raise ValueError('Unspecified dummy_leg_state')
-        if self.num_legs > 1:
-            raise ValueError('Expected a single leg')
-        if self.dummy_leg.num_sectors != 1 or self.dummy_leg.multiplicities[0] != 1:
-            raise ValueError('Not a single sector')
-        if self.symmetry.sector_dim(self.dummy_leg.sectors[0]) > 1:
-            # TODO how to handle multi-dim sectors? should cooperate with from_flat_block_single_sector
-            raise NotImplementedError
-        block = self.backend.inv_part_to_flat_block_single_sector(self.invariant_part)
-        return self.backend.block_item(self.dummy_leg_state) * block
-
-    # --------------------------------------------
-    # Overriding methods from Tensor
-    # --------------------------------------------
-
-    def relabel(self, mapping: dict[str, str | None], inplace=True) -> Tensor:
-        assert self._DUMMY_LABEL not in mapping
-        if inplace:
-            self.shape.relabel(mapping)
-            self.invariant_part.relabel(mapping, inplace=True)
-            return self
-        return ChargedTensor(invariant_part=self.invariant_part.relabel(mapping, inplace=False),
-                             dummy_leg_state=self.dummy_leg_state)
-
-    def _data_repr_lines(self, indent: str, max_lines: int) -> list[str]:
-        return self.backend._data_repr_lines(
-            self.invariant_part, indent=indent, max_width=printoptions.linewidth, max_lines=max_lines
-        )
-    
-    def _repr_header_lines(self, indent: str) -> list[str]:
-        lines = Tensor._repr_header_lines(self, indent=indent)
-        lines.append(f'{indent}* Dummy Leg: dim={self.dummy_leg.dim}, '
-                     f'dual={self.dummy_leg.is_dual}, sectors={self.dummy_leg.sectors}')
-        lines.append(f'{indent}* Dummy Leg state:')
-        if self.dummy_leg_state is None:
-            lines.append(f'{indent}  unspecified')
-        else:
-            lines.extend(self.backend._block_repr_lines(self.dummy_leg_state, indent=indent + '  '),
-                        max_width=70, max_lines=3)
-        return lines
-
-    # --------------------------------------------
-    # Implementing abstractmethods
-    # --------------------------------------------
-    
-    @classmethod
-    def zero(cls, legs: Space | list[Space], dummy_leg: Space,
-             backend=None, labels: list[str | None] = None, dtype: Dtype = Dtype.float64,
-             dummy_leg_state=None, num_domain_legs: int = 0) -> ChargedTensor:
-        if isinstance(legs, Space):
-            legs = [legs]
-        if labels is None:
-            labels = [None] * len(legs)
-        invariant_part = BlockDiagonalTensor.zero(
-            legs=legs + [dummy_leg], backend=backend, labels=labels + [cls._DUMMY_LABEL],
-            dtype=dtype, num_domain_legs=num_domain_legs
-        )
-        return cls(invariant_part=invariant_part, dummy_leg_state=dummy_leg_state)
-
-    def add_trivial_leg(self, label: str = None, is_dual: bool = False, pos: int = -1,
-                        to_domain: bool = None) -> ChargedTensor:
-        # parse pos now, since it is w.r.t. ``self.num_legs``, not ``self.invariant_part.num_legs``.
-        res_num_legs = self.num_legs + 1
-        if not (-res_num_legs <= pos < res_num_legs):
-            raise ValueError(f'`pos` out of bounds: {pos}')
-        if pos < 0:
-            pos = pos + res_num_legs
-        inv = self.invariant_part.add_trivial_leg(label=label, is_dual=is_dual, pos=pos,
-                                                  to_domain=to_domain)
-        return ChargedTensor(inv, self.dummy_leg_state)
-
-    def apply_mask(self, mask: Mask, leg: int | str) -> ChargedTensor:
-        return ChargedTensor(
-            invariant_part=self.invariant_part.apply_mask(mask, self.get_leg_idx(leg)),
-            dummy_leg_state=self.dummy_leg_state
-        )
-
-    def combine_legs(self,
-                     *legs: list[int | str],
-                     product_spaces: list[ProductSpace] = None,
-                     product_spaces_dual: list[bool] = None,
-                     new_axes: list[int] = None,
-                     new_labels: list[str | None] = None) -> ChargedTensor:
-        """See :func:`tenpy.linalg.tensors.combine_legs`."""
-        legs = [self.get_leg_idcs(group) for group in legs]  # needed, since invariant_part does not have the same legs
-        inv = self.invariant_part.combine_legs(*legs, product_spaces=product_spaces,
-                                               product_spaces_dual=product_spaces_dual,
-                                               new_axes=new_axes, new_labels=new_labels)
-        return ChargedTensor(invariant_part=inv, dummy_leg_state=self.dummy_leg_state)
-
-    def conj(self) -> ChargedTensor:
-        if self.dummy_leg_state is None:
-            # TODO think about this case carefully. We could just also do dummy_leg_state = None
-            # i.e. the state is still unspecified. Could it cause problems that we then did not
-            # keep track of the conj? Probably not, if the state is unspecified, you cant expect
-            # tenpy to keep track of what happens to it...
-            raise NotImplementedError
-        else:
-            dummy_leg_state = self.backend.block_conj(self.dummy_leg_state)
-        inv = self.invariant_part.conj().relabel({'!*': '!'})
-        return ChargedTensor(invariant_part=inv, dummy_leg_state=dummy_leg_state)
-
-    def hconj(self) -> ChargedTensor:
-        # TODO is this expected behavior? i.e. that conj() has opposite dummy_leg.is_dual
-        #      but hconj gives the same?
-        return super().hconj().flip_dummy_leg_duality()
-
-    def copy(self, deep=True) -> ChargedTensor:
-        if deep:
-            if self.dummy_leg_state is None:
-                dummy_leg_state = None
-            else:
-                dummy_leg_state = self.backend.block_copy(self.dummy_leg_state)
-            return ChargedTensor(invariant_part=self.invariant_part.copy(deep=True),
-                                 dummy_leg_state=dummy_leg_state)
-        return ChargedTensor(invariant_part=self.invariant_part.copy(deep=False),
-                             dummy_leg_state=self.dummy_leg_state)
-
-    def item(self) -> float | complex:
-        if not all(leg.dim == 1 for leg in self.invariant_part.legs[:-1]):
-            raise ValueError('Not a scalar')
-        return self.backend.block_item(self.to_dense_block())
-
-    def norm(self, order=None) -> float:
-        if order is None:
-            order = 2
-        if self.dummy_leg_state is None:
-            raise ValueError('dummy_leg_state unspecified.')
-        if self.dummy_leg.dim == 1:
-            factor = self.backend.block_item(self.dummy_leg_state)
-            return factor * self.invariant_part.norm(order=order)
-        else:
-            warnings.warn('Converting ChargedTensor to dense block for `norm`', stacklevel=2)
-            return self.backend.block_norm(self.to_dense_block(), order=order)
-
-    def permute_legs(self, permutation: list[int | str] = None, num_domain_legs: int = None
-                     ) -> ChargedTensor:
-        permutation = self.get_leg_idcs(permutation)  # needed, since invariant_part does not have the same legs
-        permutation = permutation + [-1]  # keep dummy leg at its position
-        inv_part = self.invariant_part.permute_legs(permutation, num_domain_legs)
-        return ChargedTensor(inv_part, self.dummy_leg_state)
-
-    def split_legs(self, *legs: int | str) -> ChargedTensor:
-        legs = self.get_leg_idcs(legs)  # needed, since invariant_part does not have the same legs
-        return ChargedTensor(invariant_part=self.invariant_part.split_legs(*legs),
-                             dummy_leg_state=self.dummy_leg_state)
-
-    def squeeze_legs(self, legs: int | str | list[int | str] = None) -> ChargedTensor:
-        legs = self.get_leg_idcs(legs)  # needed, since invariant_part does not have the same legs
-        return ChargedTensor(invariant_part=self.invariant_part.squeeze_legs(legs),
-                             dummy_leg_state=self.dummy_leg_state)
-
-    def to_dense_block(self, leg_order: list[int | str] = None) -> Block:
-        invariant_block = self.backend.to_dense_block(self.invariant_part)
-        if self.dummy_leg_state is None:
-            raise ValueError('dummy_leg_state not specified')
-        block = self.backend.block_tdot(invariant_block, self.dummy_leg_state, [-1], [0])
-        if leg_order is not None:
-            block = self.backend.block_permute_axes(block, self.get_leg_idcs(leg_order))
-        return block
-
-    def trace(self, legs1: int | str | list[int | str] = -2, legs2: int | str | list[int | str] = -1
-              ) -> ChargedTensor | float | complex:
-        legs1 = self.get_leg_idcs(legs1)  # needed, since invariant_part does not have the same legs
-        legs2 = self.get_leg_idcs(legs2)
-        return ChargedTensor(invariant_part=self.invariant_part.trace(legs1, legs2),
-                             dummy_leg_state=self.dummy_leg_state)
-
-    def _get_element(self, idcs: list[int]) -> float | complex:
-        if self.dummy_leg_state is None:
-            raise ValueError('dummy_leg_state unspecified.')
-        if self.dummy_leg.dim == 1:
-            factor = self.backend.block_item(self.dummy_leg_state)
-            return factor * self.invariant_part._get_element(idcs + [0])
-        masks = [Mask.from_indices([idx], leg) for idx, leg in zip(idcs, self.legs)]
-        return self._getitem_apply_masks(masks, legs=list(range(self.num_legs))).item()
-
-    def _mul_scalar(self, other: complex) -> ChargedTensor:
-        # can choose to either "scale" the invariant part or the dummy_leg_state.
-        # we might want to keep dummy_leg_state=None, so we scale the invariant part
-        return ChargedTensor(
-            invariant_part=self.invariant_part._mul_scalar(other),
-            dummy_leg_state=self.dummy_leg_state
-        )
-
-    def _set_element(self, idcs: list[int], value: float | complex) -> None:
-        if self.dummy_leg_state is None:
-            raise ValueError('dummy_leg_state unspecified.')
-        if self.dummy_leg.dim > 1:
-            msg = 'Can not set elements of ChargedTensor with non-trivial dummy leg'
-            raise ValueError(msg)
-        factor = self.backend.block_item(self.dummy_leg_state)
-        self.invariant_part._set_element(idcs + [0], value / factor)
-
-    # --------------------------------------------
-    # Implementing binary tensor methods
-    # --------------------------------------------
-
-    def almost_equal(self, other: Tensor, atol: float = 0.00001, rtol: float = 1e-8,
-                     allow_different_types: bool = False) -> bool:
-        if not isinstance(other, ChargedTensor):
-            if not allow_different_types:
-                raise TypeError(f'Different types: {type(self)} and {type(other)}.')
-            if isinstance(other, DiagonalTensor):
-                other = other.to_full()
-            if isinstance(other, BlockDiagonalTensor):
-                try:
-                    s = self.as_Tensor()
-                except ValueError:
-                    s_proj = self.project_to_invariant()
-                    return self.almost_equal(s_proj, atol, rtol) and s_proj.almost_equal(other, atol, rtol)
-                return s.almost_equal(other, atol, rtol)
-            else:
-                raise TypeError(f'almost_equal not supported for types {type(self)} and {type(other)}.')
-
-        other_order = self._input_checks_same_legs(other)
-        if other_order is not None:
-            other = other.permute_legs(other_order)
-
-        # can now assume that isinstance(other, ChargedTensor)
-        if self.legs != other.legs:
-            raise ValueError('Mismatching shapes')
-        if self.dummy_leg.is_dual != other.dummy_leg.is_dual:
-            other = other.flip_dummy_leg_duality()
-        if self.dummy_leg != other.dummy_leg:
-            return False
-        if (self.dummy_leg_state is None) != (other.dummy_leg_state is None):
-            raise ValueError('Mismatch: defined and undefined dummy_leg_state')
-        if self.dummy_leg_state is None:
-            return self.invariant_part.almost_equal(other.invariant_part, atol=atol, rtol=rtol)
-        backend = get_same_backend(self, other)
-        if self.dummy_leg.dim == 1:
-            factor = backend.block_item(self.dummy_leg_state) / backend.block_item(other.dummy_leg_state)
-            return self.invariant_part.almost_equal(factor * other.invariant_part, atol=atol, rtol=rtol)
-        else:
-            # The decomposition into invariant part and non-invariant state is not unique,
-            # so we cant just compare them individually.
-            # OPTIMIZE (JU) is there a more efficient way?
-            warnings.warn('Converting ChargedTensor to dense block for `almost_equal`')
-            other_order = self._input_checks_same_legs(other)
-            backend = get_same_backend(self, other)
-            self_block = self.to_dense_block()
-            other_block = other.to_dense_block(leg_order=other_order)
-            return backend.block_allclose(self_block, other_block)
-
-    def inner(self, other: Tensor, do_conj: bool = True, legs1: list[int | str] = None,
-              legs2: list[int | str]  = None) -> float | complex:
-        if self.dummy_leg_state is None:
-            raise ValueError('dummy_leg_state unspecified')
-        leg_order_2 = self._input_checks_inner(other, do_conj=do_conj, legs1=legs1, legs2=legs2)
-        if isinstance(other, (DiagonalTensor, BlockDiagonalTensor)):
-            # other is not charged and thus lives in the trivial sector of the parent space.
-            # thus, only the components of self in the trivial sector contribute to the overlap
-            self_projected = self._project_to_invariant()
-            if self_projected is None:
-                return Dtype.common(self.dtype, other.dtype).zero_scalar
-            return self_projected.inner(other, do_conj=do_conj, legs1=legs1, legs2=legs2)
-        if isinstance(other, ChargedTensor):
-            if other.dummy_leg_state is None:
-                raise ValueError('dummy_leg_state unspecified')
-            # OPTIMIZE could directly return 0 if the two tensors have completely different charges
-            backend = get_same_backend(self, other)
-            # contract the invariant parts with each other and convert do dense block
-            inv1 = self.invariant_part.conj() if do_conj else self.invariant_part
-            if leg_order_2 is None:
-                leg_order_2 = list(range(other.num_legs))
-            res = inv1.tdot(other.invariant_part, legs1=list(range(self.num_legs)), legs2=leg_order_2)
-            res = res.to_dense_block()
-            # contract with state on dummy leg of self
-            state = backend.block_conj(self.dummy_leg_state) if do_conj else self.dummy_leg_state
-            res = backend.block_tdot(state, res, 0, 0)
-            # contract with state on dummy leg of other
-            res = backend.block_tdot(res, other.dummy_leg_state, 0, 0)
-            return backend.block_item(res)
-        if isinstance(other, Mask):
-            # use that leg_order_2 is either [0, 1] or [1, 0]
-            # -> the leg n we need to mask is the one where leg_order_2[n] == 0, i.e. n == leg_order_2[0]
-            return self.apply_mask(other, leg=leg_order_2[0]).trace()
-        raise TypeError(f'inner not supported for {type(self)} and {type(other)}')
-    
-    def outer(self, other: Tensor, relabel1: dict[str, str] = None,
-              relabel2: dict[str, str] = None) -> Tensor:
-        assert relabel1 is None or self.invariant_part.labels[-1] not in relabel1
-        if isinstance(other, DiagonalTensor):
-            other = other.as_Tensor()
-        if isinstance(other, BlockDiagonalTensor):
-            inv_part = self.invariant_part.outer(other, relabel1=relabel1, relabel2=relabel2)
-            # permute dummy leg to the back
-            self_normal = list(range(self.num_legs))
-            self_dummy = [self.num_legs]
-            other_normal = list(range(self.num_legs + 1, self.num_legs + 1 + other.num_legs))
-            inv_part = inv_part.permute_legs(self_normal + other_normal + self_dummy)
-            return ChargedTensor(invariant_part=inv_part, dummy_leg_state=self.dummy_leg_state)
-        if isinstance(other, ChargedTensor):
-            assert relabel2 is None or other.invariant_part.labels[-1] not in relabel2
-            invariant_part = self.invariant_part.outer(other.invariant_part, relabel1=relabel1, relabel2=relabel2)
-            return ChargedTensor.from_two_dummy_legs(
-                invariant_part, leg1=self.num_legs, state1=self.dummy_leg_state, leg2=-1,
-                state2=other.dummy_leg_state, convert_to_tensor_if_possible=True
-            )
-        raise TypeError(f'outer not supported for {type(self)} and {type(other)}')
-
-    def tdot(self, other: Tensor, legs1: int | str | list[int | str] = -1,
-             legs2: int | str | list[int | str] = 0, relabel1: dict[str, str] = None,
-             relabel2: dict[str, str] = None) -> Tensor | float | complex:
-        # no need to do input checks, since we reduce to Tensor.tdot, which checks
-        legs1 = self.get_leg_idcs(legs1)  # make sure we reference w.r.t. self, not self.invariant_part
-        assert relabel1 is None or self.invariant_part.labels[-1] not in relabel1
-        if isinstance(other, (BlockDiagonalTensor, DiagonalTensor, Mask)):
-            # In both of these cases, the main work is done by tdot(self.invariant_part, other, ...)
-            invariant_part = self.invariant_part.tdot(other, legs1=legs1, legs2=legs2,
-                                                      relabel1=relabel1, relabel2=relabel2)
-            # move dummy leg to the back
-            num_legs_from_self = self.num_legs - len(legs1)
-            permutation = list(range(num_legs_from_self)) \
-                          + list(range(num_legs_from_self + 1, invariant_part.num_legs)) \
-                          + [num_legs_from_self]
-            invariant_part = invariant_part.permute_legs(permutation)
-            return ChargedTensor(invariant_part=invariant_part, dummy_leg_state=self.dummy_leg_state)
-        if isinstance(other, ChargedTensor):
-            legs2 = other.get_leg_idcs(legs2)  # make sure we reference w.r.t. other
-            assert relabel2 is None or other.invariant_part.labels[-1] not in relabel2
-            invariant = self.invariant_part.tdot(other.invariant_part, legs1=legs1, legs2=legs2,
-                                                 relabel1=relabel1, relabel2=relabel2)
-            return ChargedTensor.from_two_dummy_legs(
-                invariant, leg1=self.num_legs - len(legs1), state1=self.dummy_leg_state,
-                leg2=-1, state2=other.dummy_leg_state, convert_to_tensor_if_possible=True
-            )
-        raise TypeError(f'tdot not supported for {type(self)} and {type(other)}')
-
-    def _add_tensor(self, other: Tensor) -> ChargedTensor:
-        if not isinstance(other, ChargedTensor):
-            raise TypeError(f"unsupported operand type(s) for +: 'ChargedTensor' and '{type(other)}'")
-        if self.dummy_leg != other.dummy_leg:
-            raise ValueError('Can not add ChargedTensors with different dummy legs')
-        if (self.dummy_leg_state is None) != (other.dummy_leg_state is None):
-            raise ValueError('Can not add ChargedTensors with specified and unspecified dummy_leg_state')
-        if self.dummy_leg_state is None:
-            return ChargedTensor(self.invariant_part + other.invariant_part, dummy_leg_state=None)
-        if self.dummy_leg.dim == 1:
-            factor = self.backend.block_item(self.dummy_leg_state) / self.backend.block_item(other.dummy_leg_state)
-            return ChargedTensor(self.invariant_part + factor * other.invariant_part,
-                                 dummy_leg_state=self.dummy_leg_state)
-        raise NotImplementedError  # TODO can we cover the remaining case somehow? might be impossible.
-
-    # --------------------------------------------
-    # Internal utility methods
-    # --------------------------------------------
-
-    @staticmethod
-    def _dummy_leg_from_charge(charge: Space | Sector, symmetry: Symmetry):
-        if isinstance(charge, Space):
-            return charge.as_ElementarySpace()
-        assert symmetry.is_valid_sector(charge)
-        return ElementarySpace(symmetry, sectors=[charge], multiplicities=[1]).dual
+        return self.backend.to_dense_block_trivial_sector(self)
 
 
 class DiagonalTensor(SymmetricTensor):
-    r"""Special case of a tensor with two legs that is diagonal in the computational basis.
+    r"""Special case of a :class:`SymmetricTensor` that is diagonal in the computational basis.
 
-    TODO more "elementwise" methods (exp, log, sqrt, ...?)
+    The domain and codomain of a diagonal tensor are the same and consist of a single leg.
+    A diagonal tensor then is a map that is a multiple of the identity on each sector of the leg,
+    i.e. it is given by :math:`\bigoplus_a \lambda_a \eye_a`, where the sum goes over sectors
+    :math:`a` of the `leg` :math:`V = \bigoplus_a a`.
+    
+    This is the natural type e.g. for singular values or eigenvalue and allows elementwise methods
+    such as TODO.
 
     Parameters
     ----------
     data
         The numerical data ("free parameters") comprising the tensor. type is backend-specific
-    first_leg : Space
-        The first leg of this tensor.
-    second_leg_dual : bool
-        Wether the second leg is the dual of the first (default) or the same.
-        If ``True``, the result is a tensor :math:`\sum_n c_n \vert n \rangle\langle n \vert`.
-        Otherwise it is :math:`\sum_n c_n \vert n \rangle \otimes \vert n \rangle`.
-    backend: :class:`~tenpy.linalg.backends.abstract_backend.Backend`, optional
-        The backend for the Tensor
-    labels : list[str | None] | None
-        Labels for the legs. If None, translates to ``[None, None, ...]`` of appropriate length
+    leg: Space
+        The single leg in both the domain and codomain
+    backend : Backend
+        The backend of the tensor.
+    labels: list[list[str | None]] | list[str | None] | None
+        Specify the labels for the legs.
+        Can either give two lists, one for the codomain, one for the domain.
+        Or a single flat list for all legs in the order of the :attr:`legs`,
+        such that ``[codomain_labels, domain_labels]`` is equivalent
+        to ``[*codomain_legs, *reversed(domain_legs)]``.
     """
-    def __init__(self, data, first_leg: Space, second_leg_dual: bool = True, backend=None,
-                 labels: list[str | None] = None):
-        self.data = data
-        self.second_leg_dual = second_leg_dual
-        second_leg = first_leg.dual if second_leg_dual else first_leg
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        dtype = backend.get_dtype_from_data(data)
-        Tensor.__init__(self, legs=[first_leg, second_leg], backend=backend, labels=labels,
-                        dtype=dtype, num_domain_legs=1)
-
-    def test_sanity(self) -> None:
-        super().test_sanity()
-        self.backend.test_data_sanity(self, is_diagonal=True)
-        assert self.dtype != Dtype.bool
-
-    # --------------------------------------------
-    # Additional methods (not in Tensor)
-    # --------------------------------------------
+    _forbidden_dtypes = []
     
-    @functools.cached_property
-    def diag_block(self) -> Block:
-        return self.backend.diagonal_to_block(self)
+    def __init__(self, data, leg: Space, backend: Backend | None = None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
+        SymmetricTensor.__init__(self, data, codomain=[leg], domain=[leg], backend=backend,
+                                 labels=labels)
 
-    @functools.cached_property
-    def diag_numpy(self) -> np.ndarray:
-        block = self.diag_block
-        return self.backend.block_to_numpy(block)
+    def test_sanity(self):
+        super().test_sanity()
+        assert self.domain == self.codomain
+        assert self.domain.num_spaces == 1
 
     @classmethod
-    def eye(cls, first_leg: Space, backend=None, labels: list[str | None] = None,
-            dtype: Dtype = Dtype.float64) -> DiagonalTensor:
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        if len(labels) == 1:
-            labels = [labels[0], _dual_leg_label(labels[0])]
-        assert len(labels) == 2
-        return cls.from_block_func(
-            func=backend.ones_block,
-            first_leg=first_leg, second_leg_dual=True, backend=backend, labels=labels,
-            func_kwargs=dict(dtype=dtype),
+    def from_block_func(cls, func, leg: Space, backend: Backend | None = None,
+                        labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                        func_kwargs: dict = None,
+                        shape_kw: str = None,
+                        dtype: Dtype = None):
+        co_domain, _, backend, symmetry = cls._init_parse_args(
+            codomain=[leg], domain=[leg], backend=backend
         )
-
-    @classmethod
-    def from_block_func(cls, func, first_leg: Space, second_leg_dual: bool = True,
-                        backend=None, labels: list[str | None] = None, func_kwargs={},
-                        shape_kw: str = None, dtype: Dtype = None) -> DiagonalTensor:
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        if shape_kw is not None:
-            def block_func(shape):
-                block = func(**{shape_kw: shape}, **func_kwargs)
-                if dtype is not None:
-                    block = backend.block_to_dtype(block, dtype)
-                return block
-        else:
-            def block_func(shape):
+        # wrap func to consider func_kwargs, shape_kw, dtype
+        if func_kwargs is None:
+            func_kwargs = {}
+        
+        def block_func(shape, coupled):
+            # use same backend function as from_sector_block_func, so we include the coupled arg
+            # but just ignore it.
+            if shape_kw is None:
                 block = func(shape, **func_kwargs)
-                if dtype is not None:
-                    block = backend.block_to_dtype(block, dtype)
-                return block
+            else:
+                block = func(**{shape_kw: shape}, **func_kwargs)
+            return backend.as_block(block, dtype)
 
-        data = backend.diagonal_from_block_func(block_func, leg=first_leg)
-        res = cls(data=data, first_leg=first_leg, second_leg_dual=second_leg_dual, backend=backend,
-                   labels=labels)
+        data = backend.diagonal_from_sector_block_func(block_func, co_domain=co_domain)
+        res = cls(data, leg=leg, backend=backend, labels=labels)
         res.test_sanity()
         return res
 
     @classmethod
-    def from_diag(cls, diag: Block, first_leg: Space, second_leg_dual: bool = True,
-                  backend=None, labels: list[str | None] = None) -> DiagonalTensor:
+    def from_dense_block(cls, block: Block, leg: Space, backend: Backend | None = None,
+                         labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                         dtype: Dtype = None, tol: float = 1e-6):
+        if backend is None:
+            backend = get_backend(symmetry=leg.symmetry)
+        diag = backend.block_get_diagonal(backend.as_block(block, dtype=dtype), check_offdiagonal=True)
+        return cls.from_diag_block(diag, leg=leg, backend=backend, labels=labels, dtype=dtype,
+                                   tol=tol)
+
+    @classmethod
+    def from_diag_block(cls, diag: Block, leg: Space, backend: Backend | None = None,
+                        labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                        dtype: Dtype = None, tol: float = 1e-6):
         """Convert a dense 1D block containing the diagonal entries to a DiagonalTensor.
 
         Parameters
         ----------
-        diag : Block-like
+        diag: Block-like
             The diagonal entries as a backend-specific block or some data that can be converted
             using :meth:`AbstractBlockBackend.as_block`. This includes e.g. nested python iterables
             or numpy arrays.
-        first_leg, second_leg_dual, backend, labels
-            Same as in constructor of :class:`DiagonalTensor`.
+        leg, backend, labels
+            Arguments for constructor of :class:`DiagonalTensor`.
+        dtype: Dtype
+            If given, `diag` is converted to this dtype.
+
+        See Also
+        --------
+        diagonal_as_block, diagonal_as_numpy
+            Inverse methods that recover the `diag` entries.
         """
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        diag = backend.as_block(diag)
-        assert backend.block_shape(diag) == (first_leg.dim,)
-        data = backend.diagonal_from_block(diag, leg=first_leg)
-        return cls(data=data, first_leg=first_leg, second_leg_dual=second_leg_dual, backend=backend,
-                   labels=labels)
+        co_domain, _, backend, symmetry = cls._init_parse_args(
+            codomain=[leg], domain=[leg], backend=backend
+        )
+        diag = backend.as_block(diag, dtype=dtype)
+        return cls(
+            data=backend.diagonal_from_block(diag, co_domain=co_domain, tol=tol),
+            leg=leg, backend=backend, labels=labels
+        )
 
     @classmethod
-    def from_numpy_func(cls, func, first_leg: Space, second_leg_dual: bool = True,
-                        backend=None, labels: list[str | None] = None, func_kwargs={},
-                        shape_kw: str = None, dtype: Dtype = None) -> DiagonalTensor:
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        if shape_kw is not None:
-            def block_func(shape):
-                arr = func(**{shape_kw: shape}, **func_kwargs)
-                block = backend.block_from_numpy(arr, dtype)
-                return block
+    def from_eye(cls, leg: Space, backend: Backend | None = None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                 dtype: Dtype = Dtype.float64):
+        """The identity map as a DiagonalTensor.
 
+        Parameters
+        ----------
+        leg, backend, labels
+            Arguments for constructor of :class:`DiagonalTensor`.
+        dtype: Dtype
+            The dtype for the entries.
+        """
+        co_domain, _, backend, symmetry = cls._init_parse_args(
+            codomain=[leg], domain=[leg], backend=backend
+        )
+        return cls.from_block_func(
+            backend.ones_block, leg=leg, backend=backend, labels=labels,
+            func_kwargs=dict(dtype=dtype), dtype=dtype
+        )
+
+    @classmethod
+    def from_random_normal(cls, leg: Space,
+                           mean: DiagonalTensor | None = None,
+                           sigma: float = 1.,
+                           backend: Backend | None = None,
+                           labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                           dtype: Dtype = Dtype.complex128):
+        r"""Generate a sample from the complex normal distribution.
+
+        The probability density is
+
+        .. math ::
+            p(T) \propto \mathrm{exp}\left[
+                \frac{1}{2 \sigma^2} \mathrm{Tr} (T - \mathtt{mean}) (T - \mathtt{mean})^\dagger
+            \right]
+
+        TODO make sure we actually generate from that distribution in the non-abelian or anyonic case!
+
+        Parameters
+        ----------
+        leg, backend, labels
+            Arguments for constructor of :class:`DiagonalTensor`.
+        mean: DiagonalTensor, optional
+            The mean of the distribution. ``None`` is equivalent to zero mean.
+        sigma: float
+            The standard deviation of the distribution
+        dtype: Dtype
+            The dtype for the entries.
+        """
+        assert dtype.is_complex
+        assert sigma > 0.
+        if mean is not None:
+            assert isinstance(mean, DiagonalTensor)
+            if leg is None:
+                leg = mean.leg
+            else:
+                assert mean.leg == leg
+            if backend is None:
+                backend = mean.backend
+            else:
+                assert mean.backend == backend
+            if labels is None:
+                labels = mean.labels
+            if dtype is None:
+                dtype = mean.dtype
+            else:
+                assert mean.dtype == dtype
         else:
-            def block_func(shape):
-                arr = func(shape, **func_kwargs)
-                block = backend.block_from_numpy(arr, dtype)
-                return block
-
-        data = backend.diagonal_from_block_func(block_func, leg=first_leg)
-        return cls(data=data, first_leg=first_leg, second_leg_dual=second_leg_dual, backend=backend,
-                   labels=labels)
+            if leg is None:
+                raise ValueError('Must specify the lef if mean is not given.')
+            co_domain, _, backend, symmetry = cls._init_parse_args(
+                codomain=[leg], domain=[leg], backend=backend
+            )
+        with_zero_mean = cls.from_block_func(
+            backend.block_random_normal, leg=leg, backend=backend, labels=labels,
+            func_kwargs=dict(dtype=dtype), dtype=dtype
+        )
+        if mean is not None:
+            return mean + with_zero_mean
+        return with_zero_mean
 
     @classmethod
-    def from_tensor(cls, tens: BlockDiagonalTensor, check_offdiagonal: bool = True) -> DiagonalTensor:
+    def from_random_uniform(cls, leg: Space,
+                           backend: Backend | None = None,
+                           labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                           dtype: Dtype = Dtype.complex128):
+        """Generate a tensor with uniformly random block-entries.
+
+        The block entries, i.e. the free parameters of the tensor are drawn independently and
+        uniformly. If dtype is a real type, they are drawn from [-1, 1], if it is complex, real and
+        imaginary part are drawn independently from [-1, 1].
+
+        .. note ::
+            This is not a well defined probability distribution on the space of symmetric tensors,
+            since the meaning of the uniformly drawn numbers depends on both the choice of the
+            basis and on the backend.
+
+        Parameters
+        ----------
+        leg, backend, labels
+            Arguments for constructor of :class:`DiagonalTensor`.
+        dtype: Dtype
+            The dtype for the entries.
+        """
+        co_domain, _, backend, symmetry = cls._init_parse_args(
+            codomain=[leg], domain=[leg], backend=backend
+        )
+        return cls.from_block_func(
+            func=backend.block_random_uniform, leg=leg, backend=backend, labels=labels,
+            func_kwargs=dict(dtype=dtype), dtype=dtype
+        )
+
+    @classmethod
+    def from_sector_block_func(cls, func, leg: Space, backend: Backend | None = None,
+                               labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                               func_kwargs: dict = None,
+                               dtype: Dtype = None):
+        co_domain, _, backend, _ = cls._init_parse_args(
+            codomain=[leg], domain=[leg], backend=backend
+        )
+        # wrap func to consider func_kwargs and dtype
+        if func_kwargs is None:
+            func_kwargs = {}
+
+        def block_func(shape, coupled):
+            block = func(shape, coupled, **func_kwargs)
+            return backend.as_block(block, dtype)
+
+        data = backend.diagonal_from_sector_block_func(block_func, co_domain=co_domain)
+        res = cls(data, leg=leg, backend=backend, labels=labels)
+        res.test_sanity()
+        return res
+
+    @classmethod
+    def from_tensor(cls, tens: SymmetricTensor, check_offdiagonal: bool = True) -> DiagonalTensor:
         """Create DiagonalTensor from a Tensor.
 
         Parameters
@@ -2535,77 +1118,112 @@ class DiagonalTensor(SymmetricTensor):
             If `check_offdiagonal` and any off-diagonal element is non-zero.
             TODO should there be a tolerance?
         """
-        if tens.num_legs != 2:
-            raise ValueError
-        if tens.legs[1] == tens.legs[0]:
-            second_leg_dual = False
-        elif tens.legs[1].can_contract_with(tens.legs[0]):
-            second_leg_dual=True
-        else:
-            raise ValueError('Second leg must be equal to or dual of first leg')
+        assert tens.num_legs == 2
+        assert tens.domain == tens.codomain
         data = tens.backend.diagonal_data_from_full_tensor(tens, check_offdiagonal=check_offdiagonal)
-        return cls(data=data, first_leg=tens.legs[0], second_leg_dual=second_leg_dual,
-                   backend=tens.backend, labels=tens.labels)
+        return cls(data=data, leg=tens.codomain.spaces[0], backend=tens.backend, labels=tens.labels)
 
     @classmethod
-    def random_normal(cls, first_leg: Space = None, second_leg_dual: bool = None,
-                      mean: DiagonalTensor = None, sigma: float = 1., backend=None,
-                      labels: list[str | None] = None, dtype: Dtype = None
-                      ) -> DiagonalTensor:
-        r"""Generate a tensor from the normal distribution.
+    def from_zero(cls, leg: Space,
+                  backend: Backend | None = None,
+                  labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                  dtype: Dtype = Dtype.complex128):
+        """A zero tensor.
 
-        Like :meth:`Tensor.random_normal`."""
-        if mean is not None:
-            for name, val in zip(['first_leg', 'second_leg_dual', 'backend', 'labels'],
-                                 [first_leg, second_leg_dual, backend, labels]):
-                if val is not None:
-                    msg = f'{name} argument to Tensor.random_normal was ignored, because mean was given.'
-                    warnings.warn(msg)
-            if dtype is None:
-                dtype = mean.dtype
-            return mean + cls.random_normal(
-                first_leg=mean.legs[0], second_leg_dual=mean.second_leg_dual, mean=None,
-                sigma=sigma, backend=mean.backend, labels=mean.labels, dtype=dtype
-            )
+        Parameters
+        ----------
+        leg, backend, labels
+            Arguments for constructor of :class:`DiagonalTensor`.
+        dtype: Dtype
+            The dtype for the entries.
+        """
+        co_domain, _, backend, symmetry = cls._init_parse_args(
+            codomain=[leg], domain=[leg], backend=backend
+        )
+        return cls(
+            data=backend.zero_diagonal_data(co_domain=co_domain, dtype=dtype),
+            leg=leg, backend=backend, labels=labels
+        )
 
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        if dtype is None:
-            dtype = Dtype.float64
-        data = backend.diagonal_from_block_func(backend.block_random_normal, leg=first_leg,
-                                                func_kwargs=dict(dtype=dtype))
-        return cls(data=data, first_leg=first_leg, second_leg_dual=second_leg_dual, backend=backend,
-                   labels=labels)
+    @property
+    def leg(self) -> Space:
+        """Return the single space that makes up to domain and codomain."""
+        return self.codomain.spaces[0]
 
-    @classmethod
-    def random_uniform(cls, first_leg: Space, second_leg_dual: bool = True, backend=None,
-                       labels: list[str | None] = None, dtype: Dtype = Dtype.float64
-                       ) -> DiagonalTensor:
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        data = backend.diagonal_from_block_func(backend.block_random_uniform, leg=first_leg,
-                                                func_kwargs=dict(dtype=dtype))
-        return cls(data=data, first_leg=first_leg, second_leg_dual=second_leg_dual, backend=backend,
-                   labels=labels)
+    def __abs__(self):
+        return self._elementwise_unary(func=operator.abs, maps_zero_to_zero=True)
 
-    def _apply_mask_both_legs(self, mask: Mask) -> DiagonalTensor:
-        """Apply the same mask to both legs."""
-        assert self.legs[0].is_equal_or_dual(mask.large_leg)
-        res_leg = mask.small_leg
-        if self.legs[0].is_dual != res_leg.is_dual:
-            res_leg = res_leg.dual
-        return DiagonalTensor(
-            data=self.backend.apply_mask_to_DiagonalTensor(self, mask),
-            first_leg=res_leg,
-            second_leg_dual=self.second_leg_dual, backend=self.backend, labels=self.labels,
+    def __bool__(self):
+        if self.dtype == Dtype.bool and is_scalar(self):
+            return bool(self.item())
+        msg = 'The truth value of a non-scalar DiagonalTensor is ambiguous. Use a.any() or a.all()'
+        raise ValueError(msg)
+
+    # TODO offer elementwise boolean operations: and, or, xor, eq
+
+    def __add__(self, other):
+        return self._binary_operand(other, func=operator.add, operand='+')
+
+    def __ge__(self, other):
+        return self._binary_operand(other, func=operator.ge, operand='>=')
+
+    def __gt__(self, other):
+        return self._binary_operand(other, func=operator.gt, operand='>')
+
+    def __le__(self, other):
+        return self._binary_operand(other, func=operator.le, operand='<=')
+
+    def __lt__(self, other):
+        return self._binary_operand(other, func=operator.lt, operand='<')
+
+    def __mul__(self, other):
+        return self._binary_operand(other, func=operator.mul, operand='*')
+
+    def __pow__(self, other):
+        return self._binary_operand(other, func=operator.pow, operand='**')
+
+    def __radd__(self, other):
+        return self._binary_operand(other, func=operator.add, operand='+', right=True)
+
+    def __rmul__(self, other):
+        return self._binary_operand(other, func=operator.mul, operand='*', right=True)
+
+    def __rpow__(self, other):
+        return self._binary_operand(other, func=operator.pow, operand='**', right=True)
+
+    def __rsub__(self, other):
+        return self._binary_operand(other, func=operator.sub, operand='-', right=True)
+
+    def __rtruediv__(self, other):
+        return self._binary_operand(other, func=operator.truediv, operand='/', right=True)
+
+    def __sub__(self, other):
+        return self._binary_operand(other, func=operator.sub, operand='-')
+
+    def __truediv__(self, other):
+        return self._binary_operand(other, func=operator.truediv, operand='/')
+
+    def all(self) -> bool:
+        """For a bool dtype, if all values are True. Raises for other dtypes."""
+        if self.dtype != Dtype.bool:
+            raise ValueError(f'all is not defined for dtype {self.dtype}')
+        return self.backend.diagonal_all(self)
+
+    def any(self) -> bool:
+        """For a bool dtype, if any value is True. Raises for other dtypes."""
+        if self.dtype != Dtype.bool:
+            raise ValueError(f'all is not defined for dtype {self.dtype}')
+        return self.backend.diagonal_any(self)
+
+    def as_SymmetricTensor(self) -> SymmetricTensor:
+        return SymmetricTensor(
+            data=self.backend.full_data_from_diagonal_tensor(self),
+            codomain=self.codomain, domain=self.domain, backend=self.backend, labels=self.labels
         )
 
     def _binary_operand(self, other: Number | DiagonalTensor, func, operand: str,
-                        is_bool_valued: bool, return_NotImplemented: bool = True
-                        ) -> DiagonalTensor | Mask:
-        """Utility function for a shared implementation of binary functions, whose second argument
-        may be a scalar ("to be broadcast") or a DiagonalTensor,
-        e.g. the dunder methods, ``__mul__, __eq__, __lt__, __pow__, ...``.
+                        return_NotImplemented: bool = False, right: bool = False):
+        """Common implementation for the binary dunder methods ``__mul__`` etc.
 
         Parameters
         ----------
@@ -2616,456 +1234,210 @@ class DiagonalTensor(SymmetricTensor):
             ``func(self_block: Block, other_or_other_block: Number | Block) -> Block``
         operand
             A string representation of the operand, used in error messages
-        is_bool_valued
-            Whether the output is boolean-valued.
-            If so, a `Mask` is returned, otherwise a `DiagonalTensor`.
         return_NotImplemented
             Whether `NotImplemented` should be returned on a non-scalar and non-`Tensor` other.
+        right
+            If this is the "right" version, i.e. ``func(other, self)``.
         """
         if isinstance(other, Number):
             backend = self.backend
-            data = backend.diagonal_elementwise_unary(
-                self, func=lambda block: func(block, other), func_kwargs={}, maps_zero_to_zero=False
-            )
+            if right:
+                
+                data = backend.diagonal_elementwise_unary(
+                    self, func=lambda block: func(other, block), func_kwargs={},
+                    maps_zero_to_zero=False
+                )
+            else:
+                data = backend.diagonal_elementwise_unary(
+                    self, func=lambda block: func(block, other), func_kwargs={},
+                    maps_zero_to_zero=False
+                )
             labels = self.labels
         elif isinstance(other, DiagonalTensor):
             backend = get_same_backend(self, other)
-            if self.legs[0] != other.legs[0] or self.second_leg_dual != other.second_leg_dual:
+            if self.leg != other.leg:
                 raise ValueError('Incompatible legs!')
-            data = backend.diagonal_elementwise_binary(self, other, func=func)
-            labels = _get_same_labels(self.labels, other.labels)
-            
+            if right:
+                data = backend.diagonal_elementwise_binary(other, self, func=func)
+            else:
+                data = backend.diagonal_elementwise_binary(self, other, func=func)
+            labels = _get_matching_labels(self.labels, other.labels)
         elif return_NotImplemented and not isinstance(other, Tensor):
             return NotImplemented
         else:
-            msg = f'Invalid types for operand "{operand}": {type(self)} and {type(other)}'
+            if right:
+                msg = f'Invalid types for operand "{operand}": {type(other)} and {type(self)}'
+            else:
+                msg = f'Invalid types for operand "{operand}": {type(self)} and {type(other)}'
             raise TypeError(msg)
+        return DiagonalTensor(data, leg=self.leg, backend=self.backend, labels=labels)
 
-        res = DiagonalTensor(data, first_leg=self.legs[0], second_leg_dual=self.second_leg_dual,
-                             backend=backend, labels=labels)
-        if is_bool_valued:
-            res = Mask.from_DiagonalTensor(res)
+    def diagonal(self) -> DiagonalTensor:
+        return self
+
+    def diagonal_as_block(self, dtype: Dtype = None) -> Block:
+        res = self.backend.diagonal_to_block(self)
+        if dtype is not None:
+            res = self.backend.block_to_dtype(res, dtype)
         return res
 
-    def _elementwise_unary(self, func, func_kwargs={}, maps_zero_to_zero: bool = False) -> DiagonalTensor:
-        """Wrap backend.diagonal_elementwise_unary
+    def diagonal_as_numpy(self, numpy_dtype=None) -> np.ndarray:
+        block = self.diagonal_as_block(dtype=Dtype.from_numpy_dtype(numpy_dtype))
+        return self.backend.block_to_numpy(block, numpy_dtype=numpy_dtype)
 
-        func(a: Block, **kwargs) -> Block"""
-        data = self.backend.diagonal_elementwise_unary(
-            self, func, func_kwargs=func_kwargs, maps_zero_to_zero=maps_zero_to_zero
-        )
-        return DiagonalTensor(data=data, first_leg=self.legs[0], second_leg_dual=self.second_leg_dual,
-                              backend=self.backend, labels=self.labels)
+    def elementwise_almost_equal(self, other: DiagonalTensor, rtol: float = 1e-5, atol=1e-8
+                                 ) -> DiagonalTensor:
+        return abs(self - other) <= (atol + rtol * abs(self))
 
-    def _elementwise_binary(self, other: DiagonalTensor, func, func_kwargs={},
+    def _elementwise_binary(self, other: DiagonalTensor, func, func_kwargs: dict = None,
                             partial_zero_is_zero: bool = False) -> DiagonalTensor:
-        """Wrap backend.diagonal_elementwise_binary
+        """An elementwise function acting on two diagonal tensors.
 
-        func(a: Block, b: Block, **kwargs) -> Block"""
-        assert isinstance(other, DiagonalTensor)
-        if self.legs[0] != other.legs[0] or self.second_leg_dual != other.second_leg_dual:
-            raise ValueError('Incompatible legs!')
+        Applies ``func(self_block: Block, other_block: Block, **func_kwargs) -> Block`` elementwise.
+        Set ``partial_zero_is_zero=True`` to promise that ``func(0, any) == 0 == func(any, 0)``.
+        """
+        if not isinstance(other, DiagonalTensor):
+            raise TypeError('Expected a DiagonalTensor')
+        if not self.leg == other.leg:
+            raise ValueError('Incompatible legs')
         backend = get_same_backend(self, other)
         data = backend.diagonal_elementwise_binary(
             self, other, func=func, func_kwargs=func_kwargs,
             partial_zero_is_zero=partial_zero_is_zero
         )
-        return DiagonalTensor(data, first_leg=self.legs[0], second_leg_dual=self.second_leg_dual,
-                              backend=backend, labels=self.labels)
+        labels = _get_matching_labels(self._labels, other._labels)
+        return DiagonalTensor(data, self.leg, backend=backend, labels=labels)
 
-    def __abs__(self):
-        return self._elementwise_unary(func=operator.abs, maps_zero_to_zero=True)
+    def _elementwise_unary(self, func, func_kwargs: dict = None, maps_zero_to_zero: bool = False
+                           ) -> DiagonalTensor:
+        """An elementwise function acting on a diagonal tensor.
 
-    def __ge__(self, other):
-        return self._binary_operand(other, func=operator.ge, operand='>=', is_bool_valued=True)
-
-    def __gt__(self, other):
-        return self._binary_operand(other, func=operator.gt, operand='>', is_bool_valued=True)
-
-    def __le__(self, other):
-        return self._binary_operand(other, func=operator.le, operand='<=', is_bool_valued=True)
-
-    def __lt__(self, other):
-        return self._binary_operand(other, func=operator.lt, operand='<', is_bool_valued=True)
-
-    def __pow__(self, other):
-        return self._binary_operand(other, func=operator.pow, operand='**', is_bool_valued=False)
-
-    def __rpow__(self, other):
-        if isinstance(other, Number):
-            return self._elementwise_unary(func=lambda block: other ** block)
-        raise TypeError(f'Invalid types for operand "**": {type(other)} and {type(self)}')
-
-    # --------------------------------------------
-    # Overriding methods from Tensor
-    # --------------------------------------------
-
-    def _getitem_apply_masks(self, masks: list[Mask], legs: list[int]) -> BlockDiagonalTensor | DiagonalTensor:
-        if len(masks) == 2:
-            if masks[0].same_mask(masks[1]):
-                return self._apply_mask_both_legs(masks[0])
-        warnings.warn('Converting DiagonalTensor to Tensor in order to apply mask', stacklevel=2)
-        return self.as_Tensor()._getitem_apply_masks(masks, legs)
-
-    def __getitem__(self, idcs):
-        # allow indexing by a single integer -> applied to both axes
-        _idcs = to_iterable(idcs)
-        if len(_idcs) == 1 and isinstance(_idcs[0], int):
-            idcs = (_idcs[0], _idcs[0])
-        return Tensor.__getitem__(self, idcs)
-
-    def __mul__(self, other):
-        if isinstance(other, DiagonalTensor):
-            # _elementwise_binary performs input checks.
-            return self._elementwise_binary(other, func=operator.mul, partial_zero_is_zero=True)
-        return Tensor.__mul__(self, other)
-
-    def __setitem__(self, idcs, value):
-        _idcs = to_iterable(idcs)
-        if len(_idcs) == 1 and isinstance(_idcs[0], int):
-            idcs = (_idcs[0], _idcs[0])
-        return Tensor.__setitem__(self, idcs, value)
-
-    def __truediv__(self, other):
-        if isinstance(other, DiagonalTensor):
-            # _elementwise_binary performs input checks.
-            return self._elementwise_binary(other, func=operator.truediv)
-        return Tensor.__truediv__(self, other)
-
-    # --------------------------------------------
-    # Implementing abstractmethods
-    # --------------------------------------------
-    
-    @classmethod
-    def zero(cls, first_leg: Space, second_leg_dual: bool = True, backend=None,
-             labels: list[str | None] = None, dtype: Dtype = Dtype.float64) -> DiagonalTensor:
-        if backend is None:
-            backend = get_backend(first_leg.symmetry)
-        data = backend.zero_diagonal_data(leg=first_leg, dtype=dtype)
-        return cls(data=data, first_leg=first_leg, second_leg_dual=second_leg_dual, backend=backend,
-                   labels=labels)
-
-    def add_trivial_leg(self, label: str = None, is_dual: bool = False, pos: int = -1,
-                        to_domain: bool = None) -> DiagonalTensor:
-        warnings.warn('Converting DiagonalTensor to Tensor for add_trivial_leg', stacklevel=2)
-        return self.as_Tensor.add_trivial_leg(label=label, is_dual=is_dual, pos=pos, to_domain=to_domain)
-
-    @amend_parent_docstring(parent=Tensor.apply_mask)
-    def apply_mask(self, mask: Mask, leg: int | str = BOTH) -> DiagonalTensor | BlockDiagonalTensor:
-        """.. note ::
-            For ``DiagonalTensor``s, :meth:`apply_mask` has a default argument for `legs` which
-            causes the mask to be applied to *both* legs.
-            If it is only applied to a single leg, the result will be a `Tensor` instead if `DiagonalTensor`.
+        Applies ``func(self_block: Block, **func_kwargs) -> Block`` elementwise.
+        Set ``maps_zero_to_zero=True`` to promise that ``func(0) == 0``.
         """
-        if leg is BOTH:
-            return self._apply_mask_both_legs(mask)
-        return self.as_Tensor().apply_mask(mask, leg)
-
-    def as_Tensor(self) -> BlockDiagonalTensor:
-        """Forget about diagonal structure and convert to a Tensor"""
-        return BlockDiagonalTensor(
-            data=self.backend.full_data_from_diagonal_tensor(self),
-            legs=self.legs, num_domain_legs=1, backend=self.backend, labels=self.labels
+        data = self.backend.diagonal_elementwise_unary(
+            self, func, func_kwargs=func_kwargs, maps_zero_to_zero=maps_zero_to_zero
         )
+        return DiagonalTensor(data, self.leg, backend=self.backend, labels=self.labels)
 
-    def combine_legs(self,
-                     *legs: list[int | str],
-                     product_spaces: list[ProductSpace] = None,
-                     product_spaces_dual: list[bool] = None,
-                     new_axes: list[int] = None,
-                     new_labels: list[str | None] = None) -> BlockDiagonalTensor:
-        """See :func:`tenpy.linalg.tensors.combine_legs`."""
-        warnings.warn('Converting DiagonalTensor to Tensor in order to combine legs', stacklevel=2)
-        return self.as_Tensor().combine_legs(
-            *legs, product_spaces=product_spaces, product_spaces_dual=product_spaces_dual,
-            new_axes=new_axes, new_labels=new_labels
-        )
-
-    def conj(self) -> DiagonalTensor:
-        return DiagonalTensor(data=self.backend.conj(self), first_leg=self.legs[0].dual,
-                              second_leg_dual=self.second_leg_dual, backend=self.backend,
-                              labels=[_dual_leg_label(l) for l in self.shape._labels])
-
-    def copy(self, deep=True) -> DiagonalTensor:
+    def copy(self, deep=True) -> SymmetricTensor:
         if deep:
-            return DiagonalTensor(data=self.backend.copy_data(self.data),
-                                  first_leg=self.legs[0],
-                                  second_leg_dual=(self.legs[1].is_dual != self.legs[0].is_dual),
-                                  backend=self.backend,
-                                  labels=self.labels[:])
-        return DiagonalTensor(data=self.data,
-                              first_leg=self.legs[0],
-                              second_leg_dual=(self.legs[1].is_dual != self.legs[0].is_dual),
-                              backend=self.backend,
-                              labels=self.labels)
-
-    def item(self) -> float | complex:
-        if all(leg.dim == 1 for leg in self.legs):
-            return self.backend.item(self)
+            data = self.backend.copy_data(self)
         else:
-            raise ValueError('Not a scalar')
-        
-    def norm(self, order=None) -> float:
-        if order is None:
-            order = 2
-        return self.backend.norm(self, order=order)
+            data = self.data
+        return DiagonalTensor(data, leg=self.leg, backend=self.backend, labels=self.labels)
 
-    def permute_legs(self, permutation: list[int | str] = None, num_domain_legs: int = None
-                     ) -> DiagonalTensor:
-        assert num_domain_legs in [None, 1], 'DiagonalTensor must have one leg in the domain.'
-        permutation = self.get_leg_idcs(permutation)
-        return DiagonalTensor(data=self.data, first_leg=self.legs[permutation[0]],
-                              second_leg_dual=self.second_leg_dual, backend=self.backend,
-                              labels=[self.shape._labels[n] for n in permutation])
-
-    def split_legs(self, *legs: int | str) -> BlockDiagonalTensor:
-        warnings.warn('Converting DiagonalTensor to Tensor in order to split legs', stacklevel=2)
-        return self.as_Tensor().split_legs(*legs)
-
-    def squeeze_legs(self, legs: int | str | list[int | str] = None) -> NoReturn:
-        raise TypeError(f'{type(self)} does not support squeeze_legs')
-
-    def to_dense_block(self, leg_order: list[int | str] = None) -> Block:
-        # need to fill in the off-diagonal zeros anyway, so we may as well use as_Tensor first.
-        # OPTIMIZE a specialized implementation could be slightly more efficient...
-        return self.as_Tensor().to_dense_block(leg_order)
-
-    def trace(self, legs1: int | str | list[int | str] = -2, legs2: int | str | list[int | str] = -1
-              ) -> float | complex:
-        leg_idcs1 = self.get_leg_idcs(legs1)
-        leg_idcs2 = self.get_leg_idcs(legs2)
-        if not len(leg_idcs1) == 1 == len(leg_idcs2):
-            raise ValueError('Wrong number of legs.')
-        if leg_idcs1[0] == leg_idcs2[0]:
-            raise ValueError('Duplicate leg')
-        return self.backend.diagonal_tensor_trace_full(self)
-
-    def _get_element(self, idcs: list[int]) -> float | complex:
-        if idcs[0] != idcs[1]:
-            return self.dtype.zero_scalar
-        return self.backend.get_element_diagonal(self, idcs[0])
-
-    def _set_element(self, idcs: list[int], value: float | complex) -> None:
-        if idcs[0] != idcs[1]:
-            raise IndexError('Off-diagonal entry can not be set for DiagonalTensor')
-        self.data = self.backend.set_element_diagonal(self, idcs[0], value)
-
-    def _mul_scalar(self, other: complex) -> DiagonalTensor:
-        return self._elementwise_unary(lambda block: self.backend.block_mul(other, block),
-                                       maps_zero_to_zero=True)
-
-    # --------------------------------------------
-    # Implementing binary tensor methods
-    # --------------------------------------------
-    
-    def almost_equal(self, other: DiagonalTensor, atol: float = 1e-5, rtol: float = 1e-8,
-                     allow_different_types: bool = False) -> bool:
-        if not isinstance(other, DiagonalTensor):
-            if not allow_different_types:
-                raise TypeError(f'Different types: {type(self)} and {type(other)}.')
-            if isinstance(other, (BlockDiagonalTensor, ChargedTensor)):
-                return self.as_Tensor().almost_equal(other, atol=atol, rtol=rtol, allow_different_types=True)
-            else:
-                raise TypeError(f'almost_equal not supported for types {type(self)} and {type(other)}.')
-
-        # can now assume that other is a DiagonalTensor
-        _ = self._input_checks_same_legs(other)
-        # no need to permute legs, diagonal data is the same either way.
-        return get_same_backend(self, other).almost_equal_diagonal(self, other, atol, rtol)
-
-    def inner(self, other: Tensor, do_conj: bool = True, legs1: list[int | str] = None,
-              legs2: list[int | str]  = None) -> float | complex:
-        leg_order_2 = self._input_checks_inner(other, do_conj=do_conj, legs1=legs1, legs2=legs2)
-        t1 = self.conj() if do_conj else self
-        return t1.tdot(other, legs1=[0, 1], legs2=leg_order_2)
-
-    def outer(self, other: Tensor, relabel1: dict[str, str] = None,
-              relabel2: dict[str, str] = None) -> Tensor:
-        if isinstance(other, DiagonalTensor):
-            warnings.warn('Converting DiagonalTensors to Tensors for outer', stacklevel=2)
-            other = other.as_Tensor()
-        if isinstance(other, (BlockDiagonalTensor, ChargedTensor)):
-            return self.as_Tensor().outer(other, relabel1=relabel1, relabel2=relabel2)
-        raise TypeError(f'outer not supported for {type(self)} and {type(other)}')
-
-    def tdot(self, other: Tensor, legs1: int | str | list[int | str] = -1,
-             legs2: int | str | list[int | str] = 0, relabel1: dict[str, str] = None,
-             relabel2: dict[str, str] = None) -> Tensor | float | complex:
-        if isinstance(other, ChargedTensor):
-            legs2 = other.get_leg_idcs(legs2)  # make sure we reference w.r.t. other, not other.invariant_part
-            assert relabel2 is None or other.invariant_part.labels[-1] not in relabel2
-            invariant_part = self.tdot(other.invariant_part, legs1=legs1, legs2=legs2,
-                                       relabel1=relabel1, relabel2=relabel2)
-            return ChargedTensor(invariant_part=invariant_part, dummy_leg_state=other.dummy_leg_state)
-        legs1, legs2 = self._input_checks_tdot(other, legs1, legs2)
-        # deal with special cases
-        if len(legs1) == 0:
-            return self.outer(other, relabel1=relabel1, relabel2=relabel2)
-        if len(legs1) == 2:
-            which_first, which_second = (0, 1) if legs2[0] < legs2[1] else (1, 0)
-            res = self.tdot(other, legs1[which_first], legs2[which_first],
-                            relabel1=relabel1, relabel2=relabel2)
-            # legs1[which_second] is not at position 0, legs2[which_second] has not moved
-            return res.trace(0, legs2[which_second])
-        # now we know that exactly one leg should be contracted
-        backend = get_same_backend(self, other)
-        if isinstance(other, Mask):
-            if legs2[0] == 1:
-                # OPTIMIZE ? dont need to convert to full but its easier for now
-                return self.tdot(other.as_Tensor(), legs1=legs1, legs2=legs2, relabel1=relabel1, relabel2=relabel2)
-            # else: legs2[0] == 0, i.e. we contract the large leg of the Mask
-            new_label = other.labels[1]
-            if relabel1 is not None:
-                new_label = relabel1.get(new_label, new_label)
-            res = self.apply_mask(other, leg=legs1[0], new_label=new_label)
-            res = res.permute_legs(legs1)
-            if relabel2 is not None:
-                res.set_labels([relabel2.get(res.labels[0], res.labels[0]), res.labels[-1]])
-            return res
-        if isinstance(other, DiagonalTensor):
-            # note that contractible legs guarantee that self.legs[0] and other.legs[0] are either
-            # equal or mutually dual and we can safely use elementwise_binary, no matter which of
-            # the legs are actually contracted.
-            return DiagonalTensor(
-                data=backend.diagonal_elementwise_binary(self, other, operator.mul, partial_zero_is_zero=True),
-                first_leg=self.legs[1 - legs1[0]],
-                second_leg_dual=(self.second_leg_dual == other.second_leg_dual),
-                backend=backend,
-                labels=[self.labels[1 - legs1[0]], other.labels[1 - legs2[0]]]
-            )
-        if isinstance(other, BlockDiagonalTensor):
-            res = BlockDiagonalTensor(
-                data=backend.scale_axis(other, self, leg=legs2[0]),
-                legs=other.legs[:legs2[0]] + [self.legs[1 - legs1[0]]] + other.legs[legs2[0] + 1:],
-                num_domain_legs=other.num_domain_legs,  # TODO this correct?
-                backend=backend,
-                labels=other.labels[:legs2[0]] + [self.labels[1 - legs1[0]]] + other.labels[legs2[0] + 1:]
-            )
-            # move scaled leg to the front
-            return res.permute_legs([legs2[0]] + list(range(legs2[0])) + list(range(legs2[0] + 1, res.num_legs)))
-            
-        raise TypeError(f'tdot not supported for {type(self)} and {type(other)}')
-
-    def _add_tensor(self, other: Tensor) -> Tensor:
-        if isinstance(other, BlockDiagonalTensor):
-            return self.as_Tensor()._add_tensor(other)
-        if isinstance(other, DiagonalTensor):
-            other_order = self._input_checks_same_legs(other)
-            # by definition, permuting the legs does nothing to a DiagonalTensors data
-            backend = get_same_backend(self, other)
-            return DiagonalTensor(backend.add(self, other), first_leg=self.legs[0],
-                                  second_leg_dual=self.second_leg_dual, backend=backend,
-                                  labels=self.labels)
-        raise TypeError(f"unsupported operand type(s) for +: 'Tensor' and '{type(other)}'")
+    def to_dense_block(self, leg_order: list[int | str] = None, dtype: Dtype = None) -> Block:
+        diag = self.diagonal_as_block(dtype=dtype)
+        res = self.backend.block_from_diagonal(diag)
+        if leg_order is not None:
+            res = self.backend.block_permute_axes(res, self.get_leg_idcs(leg_order))
+        return res
 
 
 class Mask(Tensor):
     r"""A boolean mask that can be used to project a leg.
 
-    Projecting a leg can be done via `tdot`, which views the projection, which is a linear map,
-    as an :class:`Tensor`. Then, it can only project the :attr:`large_leg`.
-    Using :meth:`Tensor.apply_mask` on the other hand allows a mask to be applied either
-    to :attr:`large_leg` or its dual.
+    A mask is a special kind of projection map, that either keeps or discards any given sector.
+
+    TODO think in detail about the basis_perm and how it interacts with masking...
 
     Parameters
     ----------
     data
         The numerical data (i.e. boolean flags) comprising the mask. type is backend-specific.
         Should have boolean dtype.
-    large_leg : Space
+    large_leg: Space
         The larger leg that can be projected with this mask.
-        The resulting mask has `mask.legs[0] == large_leg.dual`, which can be contracted with
-        the `large_leg`.
-    small_leg : ElementarySpace
-        FIXME condition for duality
-        The small leg, i.e. the masked / projected version of `large_leg`.
-        Should have same :attr:`ElementarySpace.is_dual` as `large_leg`.
-    backend: :class:`~tenpy.linalg.backends.abstract_backend.Backend`, optional
-        The backend for the Tensor
-    labels : list[str | None] | None
-        Labels for the legs. If None, translates to ``[None, None, ...]`` of appropriate length
+        This is the only leg in the domain.
+    small_leg: Space
+        The small leg, i.e. the masked/projected `large_leg`.
+        This is the only leg in the codomain. Should have same :attr:`Space.is_bra_space` as the
+        `large_leg`.
+    backend: Backend, optional
+        The backend of the tensor.
+    labels: list[list[str | None]] | list[str | None] | None
+        Specify the labels for the legs.
+        Can either give two lists, one for the codomain, one for the domain.
+        Or a single flat list for all legs in the order of the :attr:`legs`,
+        such that ``[codomain_labels, domain_labels]`` is equivalent
+        to ``[*codomain_legs, *reversed(domain_legs)]``.
     """
-    def __init__(self, data, large_leg: Space, small_leg: ElementarySpace, backend=None,
-                 labels: list[str | None] = None):
-        assert small_leg.is_subspace_of(large_leg.as_ElementarySpace())
+    _forbidden_dtypes = [Dtype.float32, Dtype.float64, Dtype.complex64, Dtype.complex128]
+    
+    def __init__(self, data, large_leg: Space, small_leg: Space, backend: Backend | None = None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
+        # TODO remove tests after developing?
+        assert isinstance(data, self.backend.DataCls)
+        assert small_leg.is_subspace_of(large_leg)
+        assert small_leg.is_bra_space == large_leg.is_bra_space
+        assert isinstance(small_leg, Space)
+        Tensor.__init__(self, codomain=[small_leg], domain=[large_leg], backend=backend,
+                        labels=labels, dtype=Dtype.bool)
         self.data = data
-        if backend is None:
-            backend = get_backend(large_leg.symmetry)
-        Tensor.__init__(self, legs=[large_leg.dual, small_leg], backend=backend, labels=labels,
-                        dtype=Dtype.bool, num_domain_legs=1)
 
-    def test_sanity(self) -> None:
+    def test_sanity(self):
         super().test_sanity()
         self.backend.test_mask_sanity(self)
-        assert self.large_leg.is_dual == self.small_leg.is_dual
+        assert self.codomain.num_spaces == 1 == self.domain.num_spaces
+        assert self.large_leg.is_bra_space == self.small_leg.is_bra_space
         assert self.small_leg.is_subspace_of(self.large_leg)
         assert self.dtype == Dtype.bool
 
-    # --------------------------------------------
-    # Additional methods (not in Tensor)
-    # --------------------------------------------
-
-    @property
-    def blockmask(self) -> Block:
-        """1D block of bools, indicating which basis elements are kept."""
-        return self.backend.diagonal_to_block(self)
-    
     @property
     def large_leg(self) -> Space:
-        """The large leg that can be projected using this mask."""
-        return self.legs[0].dual
+        return self.domain.spaces[0]
 
     @property
-    def numpymask(self) -> np.ndarray:
-        """1D numpy array of bools, indicating which basis elements are kept."""
-        return self.backend.block_to_numpy(self.blockmask)
-
-    @property
-    def small_leg(self) -> ElementarySpace:
-        """The slice of :attr:`large_leg` that the mask projects to."""
-        return self.legs[1]
+    def small_leg(self) -> Space:
+        return self.codomain.spaces[0]
 
     @classmethod
-    def eye(cls, large_leg: Space, backend=None, labels: list[str | None] = None) -> Mask:
-        """The identity mask, that keeps all basis elements."""
-        # OPTIMIZE
-        return cls.from_blockmask(np.ones(large_leg.dim, dtype=bool), large_leg=large_leg,
-                                  backend=backend, labels=labels)
-
-    @classmethod
-    def from_blockmask(cls, blockmask: Block, large_leg: Space, backend: Backend = None,
-                   labels: list[str | None] = None) -> Mask:
-        """Create a Mask from a 1D boolean block.
-
-        TODO find a better word than blockmask. Use it everywhere else too.
-             We need to distinguish the concepts of the 2D rectangular block and this 1D blockmask.
-             Consider renaming numpymask property too.
+    def from_eye(cls, large_leg: Space, backend: Backend | None = None,
+                 labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
+        """The identity map as a Mask, i.e. the mask that keeps everything and discard nothing.
 
         Parameters
         ----------
-        blockmask : 1D Block-like of bool
-            A block with boolean entries, where ``blockmask[i]`` indicates if the ``i``-th element
-            of the computational basis of `large_leg` should be kept.
-        large_leg, backend, labels
-            Same as for :meth:`Mask.__init__`.
+        large_leg, backend, labels:
+            Arguments, like for constructor of :class:`Mask`.
         """
-        small_leg = large_leg.take_slice(np.asarray(blockmask, bool))
+        codomain, domain, backend, symmetry = cls._init_parse_args(
+            codomain=[large_leg], domain=[large_leg], backend=backend
+        )
+        data = backend.diagonal_from_sector_block_func(
+            lambda shape, coupled: backend.ones_block(shape, dtype=Dtype.bool),
+            co_domain=codomain
+        )
+        return Mask(data, large_leg=large_leg, small_leg=large_leg, backend=backend, labels=labels)
+
+    @classmethod
+    def from_block_mask(cls, block_mask: Block, large_leg: Space, backend: Backend | None = None,
+                        labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
+        if not large_leg.symmetry.can_be_dropped:
+            raise SymmetryError
         if backend is None:
             backend = get_backend(symmetry=large_leg.symmetry)
-        blockmask = backend.block_to_dtype(backend.as_block(blockmask), Dtype.bool)
-        return cls(backend.mask_from_block(blockmask, large_leg=large_leg, small_leg=small_leg),
-                   large_leg=large_leg, small_leg=small_leg, backend=backend, labels=labels)
+        small_leg = large_leg.take_slice(np.asarray(block_mask, bool))
+        block_mask = backend.as_block(block_mask, Dtype.bool)
+        return cls(
+            data=backend.mask_from_block(block_mask, large_leg=large_leg, small_leg=small_leg),
+            large_leg=large_leg, small_leg=small_leg, backend=backend, labels=labels
+        )
 
     @classmethod
-    def from_DiagonalTensor(cls, diag: DiagonalTensor) -> Mask:
-        """Create a Mask from a bool-valued DiagonalTensor"""
-        # OPTIMIZE could do this "directly", without converting to block, but its easier for now...
-        return cls.from_blockmask(diag.backend.block_to_dtype(diag.diag_block, Dtype.bool),
-                                  large_leg=diag.legs[0], backend=diag.backend, labels=diag.labels)
+    def from_DiagonalTensor(cls, diag: DiagonalTensor):
+        assert diag.dtype == Dtype.bool
+        data, small_leg = diag.backend.diagonal_to_mask(diag)
+        return cls(
+            data=data, large_leg=diag.domain.spaces[0], small_leg=small_leg, backend=diag.backend,
+            labels=diag.labels
+        )
 
     @classmethod
-    def from_indices(cls, indices: int | list[int] | np.ndarray | slice, large_leg: Space,
-                     backend: Backend = None, labels: list[str | None] = None) -> Mask:
+    def from_indices(cls, indices: int | Sequence[int] | slice, large_leg: Space,
+                     backend: Backend = None,
+                     labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
         """Create a Mask from the indices that are kept.
 
         Parameters
@@ -3076,38 +1448,107 @@ class Mask(Tensor):
         large_leg, backend, labels
             Same as for :meth:`Mask.__init__`.
         """
-        mask = np.zeros(large_leg.dim, dtype=bool)
-        mask[indices] = True
-        return cls.from_blockmask(mask, large_leg=large_leg, backend=backend, labels=labels)
+        block_mask = np.zeros(large_leg.dim, bool)
+        block_mask[indices] = True
+        return cls.from_block_mask(block_mask, large_leg=large_leg, backend=backend, labels=labels)
 
+    @classmethod
+    def from_random(cls, large_leg: Space, small_leg: Space | None = None,
+                    backend: Backend | None = None, p_keep: float = .5,
+                    labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                    np_random: np.random.Generator = np.random.default_rng()):
+        """Create a random Mask."""
+        
+        if backend is None:
+            backend = get_backend(symmetry=large_leg.symmetry)
+            
+        if small_leg is None:
+            diag = DiagonalTensor.from_random_uniform(large_leg, backend=backend, labels=labels,
+                                                      dtype=Dtype.float64)
+            cutoff = 2 * p_keep - 1  # diagonal entries are uniform in [-1, 1].
+            return cls.from_DiagonalTensor(diag < cutoff)
+
+        def func(shape, coupled):
+            num_keep = small_leg.sector_multiplicity(coupled)
+            block = np.zeros(shape, bool)
+            which = np_random.choice(shape[0], size=num_keep, replace=False)
+            block[which] = True
+            return block
+
+        diag = DiagonalTensor.from_sector_block_func(
+            func, leg=large_leg, backend=backend, labels=labels, dtype=Dtype.bool
+        )
+        return cls.from_DiagonalTensor(diag)
+
+    @classmethod
+    def from_zero(cls, large_leg: Space, backend: Backend | None = None,
+                  labels: Sequence[list[str | None] | None] | list[str | None] | None = None):
+        if backend is None:
+            backend = get_backend(symmetry=large_leg.symmetry)
+        data = backend.zero_diagonal_data(leg=large_leg, dtype=Dtype.bool)
+        small_leg = Space.from_null_space(symmetry=large_leg.symmetry,
+                                                    is_dual=large_leg.is_bra_space)
+        return Mask(data, large_leg=large_leg, small_leg=small_leg, backend=backend, labels=labels)
+
+    def __bool__(self):
+        if is_scalar(self):
+            return bool(self.item())
+        msg = 'The truth value of a non-scalar DiagonalTensor is ambiguous. Use a.any() or a.all()'
+        raise ValueError(msg)
+    
     def all(self) -> bool:
         """If the mask keeps all basis elements"""
-        return self.small_leg.dim == self.large_leg.dim
+        return self.small_leg.num_parameters == self.large_leg.num_parameters
 
     def any(self) -> bool:
         """If the mask keeps any basis elements"""
         return self.small_leg.dim > 0
 
-    def as_Tensor(self, dtype=Dtype.float64) -> BlockDiagonalTensor:
-        return BlockDiagonalTensor(
-            data=self.backend.full_data_from_mask(self, dtype=dtype),
-            legs=self.legs, num_domain_legs=1, backend=self.backend, labels=self.labels
-        )
+    def as_block_mask(self) -> Block:
+        return self.backend.diagonal_to_block(self)
 
-    def same_mask(self, other: Mask) -> bool:
-        return (self.large_leg == other.large_leg) and Mask.all(self == other)
+    def as_numpy_mask(self) -> np.ndarray:
+        return self.backend.block_to_numpy(self.as_block_mask(), numpy_dtype=bool)
 
-    def logical_not(self) -> Mask:
-        """The opposite mask that keeps exactly what self discard.
+    def as_DiagonalTensor(self, dtype=Dtype.complex128) -> DiagonalTensor:
+        return DiagonalTensor(data=self.data, leg=self.large_leg, backend=self.backend,
+                              labels=self.labels)
 
-        Viewing masks as projectors, this is the orthogonal complement.
-        """
-        # OPTIMIZE
-        return Mask.from_blockmask(~self.blockmask, large_leg=self.large_leg,
-                                   backend=self.backend, labels=self.labels)
+    def as_SymmetricTensor(self, dtype=Dtype.complex128) -> SymmetricTensor:
+        return self.as_DiagonalTensor(dtype=dtype).as_SymmetricTensor()
 
-    def _binary_operand(self, other: bool | Mask, func, operand: str, return_NotImplemented: bool = True
-                        ) -> Mask:
+    def copy(self, deep=True) -> Mask:
+        if deep:
+            data = self.backend.copy_data(self)
+        else:
+            data = self.data
+        return Mask(data, large_leg=self.large_leg, small_leg=self.small_leg, backend=self.backend,
+                    labels=self.labels)
+
+    def to_dense_block(self, leg_order: list[int | str] = None, dtype: Dtype = None) -> Block:
+        # for Mask, defining via numpy is actually easier, to use numpy indexing
+        numpy_dtype = None if dtype is None else dtype.to_numpy_dtype()
+        as_numpy = self.to_numpy(leg_order=leg_order, numpy_dtype=numpy_dtype)
+        return self.backend.as_block(as_numpy, dtype=dtype)
+
+    def to_numpy(self, leg_order: list[int | str] = None, numpy_dtype=None) -> np.ndarray:
+        assert self.symmetry.can_be_dropped
+        M = self.large_leg.dim
+        n = self.small_leg.dim
+        mask = self.as_numpy_mask()
+        res = np.zeros((M, n), numpy_dtype or bool)
+        res[mask, np.arange(n)] = 1
+        if leg_order is not None:
+            res = np.transpose(res, self.get_leg_idcs(leg_order))
+        return res
+
+    def _unary_operand(self, func) -> Mask:
+        data, small_leg = self.backend.mask_unary_operand(self, func)
+        return Mask(data, large_leg=self.large_leg, small_leg=small_leg, backend=self.backend,
+                    labels=self.labels)
+
+    def _binary_operand(self, other: bool | Mask, func, operand: str,
+                        return_NotImplemented: bool = True) -> Mask:
         """Utility function for a shared implementation of binary functions, whose second argument
         may be a scalar ("to be broadcast") or a Mask.
 
@@ -3124,637 +1565,342 @@ class Mask(Tensor):
             Whether `NotImplemented` should be returned on a non-scalar and non-`Tensor` other.
         """
         if isinstance(other, bool):
-            backend = backend
-            data = self.backend.diagonal_elementwise_unary(self, lambda block: func(block, other),
-                                                           func_kwargs={}, maps_zero_to_zero=False)
-            return Mask(data, large_leg=self.large_leg, small_leg=None, backend=backend,
-                        labels=self.labels)
+            return self._unary_operand(lambda block: func(block, other))
+        
         elif isinstance(other, Mask):
             backend = get_same_backend(self, other)
-            if self.legs[0] != other.legs[0]:
-                raise ValueError('Incompatible legs!')
-            # OPTIMIZE
-            return Mask.from_blockmask(func(self.blockmask, other.blockmask),
-                                       large_leg=self.large_leg, backend=backend,
-                                       labels=_get_same_labels(self.labels, other.labels))
+            if self.domain != other.domain:
+                raise ValueError('Incompatible domain.')
+            data, small_leg = backend.mask_binary_operand(self, other, func)
+            return Mask(data, large_leg=self.large_leg, small_leg=small_leg, backend=backend,
+                        labels=_get_matching_labels(self.labels, other.labels))
         elif return_NotImplemented and not isinstance(other, (Tensor, Number)):
             return NotImplemented
         msg = f'Invalid types for operand "{operand}": {type(self)} and {type(other)}'
         raise TypeError(msg)
 
-    def __and__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.and_, operand='&')
-
-    def __bool__(self):
-        raise ValueError('The truth value of a mask is undefined. Use Mask.any() or Mask.all().')
-
-    def __eq__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.eq, operand='==')
-
-    def __ne__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.ne, operand='!=')
-
-    def __rand__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.and_, operand='&')
-
-    def __ror__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.or_, operand='|')
-
-    def __rxor__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.xor, operand='^')
-
-    def __or__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.or_, operand='|')
-
-    def __xor__(self, other) -> bool:
-        return self._binary_operand(other, func=operator.xor, operand='^')
-
-    # --------------------------------------------
-    # Overriding methods from Tensor
-    # --------------------------------------------
-
-    def __getitem__(self, idcs):
-        # TODO what even is the expected behavior here?
-        raise NotImplementedError
-
-    def __setitem__(self, idcs, value):
-        # TODO what even is the expected behavior here?
-        raise NotImplementedError
-
-    # --------------------------------------------
-    # Implementing abstractmethods
-    # --------------------------------------------
-    
-    @classmethod
-    def zero(cls, large_leg: Space, backend=None, labels: list[str | None] = None) -> Mask:
-        """The zero mask, that discards all basis elements."""
-        if backend is None:
-            backend = get_backend(symmetry=large_leg.symmetry)
-        data = backend.zero_diagonal_data(leg=large_leg, dtype=Dtype.bool)
-        
-        small_leg = ElementarySpace.from_null_space(symmetry=large_leg.symmetry, is_dual=large_leg.is_bra_space)
-        return cls(data=data, large_leg=large_leg, small_leg=small_leg, backend=backend)
-
-    def add_trivial_leg(self, label: str = None, is_dual: bool = False, pos: int = -1,
-                        to_domain: bool = None) -> DiagonalTensor:
-        raise TypeError(f'add_trivial_leg not supported for types {type(self)}.')
-
-    def apply_mask(self, mask: Mask, leg: int | str) -> Mask:
-        # in principle, this is possible. it is cumbersome though, and i dont think we need it.
-        raise TypeError('apply_mask() is not supported for Mask')
-
-    def combine_legs(self, *legs: list[int | str],
-                     product_spaces: list[ProductSpace] = None,
-                     product_spaces_dual: list[bool] = None,
-                     new_axes: list[int] = None,
-                     new_labels: list[str | None] = None) -> BlockDiagonalTensor:
-        """See :func:`tenpy.linalg.tensors.combine_legs`."""
-        msg = 'Converting Mask to full Tensor for `combine_legs`. If this is what you wanted, ' \
-              'explicitly convert via Mask.as_Tensor() first to suppress the warning.'
-        warnings.warn(msg, stacklevel=2)
-        return self.as_Tensor().combine_legs(
-            *legs, product_spaces=product_spaces, product_spaces_dual=product_spaces_dual,
-            new_axes=new_axes, new_labels=new_labels
-        )
-
-    def conj(self) -> Mask:
-        return self
-
-    def copy(self, deep=True) -> Mask:
-        if deep:
-            return Mask(data=self.backend.copy_data(self.data),
-                        small_legs=self.legs[0],
-                        large_leg=self.legs[1],
-                        backend=self.backend,
-                        labels=self.labels[:])
-        return Mask(data=self.data,
-                    small_legs=self.legs[0],
-                    large_leg=self.legs[1],
-                    backend=self.backend,
+    def _unary_operand(self, func) -> Mask:
+        data, small_leg = self.backend.mask_unary_operand(self, func)
+        return Mask(data, large_leg=self.large_leg, small_leg=small_leg, backend=self.backend,
                     labels=self.labels)
 
-    def item(self) -> bool:
-        if self.large_leg.dim == 1:
-            return self.backend.item(self)
-        raise ValueError('Not a scalar')
+    def __and__(self, other):  # ``self & other``
+        return self._binary_operand(other, operator.and_, '==')
 
-    def norm(self, order=None) -> float:
-        num_true_entries = self.small_leg.dim
-        if order is None:
-            return float(np.sqrt(num_true_entries))
-        if order >= np.inf:
-            return 1. if num_true_entries > 0 else 0.
-        if order <= -np.inf:
-            return 0. if num_true_entries < self.large_leg.dim else 1.
-        if order == 0:
-            return num_true_entries
-        return num_true_entries ** (1. / order)
+    def __eq__(self, other):  # ``self == other``
+        return self._binary_operand(other, func=operator.eq, operand='==')
 
-    def permute_legs(self, permutation: list[int] = None, num_domain_legs: int = None) -> BlockDiagonalTensor:
-        msg = 'Converting Mask to full Tensor for `permute_legs`. If this is what you wanted, ' \
-              'explicitly convert via Mask.as_Tensor() first to suppress the warning.'
-        warnings.warn(msg, stacklevel=2)
-        return self.as_Tensor().permute_legs(permutation, num_domain_legs=num_domain_legs)
+    def __invert__(self):  # ``~self``
+        return self._unary_operand(operator.invert)
 
-    def split_legs(self, legs: list[int | str] = None) -> NoReturn:
-        msg = 'Converting Mask to full Tensor for `split_legs`. If this is what you wanted, ' \
-              'explicitly convert via Mask.as_Tensor() first to suppress the warning.'
-        warnings.warn(msg, stacklevel=2)
-        return self.as_Tensor().permute_legs(legs)
+    def __ne__(self, other):  # ``self != other``
+        return self._binary_operand(other, func=operator.ne, operand='!=')
 
-    def squeeze_legs(self, legs: int | str | list[int | str] = None) -> BlockDiagonalTensor:
-        msg = 'Converting Mask to full Tensor for `squeeze_legs`. If this is what you wanted, ' \
-              'explicitly convert via Mask.as_Tensor() first to suppress the warning.'
-        warnings.warn(msg, stacklevel=2)
-        return self.as_Tensor().squeeze_legs(legs)
+    def __rand__(self, other):  # ``other & self``
+        return self._binary_operand(other, func=operator.and_, operand='&')
 
-    def to_dense_block(self, leg_order: list[int | str] = None) -> Block:
-        # OPTIMIZE a dedicated implementation could be slightly more efficient
-        return self.as_Tensor().to_dense_block(leg_order)
+    def __ror__(self, other):  # ``other | self``
+        return self._binary_operand(other, func=operator.or_, operand='|')
 
-    def trace(self, *a, **k) -> NoReturn:
-        raise TypeError('Can not perform trace of a Mask, they are not square.')
+    def __rxor__(self, other):  # ``other ^ self``
+        return self._binary_operand(other, func=operator.xor, operand='^')
 
-    def _get_element(self, idcs: list[int]) -> bool:
-        raise NotImplementedError  # TODO
+    def __or__(self, other):  # ``self | other``
+        return self._binary_operand(other, func=operator.or_, operand='|')
 
-    def _set_element(self, idcs: list[int], value: bool) -> None:
-        assert isinstance(value, bool)
-        raise NotImplementedError  # TODO
+    def __xor__(self, other):  # ``self ^ other``
+        return self._binary_operand(other, func=operator.xor, operand='^')
 
-    def _mul_scalar(self, other: Number) -> Mask:
-        if isinstance(other, bool):
-            return self.__and__(other)
-        raise TypeError(f'Can not multiply Mask with {type(other)}.')
+    def logical_not(self):
+        """The "opposite" Mask, that keeps exactly what self discards and vv."""
+        return self._unary_operand(operator.invert)
 
-    # --------------------------------------------
-    # Implementing binary tensor methods
-    # --------------------------------------------
 
-    def almost_equal(self, other: Tensor, atol: float = 1e-5, rtol: float = 1e-8,
-                     allow_different_types: bool = False) -> bool:
-        if isinstance(other, Mask):
-            return self.same_mask(other)
-        raise TypeError(f'almost_equal not supported for types {type(self)} and {type(other)}.')
+class ChargedTensor(Tensor):
+    r"""Tensors which transform non-trivially under a symmetry.
 
-    def inner(self, other: Tensor, do_conj: bool = True, legs1: list[int | str] = None,
-              legs2: list[int | str]  = None) -> float | complex:
-        leg_order_2 = self._input_checks_inner(other, do_conj=do_conj, legs1=legs1, legs2=legs2)
-        if isinstance(other, Mask):
-            return self.__and__(other).small_leg.dim
-        else:
-            return other.apply_mask(self, leg=leg_order_2[0]).trace()
+    The non-trivial transformation is achieved by adding a "charged" extra leg.
+    As discussed in :ref:`tensors_as_map`, we  can view symmetric tensors :math:`T` in a tensor
+    space :math:`V_1 \otimes V_2 \otimes V_3` with ``legs == [V1, V2, V3]`` as a map
+    :math:`\Cbb \to V_1 \otimes V_2 \otimes V_3, \alpha \mapsto \alpha T`, we define charged tensors
+    with ``legs == [V1, V2, V3]`` as maps :math:`C \to V_1 \otimes V_2 \otimes V_3`.
+    Note that the :attr:`charge_leg` :math:`C` is not one of the :attr:`legs`.
 
-    def outer(self, other: Tensor, relabel1: dict[str, str] = None,
-              relabel2: dict[str, str] = None) -> Tensor:
-        raise TypeError(f'outer not supported for {type(self)} and {type(other)}')
+    The above examples had empty :attr:`domain`s. We can also consider
+    ``domain == [V3, V4]`` and ``codomain == [V1, V2]``, i.e. with ``legs == [V1, V2, V4.dual, V3.dual]``.
+    For a symmetric tensor, this is a map :math:`V_3 \otimes V_4 \to V_1 \otimes V_2`.
+    We understand a charged tensors with these attributes to be a map
+    :math:`C \otimes V_3 \otimes V_4 \to V_1 \otimes V_2`.
 
-    def tdot(self, other: Tensor, legs1: int | str | list[int | str] = -1,
-             legs2: int | str | list[int | str] = 0, relabel1: dict[str, str] = None,
-             relabel2: dict[str, str] = None) -> Tensor | float | complex:
-        legs1, legs2 = self._input_checks_tdot(other, legs1, legs2)
-        if len(legs1) == 1:
-            if legs1[0] == 0:  # contracting the large leg
-                new_label = self.labels[1]
-                if relabel1 is not None:
-                    new_label = relabel1.get(new_label, new_label)
-                res = other.apply_mask(self, legs2[0], new_label=new_label)
-                res = res.permute_legs(legs2 + [n for n in range(res.num_legs) if n not in legs2])
-                if relabel2 is not None:
-                    res.set_labels([res.labels[0]] + [relabel2.get(l, l) for l in res.labels[1:]])
-                return res
-            
-            # OPTIMIZE the remaining case could be done more efficiently, by inserting zero-slice wherever the mask is False
-            return self.as_Tensor().tdot(other, legs1, legs2, relabel1, relabel2)
-        if len(legs1) == 0:
-            raise TypeError(f'tdot with no contracted legs (i.e. outer) not supported for {type(self)} and {type(other)}')
-        if len(legs1) == 2:
-            large_leg_idx = legs1[0]  # since legs1 is [0, 1] or [1, 0], legs1[legs1[0]] == 0 is the large leg
-            res = other.apply_mask(self, legs2[large_leg_idx])
-            res = res.trace(*legs2)
-            if relabel2 is not None:
-                res.set_labels([relabel2.get(l, l) for l in res.labels])
+    We represent charged tensors as a composite object, consisting of an :attr:`invariant_part`
+    and an optional :attr:`charge_state`. The invariant part is a symmetric tensor, which
+    includes the :attr:`charge_leg` :math:`C` as its ``invariant_part.domain.spaces[0]``,
+    and therefore has ``invariant_part.legs[-1] == C.dual``.
+    Such that in the above examples we have ``invariant_part1.legs == [V1, V2, V3, C.dual]``
+    and ``invariant_part2.legs == [V1, V2, V4.dual, V3.dual, C.dual]``.
+    
+    If the symmetry :attr:`Symmetry.can_be_dropped`, a specific state on the charge leg can be
+    specified as a dense block. For example, consider an SU(2) symmetry and a charge leg :math:`C`,
+    which is a spin-1 space. Then, a block of length ``(3,)`` can be specified selecting a state
+    from the three-dimensional space. The contraction with the :attr:`charged_state` (which is not
+    symmetric and hence not a tensor!) is kept track of only symbolically, i.e. all operations
+    are performed on the symmetric :attr:`invariant_part` until e.g. :meth:`item` is called.
+
+    Typical examples for charged tensors are local operators that do not conserve the charge,
+    but have a well defined mapping, i.e. they map from one sector to a single other sector.
+    Consider for example a U(1) symmetry which conserves the boson particle number and the
+    integer sectors label that particle number. Then, the boson creation operator :math:`b^\dagger`
+    can be written as a charged tensor with charge leg
+    ``C == ElementarySpace(u1_sym, sectors=[[+1]])``.
+    Similarly, if the Sz magnetization of a spin system is conserved, the spin raising operator
+    can be written only as a charged tensor.
+
+    Charged tensors with unspecified charged state can also be used to "hide" an extra leg
+    from functions and algorithms and be retrieved later. This allows, for example, to evaluate
+    correlation functions of more general operators, such as e.g.
+    simulating :math:`\langle S_i^x(t) S_j^x(0) \rangle` with :math:`S^z` conservation.
+    The :math:`S^x` operator, when using :math:`S^z` conservation, is a `ChargedTensor` with a
+    two-dimensional charge leg. But, for the correlation function, we do not actually need a state
+    for that leg, we just need to contract it with the charge leg of the other :math:`S^x`, after
+    having time-evolved :math:`S_j^x(0) \ket{\psi_0}`.
+    TODO revisit this paragraph, do we actually support doing that? 
+    
+    Parameters
+    ----------
+    invariant_part:
+        The symmetry-invariant part. the charge leg is the its ``domain.spaces[0]``.
+    charged_state: block | None
+        Either ``None``, or a backend-specific block of shape ``(charge_leg.dim,)``, which specifies
+        a state on the charge leg (see notes above).
+    """
+    
+    _CHARGE_LEG_LABEL = '!'  # canonical label for the charge leg
+    def __init__(self, invariant_part: SymmetricTensor, charged_state: Block | None):
+        assert invariant_part.domain.num_spaces > 0, 'domain must contain at least the charge leg'
+        self.charge_leg = invariant_part.domain.spaces[0]
+        assert invariant_part._labels[-1] == self._CHARGE_LEG_LABEL, 'incorrect label on charge leg'
+        if charged_state is not None:
+            if not invariant_part.symmetry.can_be_dropped:
+                msg = f'charged_state can not be specified for symmetry {invariant_part.symmetry}'
+                raise SymmetryError(msg)
+            charged_state = invariant_part.backend.as_block(
+                charged_state, invariant_part.dtype
+            )
+        self.charged_state = charged_state
+        self.invariant_part = invariant_part
+        Tensor.__init__(
+            self,
+            codomain=invariant_part.codomain,
+            domain=ProductSpace(
+                invariant_part.domain.spaces[1:], symmetry=invariant_part.symmetry,
+                backend=invariant_part.backend
+            ),
+            backend=invariant_part.backend,
+            labels=invariant_part._labels[:-1],
+            dtype=invariant_part.dtype
+        )
+
+    def test_sanity(self):
+        super().test_sanity()
+        self.invariant_part.test_sanity()
+        if self.charged_state is not None:
+            assert self.backend.block_shape(self.charged_state) == (self.charge_leg.dim,)
+
+    @staticmethod
+    def _parse_inv_domain(domain: ProductSpace, charge: Space | Sector | Sequence[int],
+                          backend: Backend) -> tuple[ProductSpace, Space]:
+        """Helper function to build the domain of the invariant part.
+
+        Parameters
+        ----------
+        domain: ProductSpace
+            The domain of the ChargedTensor
+        charge: Space | SectorLike
+            Specification for the charge_leg, either as a space or a single sector
+        backend: Backend
+            The backend, used for building the output ProductSpace.
+
+        Returns
+        -------
+        inv_domain: ProductSpace
+            The domain of the invariant part
+        charge_leg: Space
+            The charge_leg of the resulting ChargedTensor
+        """
+        assert isinstance(domain, ProductSpace), 'call _init_parse_args first?'
+        if not isinstance(charge, Space):
+            sectors = np.asarray(charge, int)[None, :]
+            charge = Space(domain.symmetry, sectors)
+        return domain.left_multiply(charge, backend=backend)
+
+    @staticmethod
+    def _parse_inv_labels(labels: Sequence[list[str | None] | None] | list[str | None] | None,
+                          codomain: ProductSpace, domain: ProductSpace):
+        """Utility like :meth:`_init_parse_labels`, but also returns the labels for the invariant
+        part."""
+        labels = ChargedTensor._init_parse_labels(labels, codomain, domain)
+        inv_labels = labels + [ChargedTensor._CHARGE_LEG_LABEL]
+        return labels, inv_labels
+
+    @classmethod
+    def from_block_func(cls, func,
+                        charge: Space | Sector,
+                        codomain: ProductSpace | list[Space],
+                        domain: ProductSpace | list[Space] | None = None,
+                        charged_state: Block | None = None,
+                        backend: Backend | None = None,
+                        labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                        func_kwargs: dict = None,
+                        shape_kw: str = None,
+                        dtype: Dtype = None,):
+        """Create a charged tensor with inv_part from :meth:`SymmetricTensor.from_block_func`.
+
+        Parameters
+        ----------
+        func, codomain, backend, labels, func_kwargs, shape_kw, dtype
+            Like the arguments for :meth:`SymmetricTensor.from_block_func`.
+        domain
+            The domain of the resulting charged tensor. Its invariant part has the additional
+            charged leg in the domain.
+        charge: Space | Sector-like
+            The charged leg. A single sector is equivalent to a space consisting of only that sector.
+        charged_state: Block-like | None
+            Argument for constructor of :class:`ChargedTensor`.
+        """
+        codomain, domain, backend, symmetry = cls._init_parse_args(codomain, domain, backend)
+        inv_domain, charge_leg = cls._parse_inv_domain(domain=domain, charge=charge, backend=backend)
+        inv = SymmetricTensor.from_block_func(
+            func=func, codomain=codomain, domain=inv_domain, backend=backend, labels=labels,
+            func_kwargs=func_kwargs, shape_kw=shape_kw, dtype=dtype
+        )
+        return ChargedTensor(inv, charged_state)
+
+    @classmethod
+    def from_dense_block(cls, block: Block,
+                         codomain: ProductSpace | list[Space],
+                         domain: ProductSpace | list[Space] | None = None,
+                         charge: Space | Sector | None = None,
+                         backend: Backend | None = None,
+                         labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                         dtype: Dtype = None,
+                         tol: float = 1e-6
+                         ):
+        """Convert a dense block of to a ChargedTensor, if possible.
+
+        Parameters
+        ----------
+        block : Block-like
+            The data to be converted to a ChargedTensor as a backend-specific block or some data
+            that can be converted using :meth:`BlockBackend.as_block`.
+            This includes e.g. nested python iterables or numpy arrays.
+            The order of axes should match the :attr:`Tensor.legs`, i.e. first the codomain legs,
+            then the domain leg *in reverse order*.
+            The block should be given in the "public" basis order of the `legs`, e.g.
+            according to :attr:`ElementarySpace.sectors_of_basis`.
+        codomain, domain, backend, labels
+            Arguments, like for constructor of :class:`SymmetricTensor`.
+        dtype: Dtype, optional
+        If given, the block is converted to that dtype and the resulting tensor will have that
+            dtype. By default, we detect the dtype from the block.
+        """
+        codomain, domain, backend, symmetry = cls._init_parse_args(codomain, domain, backend)
+        labels, inv_labels = cls._parse_inv_labels(labels, codomain, domain)
+        if not symmetry.can_be_dropped:
+            raise SymmetryError
+        block, dtype = backend.as_block(block, dtype, return_dtype=True)
+        inv_domain, charge_leg = cls._parse_inv_domain(domain=domain, charge=charge, backend=backend)
+        if charge_leg.dim != 1:
+            raise NotImplementedError  # TODO
+        inv_part = SymmetricTensor.from_dense_block(
+            block=backend.add_axis(block, -1),
+            codomain=codomain, domain=inv_domain, backend=backend, labels=inv_labels, dtype=dtype,
+            tol=tol
+        )
+        return cls(inv_part, charged_state=[1])
+
+    @classmethod
+    def from_dense_block_single_sector(cls, vector: Block, space: Space, sector: Sector,
+                                       backend: Backend | None = None, label: str | None = None
+                                       ) -> ChargedTensor:
+        """Given a `vector` in single `space`, represent the components in a single given `sector`.
+
+        The resulting charged tensor has a charge lector which has the `sector`.
+
+        See Also
+        --------
+        to_dense_block_single_sector
+        """
+        if backend is None:
+            backend = get_backend(symmetry=space.symmetry)
+        if space.symmetry.sector_dim(sector) > 1:
+            # TODO how to handle multi-dim sectors? which dummy leg state to give?
+            raise NotImplementedError
+        charge_leg = ElementarySpace(space.symmetry, [sector])
+        inv_data = backend.inv_part_from_dense_block_single_sector(
+            vector=vector, space=space, charge_leg=charge_leg
+        )
+        inv_part = SymmetricTensor(inv_data, codomain=[space], domain=[charge_leg], backend=backend,
+                                   labels=[[label, cls._CHARGE_LEG_LABEL]])
+        return cls(inv_part, [1])
+
+    @classmethod
+    def from_zero(cls, codomain: ProductSpace | list[Space],
+                  domain: ProductSpace | list[Space] | None = None,
+                  charge: Space | Sector | None = None,
+                  charged_state: Block | None = None,
+                  backend: Backend | None = None,
+                  labels: Sequence[list[str | None] | None] | list[str | None] | None = None,
+                  dtype: Dtype = Dtype.complex128,
+                  ):
+        """A zero tensor."""
+        codomain, domain, backend, symmetry = cls._init_parse_args(codomain, domain, backend)
+        inv_domain, charge_leg = cls._parse_inv_domain(domain=domain, charge=charge, backend=backend)
+        labels, inv_labels = cls._parse_inv_labels(labels, codomain, domain)
+        inv_part = SymmetricTensor.from_zero(codomain=codomain, domain=inv_domain, backend=backend,
+                                             labels=inv_labels, dtype=dtype)
+        return ChargedTensor(inv_part, charged_state)
+
+    def as_SymmetricTensor(self) -> SymmetricTensor:
+        """Convert to symmetric tensor, if possible."""
+        if not np.all(self.charge_leg.sectors == self.symmetry.trivial_sector[None, :]):
+            raise SymmetryError('Not a symmetric tensor')
+        if self.charge_leg.dim == 1:
+            res = squeeze_legs(self.invariant_part, -1)
+            if self.charged_state is not None:
+                res = self.backend.block_item(self.charged_state) * res
             return res
-        raise ValueError  # should have been caught by input checks
-
-    def _add_tensor(self, other: Tensor) -> Tensor:
-        raise TypeError(f"unsupported operand type(s) for +: '{type(self)}' and '{type(other)}'")
-
-# ##################################
-# API functions
-# ##################################
-
-# TODO (JU) find a good way to write type hints for these, having in mind the possible combinations
-#           of Tensor-subtypes.
-
-def add_trivial_leg(tens: Tensor, label: str = None, is_dual: bool = False, pos: int = -1,
-                    to_domain: bool = None):
-    """Add a trivial leg to a tensor.
-
-    A trivial leg is one-dimensional and consists only of the trivial sector of the symmetry.
-
-    Parameters
-    ----------
-    tens : Tensor
-        The tensor to add a leg to.
-    label : str | None
-        The label for the new leg
-    is_dual : bool
-        If the new leg should be dual
-    pos : int
-        The position to insert the new leg at.
-        The result has the new trivial leg at ``result.legs[pos]``.
-    to_domain : int
-        If the new leg should be added to domain or codomain. See :ref:`tensors_as_maps`.
-        If ``pos < tens.num_domain_legs`` we always add to the domain (or raise) and
-        if ``pos > tens.num_domain_legs`` we always add to the codomain (or raise).
-        There is only a choice if ``pos == tens.num_domain_legs``.
-        Then, we get ``result.num_domain_legs == tens.num_domain_legs + int(to_domain)``.
-        Per default, we add to the codomain.
-    """
-    return tens.add_trivial_leg(label=label, is_dual=is_dual, pos=pos, to_domain=to_domain)
-
-
-def almost_equal(t1: Tensor, t2: Tensor, atol: float = 1e-5, rtol: float = 1e-8,
-                 allow_different_types: bool = False) -> bool:
-    """Checks if two tensors are equal up to numerical tolerance.
-
-    The blocks of the two tensors are compared.
-    The tensors count as almost equal if all block-entries, i.e. all their free parameters
-    individually fulfill `abs(a1 - a2) <= atol + rtol * abs(a1)`.
-
-    In the non-symmetric case, this is equivalent to e.g. ``numpy.allclose``.
-    In the symmetric case, it is a close analogue.
-
-    .. note ::
-        The definition is not symmetric, so there may be edge-cases where
-        ``almost_equal(t1, t2) != almost_equal(t2, t1)``
-
-    Parameters
-    ----------
-    t1, t2
-        The tensors to compare
-    atol, rtol
-        Absolute and relative tolerance, see above.
-    allow_different_types : bool
-        If ``False`` (default), comparing tensors of different types raises a ``TypeError``.
-        If ``True``, types are converted, *if possible*.
+        if self.charged_state is None:
+            raise ValueError('Can not convert to SymmetricTensor. charged_state is not defined.')
+        state = SymmetricTensor.from_dense_block(
+            self.charged_state, codomain=[self.charged_state.dual], backend=self.backend,
+            labels=[_dual_leg_label(self._CHARGE_LEG_LABEL)], dtype=self.dtype
+        )
+        res = tdot(state, self.invariant_part, 0, -1)
+        return bend_legs(res, num_codomain_legs=self.num_codomain_legs)
         
-    """
-    return t1.almost_equal(t2, atol=atol, rtol=rtol, allow_different_types=allow_different_types)
-
-
-def combine_legs(t: Tensor,
-                 *legs: list[int | str],
-                 product_spaces: list[ProductSpace] = None,
-                 product_spaces_dual: list[bool] = None,
-                 new_axes: list[int] = None,
-                 new_labels: list[str | None] = None):
-    """
-    Combine (multiple) groups of legs on a tensor to (multiple) ProductSpaces.
-
-    .. warning ::
-        Combining legs introduces a basis-transformation. This is important to consider if
-        you convert to a dense block (e.g. via :meth:`Tensor.to_dense_block`). In
-        particular ``some_tens.combine_legs(...).to_dense_block()`` is not equivalent
-        to ``some_tens.to_dense_block().reshape(...)``.
-        See :meth:`ProductSpace.get_basis_transformation`.
-
-    Parameters
-    ----------
-    t :
-        The tensor whose legs should be combined.
-    *legs : tuple of list of {int | str}
-        One or more groups of legs.
-    product_spaces : list of ProductSpace
-        For optimization, the resulting ProductSpace instances per leg group can be passed. keyword only.
-        By default, they are recomputed.
-    product_spaces_dual : list of bool
-        For each group, whether the resulting ProductSpace should be dual. keyword only.
-        Per default, it has the same is_dual as the first (by appearance in `legs`) of the combined legs.
-    TODO doc or remove new_axes
-    new_labels : list of str
-        A new label for each group of legs.
-        By default, the label is given by joining the original labels with dots ``'.'`` and
-        surrounding with parentheses. For example, combining legs ``'vL', 'p0', 'p1'`` results in
-        a leg with label ``'(vL.p0.p1)'``.
-    Result
-    ------
-    combined :
-        A tensor with combined legs.
-        The order of legs is the same as for `t`, except that ``legs[n][0]`` is replaced by the
-        ``n``-th ``ProductSpace`` and the other ``legs[n][1:]`` are left out.
-
-    See Also
-    --------
-    split_legs
-    """
-    return t.combine_legs(*legs, product_spaces=product_spaces, product_spaces_dual=product_spaces_dual,
-                          new_axes=new_axes, new_labels=new_labels)
-
-
-def conj(t: Tensor) -> Tensor:
-    """
-    The conjugate of t, living in the dual space.
-    Labels are adjusted as `'p'` -> `'p*'` and `'p*'` -> `'p'`
-    """
-    return t.conj()
-
-
-def detect_sectors_from_block(block: Block, legs: list[Space], backend: Backend
-                              ) -> SectorArray:
-    """Detect the symmetry sectors of a dense block.
-
-    Given a `block` that represents a symmetric tensor with the given `legs`, return
-    the sectors (one sector per leg) of the largest (by magnitude) entry of the `block`.
-    """
-    assert backend.block_shape(block) == tuple(l.dim for l in legs)
-    idcs = backend.block_abs_argmax(block)
-    sectors = [leg.sectors[leg.parse_index(i)[0]] for leg, i in zip(legs, idcs)]
-    return np.stack(sectors, axis=0)
-
-
-def entropy(p: DiagonalTensor | Sequence[float], n: float = 1):
-    r"""Entropy of a probability distribution.
-
-    Assumes that `p` is a normalized (``sum(p) == 1``) probability distribution (real, non-negative).
-
-    Parameters
-    ----------
-    p : :class:`DiagonalTensor` | iterable of float
-        A normalized distribution.
-    n : 1 | float | np.inf
-        Selects the entropy, see below.
-
-    Returns
-    -------
-    entropy : float
-        Shannon-entropy :math:`-\sum_i p_i \log(p_i)` (n=1) or
-        Renyi-entropy :math:`\frac{1}{1-n} \log(\sum_i p_i^n)` (n != 1)
-        of the distribution `p`.
-    """
-    if isinstance(p, DiagonalTensor):
-        p = p.diag_numpy
-    else:
-        p = np.array(p)
-    assert len(p.shape) == 1
-    p = p[p > 1e-30]  # for stability reasons / to avoid NaN in log
-    if n == 1:
-        return -np.inner(np.log(p), p)
-    elif n == np.inf:
-        return -np.log(np.max(p))
-    else:  # general n != 1, inf
-        return np.log(np.sum(p**n)) / (1. - n)
-
-
-def flip_leg_duality(t: Tensor, which_leg: int | str, *more: int | str) -> Tensor:
-    r"""Flip the duality of one or more legs.
-
-    E.g. flipping the second leg of a three-leg tensor (assuming the first leg is ket-like) means
-
-    .. math ::
-        t = \sum_{i,j,k} c_{i, j, k} \ket{i} \otimes \ket{j} \otimes \bra{k}
-        \mapsto \sum_{i,j} c_{i, j} \ket{i} \otimes \bra{j} \otimes \bra{k}
-
-    Notes
-    -----
-    This is a basis-dependent notion. It depends on the choice of (co-)evaluation maps.
-    Here we choose the canonical maps
-
-    .. math ::
-        \varepsilon_V\colon V^* \otimes V \to \mathbb{C} , \bra{m} \otimes \bra{n} \mapsto \delta_{m, n}
-
-        \eta_V\colon \mathbb{C} \to V \otimes V^* , \alpha \mapsto \alpha \sum_n \ket{n} \otimes \bra{n}
-
-    which are defined by linear extension and depend on the basis :math:`\set{n}`.
-    """
-    return t.flip_leg_duality(which_leg, *more)
-
-
-def hconj(t: Tensor, legs1: int | str | list[int | str] = -1,
-          legs2: int | str | list[int | str] = None) -> Tensor:
-    """Hermitian conjugate.
-
-    This is basically :func:`conj` with additional input checks and a :func:`permute_legs`, such
-    that the result has the same legs as `t`, and can e.g. be added to `t`.
-    """
-    return t.hconj(legs1=legs1, legs2=legs2)
-
-
-def inner(t1: Tensor, t2: Tensor, do_conj: bool = True,
-          legs1: list[int | str] = None, legs2: list[int | str]  = None) -> complex:
-    """
-    Inner product ``<t1|t2>`` of two tensors.
-
-    Parameters
-    ----------
-    t1, t2 :
-        The two tensors
-    do_conj : bool
-        If true (default), `t1` lives in the same space as `t2` and will be conjugated to form ``<t1|t2>``.
-        Otherwise, `t1` lives in the dual space of `t2` and will not be conjugated.
-    legs1, legs2 : list of int or str, optional
-        Specify which legs are to be contracted with which ones.
-        If both are ``None`` (default), legs are identified "by label" in strict label mode or "by order"
-        in lax label mode, like in :meth:`_match_leg_order`.
-        Otherwise, ``legs1[n]`` of ``t1`` is contracted with ``legs2[n]`` of ``t2``, where
-        a single ``None``/unspecified list is interpreted as ``list(range(num_legs))``.
-    """
-    return t1.inner(t2, do_conj=do_conj, legs1=legs1, legs2=legs2)
-
-
-def is_scalar(obj) -> bool:
-    """If obj is a scalar, meaning either a python scalar like float or complex, or a Tensor
-    which has only one-dimensional legs"""
-    if isinstance(obj, Tensor):
-        return all(d == 1 for d in obj.shape)
-    # checking for Number includes int, float, complex, but also e.g. np.int64()
-    if isinstance(obj, Number):
-        return True
-    return False
-
-
-def norm(t: Tensor, order=None) -> float:
-    """Norm of a tensor.
-
-    Equivalent to ``np.linalg.norm(a.to_numpy().flatten(), order)``.
-    TODO is this statement true for general nonabelian symmetries?
-
-    In contrast to numpy, we don't distinguish between matrices and vectors, but rather
-    compute the `order`-norm of the "flattened" coefficients `x` of `t` in the computational basis.
-
-    ==========  ======================================
-    ord         norm
-    ==========  ======================================
-    None        Frobenius norm (same as 2-norm)
-    np.inf      ``max(abs(x))``
-    -np.inf     ``min(abs(x))``
-    0           ``sum(x != 0) == np.count_nonzero(x)``
-    other       usual p-norm with p=`order`
-    ==========  ======================================
-
-    Parameters
-    ----------
-    t : :class:`Tensor`
-        The tensor of which the norm should be calculated
-    order :
-        The order of the norm. See table above.
-    """
-    return t.norm(order=order)
-
-
-def outer(t1: Tensor, t2: Tensor, relabel1: dict[str, str] = None,
-          relabel2: dict[str, str] = None) -> Tensor:
-    """outer product, aka tensor product, aka direct product of two tensors"""
-    return t1.outer(t2, relabel1=relabel1, relabel2=relabel2)
-
-
-def permute_legs(t: Tensor, permutation: list[int] = None, num_domain_legs: int = None) -> Tensor:
-    """Change the order of legs of a Tensor.
-
-    TODO elaborate what this does to the underlying data for the respective backends.
-
-    Parameters
-    ----------
-    t : Tensor
-        The tensor to permute
-    permutation : list of int, optional
-        The permutation. The new legs will be ``[T.legs[n] for n in permutation]``.
-    num_domain_legs : int or None
-        The number of legs that should be in the domain. Per default (``None``), it is not changed.
-
-    Returns
-    -------
-    Tensor
-        A copy with modified leg order.
-    """
-    # TODO: also have an inplace version?
-    return t.permute_legs(permutation, num_domain_legs=num_domain_legs)
-
-
-def split_legs(t: Tensor, *legs: int | str) -> BlockDiagonalTensor:
-    """
-    Split legs that were previously combined.
-
-    Up to a possible ``permute_legs``, this is the inverse operation of ``combine_legs``.
-    It is the exact inverse if the original non-fused legs were contiguous and ordered in ``t_before_combine.legs``.
-
-    Parameters
-    ----------
-    t :
-        The tensor whose legs should be split.
-    legs : tuple of {int | str}, or None
-        Which legs should be split. If none are specified, all ``ProductSpace``s are split.
-
-    See Also
-    --------
-    combine_legs
-    """
-    # TODO inplace version?
-    return t.split_legs(*legs)
-
-
-def squeeze_legs(t: Tensor, legs: int | str | list[int | str] = None) -> Tensor:
-    """
-    Remove trivial leg from tensor.
-    If legs are specified, they are squeezed if they are trivial and a ValueError is raised if not.
-    If legs is None (default), all trivial legs are squeezed
-    """
-    return t.squeeze_legs(legs=legs)
-
-
-def tdot(t1: Tensor, t2: Tensor,
-         legs1: int | str | list[int | str] = -1, legs2: int | str | list[int | str] = 0,
-         relabel1: dict[str, str] = None, relabel2: dict[str, str] = None
-         ) -> Tensor | float | complex:
-    """
-    Contraction of two tensors.
-
-    A number of legs of `t1`, indicated by `legs1` are contracted with the *same* number of legs
-    of `t2`, indicated by `legs2`. The pairs of legs need to be mutually dual.
-
-    The legs of the resulting tensor are in "numpy-style" order, i.e. first the uncontracted legs
-    of `t1`, then those of `t2`.
-
-    Parameters
-    ----------
-    t1 : Tensor
-    t2 : Tensor
-    legs1 : int or str or list of int or list of str
-        the leg(s) on t1 to be contracted, referenced either by index or by label
-    legs2 : int or str of list of int or list of str
-        the leg(s) on t2 to be contracted, referenced either by index or by label
-    relabel1 : dict
-        labels of the result are determined as if t1 had been relabelled by this mapping before contraction
-    relabel2
-        labels of the result are determined as if t2 had been relabelled by this mapping before contraction
-
-    Returns
-    -------
-
-    """
-    return t1.tdot(t2, legs1=legs1, legs2=legs2, relabel1=relabel1, relabel2=relabel2)
-
-
-def trace(t: Tensor, legs1: int | str | list[int | str] = -2, legs2: int | str | list[int | str] = -1
-          ) -> Tensor | float | complex:
-    """
-    Trace over one or more pairs of legs, that is contract these pairs.
-    """
-    return t.trace(legs1=legs1, legs2=legs2)
-
-
-def zero_like(tens: Tensor) -> Tensor:
-    if isinstance(tens, BlockDiagonalTensor):
-        return BlockDiagonalTensor.zero(legs=tens.legs, backend=tens.backend, labels=tens.labels,
-                                        dtype=tens.dtype, num_domain_legs=tens.num_domain_legs)
-    if isinstance(tens, DiagonalTensor):
-        return DiagonalTensor.zero(first_leg=tens.first_leg, second_leg_dual=tens.second_leg_dual,
-                                   backend=tens.backend, labels=tens.labels, dtype=tens.dtype)
-    if isinstance(tens, Mask):
-        return Mask.zero(large_leg=tens.large_leg, backend=tens.backend, labels=tens.labels)
-    raise TypeError(f'zero is not defined for type {type(tens)}')
-
-
-def eye_like(tens: Tensor) -> BlockDiagonalTensor | DiagonalTensor:
-    """The identity map, as a tensor of the same type, with the same legs as `tens`.
-
-    The legs of `tens` must be compatible with the identity map.
-    There must be an even number, where the second half are the duals of the first half
-    in reverse order, i.e. ``tens.legs[i] == tens.legs[-1 - i].dual``.
-    """
-    if isinstance(tens, BlockDiagonalTensor):
-        if tens.num_legs % 2 != 0:
-            raise ValueError('eye is not defined for an odd number of legs')
-        legs_1 = tens.legs[:tens.num_legs // 2]
-        legs_2 = tens.legs[tens.num_legs // 2:]
-        for l1, l2 in zip(legs_1, legs_2[::-1]):
-            if not l1.can_contract_with(l2):
-                if len(legs_1) == 1:
-                    msg = 'Second leg must be the dual of the first leg'
-                else:
-                    msg = 'Second half of legs must be the dual of the first half'
-                raise ValueError(msg)
-        return BlockDiagonalTensor.eye(legs=legs_1, backend=tens.backend, labels=tens.labels,
-                                       dtype=tens.dtype)
-    if isinstance(tens, DiagonalTensor):
-        if tens.legs[0].is_dual == tens.legs[1].is_dual:
-            raise ValueError('Second leg must be the dual of the first leg')
-        return DiagonalTensor.eye(tens.legs[0], backend=tens.backend, labels=tens.labels,
-                                  dtype=tens.dtype)
-    if isinstance(tens, Mask):
-        return Mask.eye(tens.large_leg, backend=tens.backend, labels=tens.labels)
-    raise TypeError(f'eye is not defined for type {type(tens)}')
-
-
-# ##################################
-# element-wise function for DiagonalTensor
-# ##################################
-
-ElementwiseData = TypeVar('ElementwiseData', Number, DiagonalTensor)
-
-
-def elementwise_function(block_func: str, func_kwargs={}, maps_zero_to_zero=False):
+    def copy(self, deep=True) -> ChargedTensor:
+        inv_part = self.invariant_part.copy(deep=deep)  # this extra layer is cheap...
+        charged_state = self.charged_state
+        if deep and self.charged_state is not None:
+            charged_state = self.backend.block_copy(charged_state)
+        return ChargedTensor(inv_part, charged_state)
+
+    def to_dense_block(self, leg_order: list[int | str] = None, dtype: Dtype = None) -> Block:
+        if self.charged_state is None:
+            raise ValueError('charged_state not specified.')
+        inv_block = self.backend.to_dense_block(self)
+        block = self.backend.block_tdot(inv_block, self.charged_state, [-1], [0])
+        if dtype is not None:
+            block = self.backend.block_to_dtype(block, dtype)
+        if leg_order is not None:
+            block = self.backend.block_permute_axes(block, self._as_leg_idcs(leg_order))
+        return block
+
+
+_ElementwiseType = TypeVar('_ElementwiseType', Number, DiagonalTensor)
+
+
+def _elementwise_function(block_func: str, func_kwargs={}, maps_zero_to_zero=False):
     """Decorator factory used to define elementwise functions.
 
     The resulting decorator can take a ``function(x: Number, *a, **kw) -> Number`` that is defined
@@ -3785,11 +1931,11 @@ def elementwise_function(block_func: str, func_kwargs={}, maps_zero_to_zero=Fals
     """
     def decorator(function):
         @functools.wraps(function)
-        def wrapped(x: ElementwiseData, *args, **kwargs) -> ElementwiseData:
+        def wrapped(x, *args, **kwargs):
             if isinstance(x, DiagonalTensor):
                 return x._elementwise_unary(
-                    functools.partial(getattr(x.backend, block_func), *args),
-                    func_kwargs={**kwargs, **func_kwargs}, maps_zero_to_zero=maps_zero_to_zero
+                    lambda block: getattr(x.backend, block_func)(block, *args, **kwargs, **func_kwargs),
+                    maps_zero_to_zero=maps_zero_to_zero
                 )
             elif is_scalar(x):
                 return function(x, *args, **kwargs)
@@ -3798,24 +1944,700 @@ def elementwise_function(block_func: str, func_kwargs={}, maps_zero_to_zero=Fals
     return decorator
 
 
-@elementwise_function('block_angle', maps_zero_to_zero=True)
-def angle(x: ElementwiseData) -> ElementwiseData:
+def add_trivial_leg(tens: Tensor,
+                    legs_pos: int = None, *, codomain_pos: int = None, domain_pos: int = None,
+                    label: str = None, is_dual: bool = False):
+    """Add a trivial leg to a tensor.
+
+    A trivial leg is one-dimensional and consists only of the trivial sector of the symmetry.
+
+    Parameters
+    ----------
+    tens: Tensor
+        The tensor to add a leg to. Since :class:`DiagonalTensor` and :class:`Mask` do not
+        support adding legs, they will be converted to :class:`SymmetricTensor` first.
+    legs_pos, codomain_pos, domain_pos: int
+        The position of the new leg can be specified in three mutually exclusive ways.
+        If the positional argument `leg_pos` is used, ``result.legs[leg_pos]`` will be the trivial
+        leg. In most cases that unambiguously assigns it to either the domain or the codomain.
+        If ambiguous (``if legs_pos == num_codomain_legs``), it is added to the codomain.
+        Alternatively, it can be added to the codomain at ``codomain[codomain_pos]``
+        or to the domain at ``domain_pos``.
+        Note the implications for the ``is_dual`` argument!
+        Per default, we use ``0``, i.e. add at ``legs[0]`` / ``codomain[0]``.
+    label: str
+        The label for the new leg.
+    is_dual: bool
+        If we add a dual (bra-like) or ket-like leg.
+        If `leg_pos` is given, we have ``result.legs[leg_pos].is_dual == is_dual``,
+        but if `domain_pos` is given, we have ``result.domain[domain_pos].is_dual == is_dual``.
+    """
+    if isinstance(tens, (DiagonalTensor, Mask)):
+        warnings.warn('Converting DiagonalTensor to Tensor for add_trivial_leg', stacklevel=2)
+        return add_trivial_leg(tens.as_SymmetricTensor(), legs_pos, codomain_pos=codomain_pos,
+                               domain_pos=domain_pos, label=label, is_dual=is_dual)
+
+    res_num_legs = tens.num_legs + 1
+    # parse position to format:
+    #  - leg_pos: int,  0 <= leg_pos < res_num_legs
+    #  - add_to_domain: bool
+    #  - co_domain_pos: int, 0 <= co_domain_pos < num_[co]domain_legs
+    #  - is_dual: bool, if the leg in the [co]domain should be dual
+    if legs_pos is not None:
+        assert codomain_pos is None and domain_pos is None
+        legs_pos = _normalize_idx(legs_pos, res_num_legs)
+        add_to_domain = (legs_pos > tens.num_codomain_legs)
+        if add_to_domain:
+            co_domain_pos = res_num_legs - 1 - legs_pos
+        else:
+            co_domain_pos = legs_pos
+    elif codomain_pos is not None:
+        assert legs_pos is None and domain_pos is None
+        res_codomain_legs = tens.num_codomain_legs + 1
+        codomain_pos = _normalize_idx(codomain_pos, res_codomain_legs)
+        add_to_domain = False
+        co_domain_pos = codomain_pos
+        legs_pos = codomain_pos
+    elif domain_pos is not None:
+        assert legs_pos is None and codomain_pos is None
+        res_domain_legs = tens.num_domain_legs
+        domain_pos = _normalize_idx(domain_pos, res_domain_legs)
+        add_to_domain = True
+        co_domain_pos = domain_pos
+        legs_pos = res_num_legs - 1 - domain_pos
+    else:
+        add_to_domain = False
+        co_domain_pos = 0
+        legs_pos = 0
+
+    if isinstance(tens, ChargedTensor):
+        if add_to_domain:
+            # domain[0] is the charge leg, so we need to add 1
+            inv_part = add_trivial_leg(tens.invariant_part, domain_pos=domain_pos + 1, label=label,
+                                       is_dual=is_dual)
+        else:
+            inv_part = add_trivial_leg(tens.invariant_part, codomain_pos=codomain_pos, label=label,
+                                       is_dual=is_dual)
+        return ChargedTensor(inv_part, charged_state=tens.charged_state)
+
+    if not isinstance(tens, SymmetricTensor):
+        raise TypeError
+
+    new_leg = Space.from_trivial_sector(1, symmetry=tens.symmetry, is_dual=is_dual)
+    if add_to_domain:
+        domain = tens.domain.insert_multiply(new_leg, pos=co_domain_pos)
+        codomain = tens.codomain
+    else:
+        domain = tens.domain
+        codomain = tens.codomain.insert_multiply(new_leg, pos=co_domain_pos)
+    data = tens.backend.add_trivial_leg(
+        tens, legs_pos=legs_pos, add_to_domain=add_to_domain, co_domain_pos=co_domain_pos,
+        new_codomain=codomain, new_domain=domain
+    ),
+    return SymmetricTensor(
+        data, codomain=codomain, domain=domain, backend=tens.backend,
+        labels=[*tens.labels[:legs_pos], label, *tens.labels[legs_pos:]],
+    )
+
+
+@_elementwise_function(block_func='block_angle', maps_zero_to_zero=True)
+def angle(x: _ElementwiseType) -> _ElementwiseType:
     """The angle of a complex number, elementwise.
 
     The counterclockwise angle from the positive real axis on the complex plane in the
     range (-pi, pi] with a real dtype. The angle of `0.` is `0.`.
     """
     return np.angle(x)
+
+
+def almost_equal(tensor_1: Tensor, tensor_2: Tensor, rtol: float = 1e-5, atol=1e-8,
+                 allow_different_types: bool = False) -> bool:
+    """Checks if two tensors are equal up to numerical tolerance.
+
+    We compare the blocks, i.e. the free parameters of the tensors.
+    The tensors count as almost equal if all block-entries, i.e. all their free parameters
+    individually fulfill ``abs(a1 - a2) <= atol + rtol * abs(a1)``.
+    Note that this is a basis-dependent and backend-dependent notion of distance, which does
+    not come from a norm in the strict mathematical sense.
+
+    Parameters
+    ----------
+    t1, t2
+        The tensors to compare
+    atol, rtol
+        Absolute and relative tolerance, see above.
+    allow_different_types: bool
+        If ``True``, we convert types, e.g. via :meth:`DiagonalTensor.as_SymmetricTensor`
+        to allow comparison. If ``False``, we raise on mismatching types.
+
+    Notes
+    -----
+    Unlike numpy, our definition is symmetric under exchanging 
+    """
+    check_same_legs(tensor_1, tensor_2)
+    
+    if isinstance(tensor_1, Mask):
+        if isinstance(tensor_2, Mask):
+            return Mask.all(tensor_1 == tensor_2)
+        if isinstance(tensor_2, DiagonalTensor) and allow_different_types:
+            return almost_equal(tensor_1.as_DiagonalTensor(), tensor_2, rtol=rtol, atol=atol)
+        if isinstance(tensor_2, (SymmetricTensor, ChargedTensor)) and allow_different_types:
+            return almost_equal(tensor_1.as_SymmetricTensor(), tensor_2, rtol=rtol, atol=atol)
+        
+    if isinstance(tensor_1, DiagonalTensor):
+        if isinstance(tensor_2, Mask) and allow_different_types:
+            return almost_equal(tensor_1, tensor_2.as_DiagonalTensor(), rtol=rtol, atol=atol)
+        if isinstance(tensor_2, DiagonalTensor):
+            return tensor_1.elementwise_almost_equal(tensor_2).all()
+        if isinstance(tensor_2, (SymmetricTensor, ChargedTensor)) and allow_different_types:
+            return almost_equal(tensor_1.as_SymmetricTensor(), tensor_2, rtol=rtol, atol=atol)
+
+    if isinstance(tensor_1, SymmetricTensor):
+        if isinstance(tensor_2, (Mask, DiagonalTensor)) and allow_different_types:
+            return almost_equal(tensor_1, tensor_2.as_SymmetricTensor(), rtol=rtol, atol=atol)
+        if isinstance(tensor_2, SymmetricTensor):
+            return get_same_backend(tensor_1, tensor_2).almost_equal(tensor_1, tensor_2, rtol=rtol, atol=atol)
+        if isinstance(tensor_2, ChargedTensor) and allow_different_types:
+            try:
+                t2_symm = tensor_2.as_SymmetricTensor()
+                return almost_equal(tensor_1, t2_symm, rtol=rtol, atol=atol)
+            except SymmetryError:
+                pass
+            raise NotImplementedError
+
+    if isinstance(tensor_1, ChargedTensor):
+        # we implement the mixed type comparison SymmetricTensor and ChargedTensor only once.
+        # to swap the arguments we need to adjust the definition, to use abs(a2)
+        if isinstance(tensor_2, (Mask, DiagonalTensor)) and allow_different_types:
+            return almost_equal(tensor_1, tensor_2.as_SymmetricTensor(), rtol=rtol, atol=atol)
+        if isinstance(tensor_2, SymmetricTensor):
+            # TODO this is not strictly correct, since definition is not symmetric...
+            return almost_equal(tensor_2, tensor_1, rtol=rtol, atol=atol)
+        if isinstance(tensor_2, ChargedTensor):
+            if tensor_1.charge_leg != tensor_2.charge_leg:
+                raise ValueError('Mismatched charge_leg')
+            if (tensor_1.charged_state is None) != (tensor_2.charged_state is None):
+                raise ValueError('Mismatch: defined and undefined dummy_leg_state')
+            if tensor_1.charged_state is None:
+                return almost_equal(tensor_1.invariant_part, tensor_2.invariant_part, rtol=rtol, atol=atol)
+            backend = get_same_backend(tensor_1, tensor_2)
+            if tensor_1.charge_leg.dim == 1:
+                return almost_equal(
+                    backend.block_item(tensor_2.charged_state) * tensor_1.invariant_part,
+                    backend.block_item(tensor_1.charged_state) * tensor_2.invariant_part,
+                    rtol=rtol, atol=atol
+                )
+            raise NotImplementedError  # TODO
+
+    msg = f'Incompatible types: {tensor_1.__class__.__name__} and {tensor_2.__class__.__name__}'
+    raise TypeError(msg)
+
+
+def apply_mask(tensor: Tensor, mask: Mask, leg: int | str) -> Tensor:
+    ...  # TODO
+
+
+def bend_legs(tensor: Tensor, num_codomain_legs: int = None, num_domain_legs: int = None) -> Tensor:
+    """Move legs between codomain and domain without changing the order of ``tensor.legs``.
+
+    Parameters
+    ----------
+    tensor:
+        The tensor to modify
+    num_codomain_legs, num_domain_legs: int, optional
+        The desired number of legs in to (co-)domain. Only one is required.
+    """
+    if num_codomain_legs is None and num_domain_legs is None:
+        raise ValueError
+    elif num_domain_legs is None:
+        num_domain_legs = tensor.num_legs - num_codomain_legs
+    elif num_codomain_legs is None:
+        num_codomain_legs = tensor.num_legs - num_domain_legs
+    else:
+        assert num_codomain_legs + num_domain_legs == tensor.num_legs
+    return permute_legs(tensor,
+                        codomain=range(num_codomain_legs),
+                        domain=range(num_codomain_legs, tensor.num_legs))
+
+
+def check_same_legs(t1: Tensor, t2: Tensor) -> tuple[list[int], list[int]] | None:
+    """Check if two tensors have the same legs. Warn on labels that indicate a mix up."""
+    incompatible_labels = False
+    for n1, l1 in enumerate(t1._labels):
+        n2 = t2._labelmap.get(l1, None)
+        if n2 is None:
+            # either l1 is None or l1 not in l2.labels
+            continue
+        if n2 != n1:
+            incompatible_labels = True
+            break
+    same_legs = (t1.domain == t2.domain and t1.codomain == t1.codomain)
+    if not same_legs:
+        msg = 'Incompatible legs. '
+        if incompatible_labels:
+            msg += f'Should you permute_legs first? {t1.labels=}  {t2.labels=}'
+        raise ValueError(msg)
+    if incompatible_labels:
+        logger.warning('Compatible legs with permuted labels detected. Double check your leg order!',
+                       stacklevel=3)
+    # done
+
+
+def combine_legs(tensor: Tensor,
+                 *which_legs: list[int | str],
+                 combined_spaces: list[ProductSpace | None] = None,
+                 ) -> Tensor:
+    """Combine (multiple) groups of legs, each to a :class:`ProductSpace`.
+
+    .. warning ::
+        Combining legs introduces a basis-transformation. This is important to consider if
+        you convert to a dense block (e.g. via :meth:`Tensor.to_dense_block`).
+        In particular it is (in general) impossible to obtain
+        ``some_tens.combine_legs(...).to_numpy()`` via
+        ``some_tens.to_numpy().transpose(transp).reshape(new_shape)``.
+        See :meth:`ProductSpace.get_basis_transformation`.
+
+    Parameters
+    ----------
+    tensor:
+        The tensor whose legs should be combined.
+    *legs : tuple of list of {int | str}
+        One or more groups of legs to combine.
+    combined_spaces: list of {ProductSpace | None}, optional
+        For each group of `legs`, the resulting ProductSpace can be passed to avoid recomputation.
+        Must be the same legs as on the result described below. In particular, choosing the right
+        duality depends on if the resulting combined leg ends up in domain or codomain.
+
+    Returns
+    -------
+    A tensor with combined legs, such that up to a :meth:`permute_legs`, the original tensor
+    can be recovered with :meth:`split_legs`.
+    The leg order of the result arises as follows;
+    In both the domain and the codomain, the first leg of each group is replaced by the entire group,
+    in order of appearance in `which_legs`. This may involve moving some legs from codomain to
+    domain or vice versa. Naturally, those other legs are removed from their previous positions,
+    such that the ordering of non-participating legs is preserved.
+    Then, each group is replaced by the appropriate product space, either in the domain or the
+    codomain.
+
+    Notes
+    -----
+    TODO example
+    """
+
+    # 1) Deal with different tensor types. Reduce everything to SymmetricTensor.
+    # ==============================================================================================
+    
+    if isinstance(tensor, (DiagonalTensor, Mask)):
+        msg = (f'Converting {tensor.__class__.__name__} to SymmetricTensor for combine_legs. '
+               f'To suppress this warning, explicitly use as_SymmetricTensor() first.')
+        warnings.warn(msg, stacklevel=2)
+        tensor = tensor.as_SymmetricTensor()
+
+    which_legs = [tensor.get_leg_idcs(group) for group in which_legs]
+
+    if isinstance(tensor, ChargedTensor):
+        # note: its important to parse negative integers before via tensor.get_leg_idcs, since
+        #       the invariant part has an additional leg.
+        inv_part = combine_legs(
+            tensor.invariant_part, *which_legs, combined_spaces=combined_spaces
+        )
+        return ChargedTensor(inv_part, charged_state=tensor.charged_state)
+
+    # 2) permute legs such that the groups are contiguous and fully in codomain or fully in domain
+    # ==============================================================================================
+
+    if combined_spaces is None:
+        combined_spaces = [None] * len(which_legs)
+
+    # 2a) populate the following data structures:
+    domain_groups = {}  # {domain_pos: (leg_idcs_to_combine, combined_ProductSpace)}
+    domain_skip = []  # [domain_pos to skip, bc they are part of a group[1:]]
+    codomain_groups = {}  # same as above, but for codomain
+    codomain_skip = []  # same as above, but for codomain
+    
+    for n, group in enumerate(which_legs):
+        combine_to_domain, combined_pos, first_leg = tensor._parse_leg_idx(group[0])
+        group = [first_leg]
+        to_combine = []  # the legs we need to combine. duality adjusted if they need to be bent.
+        if combine_to_domain:
+            to_combine.append(tensor.domain.spaces[combined_pos])
+        else:
+            to_combine.append(tensor.codomain.spaces[combined_pos])
+        for l in group[1:]:
+            in_domain, pos, leg_idx = tensor._parse_leg_idx(l)
+            group.append(leg_idx)
+            if in_domain:
+                domain_skip.append(pos)
+                leg = tensor.domain.spaces[pos]
+            else:
+                codomain_skip.append(pos)
+                leg = tensor.codomain.spaces[pos]
+            if in_domain == combine_to_domain:
+                to_combine.append(leg)
+            else:
+                to_combine.append(leg.dual)
+        if combined_spaces[n] is None:
+            combined = ProductSpace(to_combine, backend=tensor.backend)
+        else:
+            combined = combined_spaces[n]
+            assert combined.spaces == to_combine
+        if combine_to_domain:
+            domain_groups[combined_pos] = (group, combined)
+        else:
+            codomain_groups[combined_pos] = (group, combined)
+
+    # 2b) populate the following data structures:
+    new_domain_combine = []  # list[tuple[list[domain_pos], ProductSpace]], instructions for after permuting
+    new_codomain_combine = []  # same as above, but for codomain
+    codomain_idcs = []  # [leg_idx], input for permute_legs
+    domain_idcs = []  # [leg_idx], input for permute_legs
+    
+    for n in range(tensor.num_codomain_legs):
+        # for codomain, n==leg_idx
+        if n in codomain_skip:
+            continue
+        group = codomain_groups.get(n, None)
+        if group is None:
+            codomain_idcs.append(n)
+            continue
+        leg_idcs, combined = group
+        start = len(codomain_idcs)
+        num = len(leg_idcs)
+        new_codomain_combine.append((range(start, start + num), combined))
+        codomain_idcs.extend(leg_idcs)
+    for n in range(tensor.num_domain_legs):
+        if n in domain_skip:
+            continue
+        group = domain_groups.get(n, None)
+        if group is None:
+            leg_idx = tensor.num_legs - 1 - n
+            domain_idcs.append(leg_idx)
+            continue
+        leg_idcs, combined = group
+        start = len(domain_idcs)
+        num = len(leg_idcs)
+        new_domain_combine.append((range(start, start + num), combined))
+        domain_idcs.extend(leg_idcs)
+
+    # 2c) finally, do the permute
+    tensor = permute_legs(tensor, codomain_idcs, domain_idcs)
+
+    # 3) build new domain and codomain, labels
+    # ==============================================================================================
+
+    # strategy:
+    #   a) preserve list lengths to not invalidate the positions, fill with None
+    #   b) remove the Nones
+    # [a, b, c, d, e, f, g]
+    #  -> [a, None, None, (b.c.d), e, None, (f.g)]
+    #  -> [a, (b.c.d), e, (f.g)]
+    
+    domain_spaces = tensor.domain.spaces[:]
+    codomain_spaces = tensor.codomain.spaces[:]
+    domain_labels = tensor.domain_labels
+    codomain_labels = tensor.codomain_labels
+    for positions, combined in new_domain_combine:
+        first, *_, last = positions
+        label = _combine_leg_labels(domain_labels[first:last + 1])
+        domain_spaces[first:last] = None
+        domain_spaces[last] = combined
+        domain_labels[first:last] = None
+        domain_labels[last] = label
+    for positions, combined in new_codomain_combine:
+        first, *_, last = positions
+        label = _combine_leg_labels(codomain_labels[first:last + 1])
+        codomain_spaces[first:last] = None
+        codomain_spaces[last] = combined
+        codomain_labels[first:last] = None
+        codomain_labels[last] = label
+    domain_spaces = [s for s in domain_spaces if s is not None]
+    codomain_spaces = [s for s in codomain_spaces if s is not None]
+    domain_labels = [l for l in domain_labels if l is not None]
+    codomain_labels = [l for l in codomain_labels if l is not None]
+    
+    domain = ProductSpace(domain_spaces, backend=tensor.backend,
+                          _sectors=tensor.domain.sectors,
+                          _multiplicities=tensor.domain.multiplicities)
+    codomain = ProductSpace(codomain_spaces, backend=tensor.backend,
+                            _sectors=tensor.codomain.sectors,
+                            _multiplicities=tensor.codomain.multiplicities)
+
+    # 4) Build the data / finish up
+    # ==============================================================================================
+    raise NotImplementedError  # TODO probably need to rework the backend method.
+    data = tensor.backend.combine_legs(tensor, ...)
+    return SymmetricTensor(data, codomain=codomain, domain=domain, backend=tensor.backend,
+                           labels=[codomain_labels, domain_labels])
     
 
-@elementwise_function('block_real', maps_zero_to_zero=True)
-def real(x: ElementwiseData) -> ElementwiseData:
+def conj(tensor: Tensor):
+    """TODO doc this.
+    TODO do we even need this?
+    """
+    return dagger(transpose(tensor))  # OPTIMIZE
+
+
+def dagger(tensor: Tensor) -> Tensor:
+    r"""The hermitian conjugate tensor.
+
+    For a tensor ``A: [V1, V2] -> [W1, W2]`` with ``A.legs == [W1, W2, V2.dual, V1.dual]``,
+    the dagger is given by ``dagger(A): [W1, W2] -> [V1, V2]`` with
+    ``dagger(A).legs == [V1, V2, W2.dual, W1.dual]``.
+
+    Any number of legs can be contracted between ``A`` and ``dagger(A)`` and the resulting legs
+    only depend on the input legs, not on their bipartition into domain and codomain.
+
+    For a matrix (i.e. a two-leg tensor), the dagger is the hermitian conjugate,
+    given by :math:`(M^\dagger)_{i,j} = \bar{M}_{j, i}`.
+
+    TODO doctest comparing ``tenpy.dagger -> to_numpy`` with ``to_numpy -> transpose().conj()``
+    """
+    if isinstance(tensor, Mask):
+        raise NotImplementedError  # TODO. revisit when "opposite Mask" is implemented
+    if isinstance(tensor, DiagonalTensor):
+        return tensor._elementwise_unary(tensor.backend.block_conj, maps_zero_to_zero=True)
+    if isinstance(tensor, SymmetricTensor):
+        return SymmetricTensor(
+            data=tensor.backend.dagger(tensor),
+            codomain=tensor.domain, domain=tensor.codomain,
+            backend=tensor.backend,
+            labels=[_dual_leg_label(l) for l in reversed(tensor._labels)]
+        )
+    if isinstance(tensor, ChargedTensor):
+        inv_part = dagger(tensor.invariant_part)
+        inv_part = move_leg(tensor, ChargedTensor._CHARGE_LEG_LABEL, domain_pos=0)
+        charged_state = tensor.charged_state
+        if charged_state is not None:
+            charged_state = tensor.backend.block_conj(charged_state)
+        return ChargedTensor(inv_part, charged_state)
+    raise TypeError
+
+
+def dot(A: Tensor, B: Tensor) -> Tensor:
+    r"""Tensor contraction as map composition. Requires ``A.domain == B.codomain``.
+
+    Returns
+    -------
+    The composite map :math:`A \circ B` from ``B.domain`` to ``A.codomain``.
+    """
+    raise NotImplementedError  # TODO
+
+
+def entropy(p: DiagonalTensor | Sequence[float], n=1):
+    """The entropy of a probability distribution.
+
+    Assumes that `p` is a probability distribution, i.e. real, non-negative and normalized to
+    ``p.sum() == 1.``.
+    
+    """
+    if isinstance(p, DiagonalTensor):
+        p = p.to_numpy()
+    else:
+        p = np.asarray(p)
+        p = np.real_if_close(p)
+    p = p[p > 1e-30]  # for stability of log
+    if n == 1:
+        return -np.inner(np.log(p), p)
+    if n == np.inf:
+        return -np.log(np.max(p))
+    return np.log(np.sum(p ** n)) / (1. - n)
+
+
+def get_same_backend(*tensors: Tensor, error_msg: str = 'Incompatible backends.') -> Backend:
+    """If the given tensors have the same backend, return it. Raise otherwise."""
+    if len(tensors) == 0:
+        raise ValueError('Need at least one tensor')
+    backend = tensors[0].backend
+    if not all(tens.backend == backend for tens in tensors[1:]):
+        raise ValueError(error_msg)
+    return backend
+
+
+@_elementwise_function(block_func='block_imag', maps_zero_to_zero=True)
+def imag(x: _ElementwiseType) -> _ElementwiseType:
+    """The imaginary part of a complex number, elementwise."""
+    return np.imag(x)
+
+
+def inner(A: Tensor, B: Tensor, do_dagger: bool = True) -> float | complex:
+    r"""The frobenius inner product :math:`\langle A \vert B \rangle_\text{F}` of two tensors.
+
+    Assumes that the two tensors have the same (co-)domains.
+    The inner product is defined as :math:`\mathrm{Tr}[ A^\dagger \circ B]`.
+    It is thus equivalent to, but more efficient than ``trace(dot(A, B))``.
+
+    Parameters
+    ----------
+    A, B
+        The two tensors. Must have matching (co-)domains, except if ``do_dagger=False``.
+    do_dagger: bool
+        If ``True``, the standard inner product as above is computed.
+        If ``False``, we assume that the dagger has already been performed on one of the tensors.
+        Thus we require ``tensor_1.domain == tensor_2.codomain`` and vice versa and just perform
+        the contraction and trace.
+    
+    See Also
+    --------
+    norm
+        The Frobenius norm, induced by this inner product.
+    """
+    if isinstance(A, (DiagonalTensor, Mask)):
+        # in this case, there is no benefit to having a dedicated backend function,
+        # as the dot is cheap
+        if do_dagger:
+            return trace(dot(dagger(A), B))
+        return trace(dot(A, B))
+    if isinstance(B, (DiagonalTensor, Mask)):
+        # same argument as above.
+        if do_dagger:
+            return conj(trace(dot(dagger(B), A)))
+        return trace(dot(A, B))
+
+    # remaining cases: both are either SymmetricTensor or ChargedTensor
+    
+    if isinstance(A, ChargedTensor) and isinstance(B, ChargedTensor):
+        raise NotImplementedError  # TODO
+    
+    if isinstance(B, ChargedTensor):
+        if do_dagger:
+            return conj(inner(B, A))
+        return inner(B, A, do_dagger=False)
+
+    if isinstance(A, ChargedTensor):  # and B is a SymmetricTensor
+        raise NotImplementedError   # TODO
+
+    # remaining case: both are SymmetricTensor
+    raise NotImplementedError  # TODO
+
+
+def is_scalar(obj):
+    """If an object is a scalar. We count numbers as scalars and some specific :class:`Tensor`s.
+
+    A tensor counts as a scalar if both its domain and its codomain consist of the *same* single
+    sector. For abelian group symmetries, this is equivalent to saying that ``tensor.to_numpy()``
+    is an array with a single entry.
+
+    In the general case, the consequence is that ``tensor.num_parameters == 1``.
+    TODO double-check that this statement is actually true.
+    The tensor, as a map from codomain to domain must be a multiple of the identity on that single
+    sector and the prefactor is the single free parameter.
+    We can thus think of the tensor as equivalent to that single parameter, i.e. a scalar.
+    """
+    raise NotImplementedError  # TODO
+
+
+def item(tensor: Tensor) -> float | complex | bool:
+    if not is_scalar(tensor):
+        raise ValueError('Not a scalar')
+    if isinstance(tensor, Mask):
+        return Mask.any(tensor)
+    if isinstance(tensor, (DiagonalTensor, SymmetricTensor)):
+        return tensor.backend.item(tensor)
+    if isinstance(tensor, ChargedTensor):
+        if tensor.charged_state is None:
+            raise ValueError('Can not compute .item of ChargedTensor with unspecified charged_state.')
+        inv_block = tensor.invariant_part.to_dense_block()
+        res = tensor.backend.block_tdot(tensor.charged_state, inv_block, 0, -1)
+        return tensor.backend.block_item(res)
+    raise TypeError
+
+
+def move_leg(tensor: Tensor, which_leg: int | str, *, codomain_pos: int = None, domain_pos: int = None):
+    """Move one leg of a tensor to a specified position.
+
+    TODO implement via permute_legs
+    TODO specify levels somehow?
+    OPTIMIZE direct implementation in fusion tree backend? have extra info for the sequence of needed braids.
+    """
+    if codomain_pos is not None:
+        assert domain_pos is None
+        codomain_pos = _normalize_idx(codomain_pos, tensor.num_codomain_legs)
+        ...
+    if domain_pos is not None:
+        assert codomain_pos is None
+        domain_pos = _normalize_idx(domain_pos, tensor.num_domain_legs)
+    raise NotImplementedError  # TODO
+
+
+def norm(tensor: Tensor) -> Tensor:
+    """The Frobenius norm of a Tensor.
+
+    TODO expand docs. See :meth:`inner`
+
+    See Also
+    --------
+    inner
+        The associated Frobenius inner product.
+    """
+    if isinstance(tensor, Mask):
+        # norm ** 2 = Tr(m^\dagger . m) = Tr(id_{small_leg}) = dim(small_leg)
+        return np.sqrt(tensor.small_leg.dim)
+    if isinstance(tensor, (DiagonalTensor, SymmetricTensor)):
+        return tensor.backend.norm(tensor)
+    if isinstance(tensor, ChargedTensor):
+        if tensor.charged_state is None:
+            msg = ('norm of a ChargedTensor with unspecified charged_state is ambiguous. '
+                   'Use e.g. norm(tensor.invariant_part).')
+            raise ValueError(msg)
+        if tensor.charge_leg.dim == 1:
+            factor = tensor.backend.block_item(tensor.charged_state)
+            return factor * tensor.backend.norm(tensor.invariant_part)
+        else:
+            # OPTIMIZE
+            warnings.warn('Converting ChargedTensor to dense block for `norm`', stacklevel=2)
+            return tensor.backend.block_norm(tensor.to_dense_block(), order=2)
+    raise TypeError
+
+
+def outer(A: Tensor, B: Tensor):
+    r"""The outer product, or tensor product.
+
+    The outer product of two maps :math:`A : W_A \to V_A` and :math:`B : W_B \to V_B` is
+    a map :math:`A \otimes B : W_A \otimes W_B \to V_A \otimes V_B`.
+    Thus, as a tensor its legs are, up to a permutation, the legs of `A` plus the legs of `B`.
+
+    Returns
+    -------
+    The outer product :math:`A \otimes B`, which has
+    ``domain == ProductSpace.from_partial_products(A.domain, B.domain)``
+    and ``codomain == ProductSpace.from_partial_products(A.codomain, B.codomain)``.
+    """
+    raise NotImplementedError  # TODO
+
+
+def permute_legs(tensor: Tensor, codomain: list[int | str], domain: list[int | str],
+                 levels: list[int] | dict[str | int, int] = None):
+    """Permute the legs of a tensor by braiding legs and bending lines.
+
+    Parameters
+    ----------
+    tensor: Tensor
+        The tensor to permute
+    codomain, domain: list of {int | str}
+        Which of the legs of `tensor`, specified by their position in ``tensor.legs`` or by
+        string label, should end up in the (co)domain of the result.
+        Together, `codomain` and `domain` must comprise all legs of the original `tensor`.
+    levels
+        If the symmetry has symmetric braiding (e.g. for group symmetries, or fermions, see
+        :attr:`Symmetry.braiding_style`), this argument is ignored.
+        For non-symmetric braiding, this argument specifies if a crossing of legs is an over-
+        or under-crossing. It assigns a "level" or height to each leg.
+        Either as a list ``levels[leg_num]`` or as a dictionary ``levels[leg_num_or_label]``.
+        If two legs are crossed at some point, the one with the higher level goes over the other.
+    """
+    # TODO decide signature of backend function
+    raise NotImplementedError
+
+
+@_elementwise_function(block_func='block_real', maps_zero_to_zero=True)
+def real(x: _ElementwiseType) -> _ElementwiseType:
     """The real part of a complex number, elementwise."""
     return np.real(x)
 
 
-@elementwise_function('block_real_if_close', func_kwargs=dict(tol=100), maps_zero_to_zero=True)
-def real_if_close(x: ElementwiseData, tol: float = 100) -> ElementwiseData:
+@_elementwise_function(block_func='block_real_if_close', func_kwargs=dict(tol=100), maps_zero_to_zero=True)
+def real_if_close(x: _ElementwiseType, tol: float = 100) -> _ElementwiseType:
     """If the :func:`imag` part is close to 0, return the :func:`real` part. Elementwise.
 
     Parameters
@@ -3833,113 +2655,160 @@ def real_if_close(x: ElementwiseData, tol: float = 100) -> ElementwiseData:
     return np.real_if_close(x, tol=tol)
 
 
-@elementwise_function('block_sqrt', maps_zero_to_zero=True)
-def sqrt(x: ElementwiseData) -> ElementwiseData:
+def set_as_slice():
+    # TODO define what this even means
+    raise NotImplementedError
+
+
+def split_legs():
+    # TODO define signature and meaning.
+    # should be exact inverse of combine_legs if the legs where contiguous before combining.
+    # otherwise, should be its inverse up to a permute_legs
+    raise NotImplementedError  # TODO
+
+
+@_elementwise_function(block_func='block_sqrt', maps_zero_to_zero=True)
+def sqrt(x: _ElementwiseType) -> _ElementwiseType:
     """The square root of a number, elementwise."""
     return np.sqrt(x)
 
 
-@elementwise_function('block_imag', maps_zero_to_zero=True)
-def imag(x: ElementwiseData) -> ElementwiseData:
-    """The imaginary part of a complex number, elementwise."""
-    return np.imag(x)
+def squeeze_legs():
+    """Remove trivial legs.
+
+    TODO elaborate, decide signature...
+    """
+    raise NotImplementedError
 
 
-# we define abs via __abs__ on diagonal tensors
-    
-
-# ##################################
-# utility functions
-# ##################################
+def tdot():
+    raise NotImplementedError  # TODO
 
 
-def get_same_backend(*tensors: Tensor, error_msg: str = 'Incompatible backends.'
-                     ) -> Backend:
-    """If all tensors have the same backend, return it. Otherwise raise a ValueError"""
-    try:
-        backend = tensors[0].backend
-    except IndexError:
-        raise ValueError('expected at least one tensor') from None
-    if not all(tens.backend == backend for tens in tensors):
-        raise ValueError(error_msg)
-    return backend
+def trace(tensor: Tensor,
+          legs1: int | str | list[int | str] | None = None,
+          legs2: int | str | list[int | str] | None = None):
+    """Perform a (partial) trace.
+
+    TODO elaborate
+    By default, require that ``tensor.domain == tensor.codomain`` and perform the full trace.
+    """
+    raise NotImplementedError  # TODO
 
 
-def tensor_from_block(block: Block, legs: list[Space], backend: Backend,
-                      labels: list[str] = None, num_domain_legs: int = 0
-                      ) -> ChargedTensor | BlockDiagonalTensor:
-    """Assume the block lives in a single symmetry sector and convert to tensor.
+def transpose(tensor: Tensor) -> Tensor:
+    r"""The transpose of a tensor.
 
-    Parameters
-    ----------
-    block : backend-specific block
-        The data to convert.
-    legs : list of :class:`Space`
-        The legs of the resulting tensor. Length must match number of axes of `block`.
-    backend : :class:`Backend`
-        The backend for the resulting tensor.
-    labels : list of str, optional
-        The labels for the resulting tensor.
-    num_domain_legs : int
-        How many of the legs should be in the domain. See :ref:`tensors_as_maps`.
+    For a map :math:`f: V \to W`, the transpose is a map :math:`f: W^* \to V^*`.
 
     Returns
     -------
-    If the block is symmetric, i.e. lives in the trivial sector, returns a :class:`Tensor`.
-    Otherwise, returns a :class:`ChargedTensor`.
+    TODO describe labels, leg order
     """
-    # TODO test
-    block = backend.as_block(block)
-    sectors = detect_sectors_from_block(block=block, legs=legs, backend=backend)
-    symmetry = legs[0].symmetry
-    if not symmetry.is_abelian:
-        # TODO in the non-abelian case we can not infer a single sector from the largest entry.
-        #  multiple sectors could have entries at that position.
-        #  The code below identifies all of these sectors and packages them in the dummy_leg.
-        #  We should either:
-        #   a) Assume the block is only in one of those sectors and identify which be calculating
-        #      overlaps.
-        #   b) leave that as is (allow multi-dimensional dummy_leg) and adjust docs accordingly
-        raise NotImplementedError
-    assert all(leg.symmetry == symmetry for leg in legs[1:])
-    dummy_leg = ProductSpace([ElementarySpace(symmetry, [s]) for s in sectors]).as_ElementarySpace().dual
-    if np.all(dummy_leg.sectors == symmetry.trivial_sector[None, :]):
-        return BlockDiagonalTensor.from_dense_block(block, legs=legs, backend=backend, labels=labels,
-                                                    num_domain_legs=num_domain_legs)
-    else:
-        assert dummy_leg.dim == 1
-        return ChargedTensor.from_dense_block(block, legs=legs, backend=backend, labels=labels,
-                                              charge=dummy_leg, num_domain_legs=num_domain_legs,
-                                              dummy_leg_state=backend.as_block([1]))
+    if isinstance(tensor, Mask):
+        raise NotImplementedError  # TODO
+    if isinstance(tensor, DiagonalTensor):
+        # TODO implement this backend method.
+        #      the result has dual leg, which means a permutation of sectors.
+        dual_leg, data = tensor.backend.diagonal_transpose(tensor)
+        labels = _dual_label_list(tensor._labels)
+        return DiagonalTensor(data=data, leg=dual_leg, backend=tensor.backend, labels=labels)
+    if isinstance(tensor, SymmetricTensor):
+        return SymmetricTensor(
+            data=tensor.backend.transpose(tensor),
+            codomain=tensor.domain.dual, domain=tensor.codomain.dual,
+            backend=tensor.backend,
+            labels=_dual_label_list(tensor._labels)
+        )
+    if isinstance(tensor, ChargedTensor):
+        inv_part = transpose(tensor.invariant_part)
+        inv_part.relabel({_dual_leg_label(ChargedTensor._CHARGE_LEG_LABEL): ChargedTensor._CHARGE_LEG_LABEL})
+        inv_part = move_leg(tensor, ChargedTensor._CHARGE_LEG_LABEL, domain_pos=0)
+        return ChargedTensor(inv_part, tensor.charged_state)
+    raise TypeError
 
 
-# ##################################
-# "private" helper functions
-# ##################################
-
-
-def _match_leg_order(t1: Tensor, t2: Tensor) -> list[int] | None:
-    """Utility function to determine how to match legs of two tensors.
-
-    In strict label mode, returns the permutation ``perm`` that matches the legs "by label",
-    i.e. such that ``t2.labels[perm[n]] == t1.labels[n]``.
-    In other words, it is the order of legs on ``t2``, such that they match those on ``t1``.
-    None is returned instead of a trivial permutation.
-    In lax label mode, we want to match the legs "by order" and hence always return None.
-    """
-    if config.strict_labels:
-        if _no_userdefined_labels(t1) and _no_userdefined_labels(t2):
-            return None
-        if not (t1.is_fully_labelled and t2.is_fully_labelled):
-            raise ValueError('In strict label mode, labelled tensors must be *fully* labelled.')
-        if t1.shape._labels == t2.shape._labels:
-            return None
-        return t2.get_leg_idcs(t1.labels)
-    else:
-        return None
+def zero_like(tensor: Tensor) -> Tensor:
+    if isinstance(tensor, Mask):
+        return Mask.from_zero(large_leg=tensor.large_leg, backend=tensor.backend, labels=tensor.labels)
+    if isinstance(tensor, DiagonalTensor):
+        return DiagonalTensor.from_zero(leg=tensor.leg, backend=tensor.backend, labels=tensor.labels,
+                                        dtype=tensor.dtype)
+    if isinstance(tensor, SymmetricTensor):
+        return SymmetricTensor.from_zero(codomain=tensor.codomain, domain=tensor.domain,
+                                         backend=tensor.backend, labels=tensor.labels,
+                                         dtype=tensor.dtype)
+    if isinstance(tensor, ChargedTensor):
+        return ChargedTensor.from_zero(
+            codomain=tensor.codomain, domain=tensor.domain, charge=tensor.charge_leg,
+            charged_state=tensor.charged_state, backend=tensor.backend, labels=tensor.labels,
+            dtype=tensor.dtype
+        )
+    raise TypeError
 
 
 T = TypeVar('T')
+
+
+def _combine_leg_labels(labels: list[str | None]) -> str:
+    """the label that a combined leg should have"""
+    return '(' + '.'.join(f'?{n}' if l is None else l for n, l in enumerate(labels)) + ')'
+
+
+def _dual_label_list(labels: list[str | None]) -> list[str | None]:
+    return [_dual_leg_label(l) for l in reversed(labels)]
+
+
+def _dual_leg_label(label: str | None) -> str | None:
+    """the label that a leg should have after conjugation"""
+    if label is None:
+        return None
+    if label.startswith('(') and label.endswith(')'):
+        return _combine_leg_labels(_dual_label_list(_split_leg_label(label)))
+    if label.endswith('*'):
+        return label[:-1]
+    else:
+        return label + '*'
+
+
+def _get_matching_labels(labels1: list[str | None], labels2: list[str | None],
+                         stacklevel: int = 1) -> list[str | None]:
+    """Utility function to combine two lists of labels that should match.
+
+    Per pair of labels::
+        - If one is ``None``, use the other.
+        - If they are equal, use that label.
+        - If they are different, emit DEBUG message to the logger and choose ``None``.
+          ``stacklevel=1`` refers to the line that calls this function. Increment to skip to
+          higher frames.
+    """
+    labels = []
+    conflicts = []
+    for n, (l1, l2) in enumerate(zip(labels1, labels2)):
+        if l1 is None:
+            labels.append(l2)
+        elif (l2 is None) or (l1 == l2):
+            labels.append(l1)
+        else:
+            conflicts.append(n)
+            labels.append(None)
+    if conflicts:
+        msg = (f'Conflicting labels at positions {", ".join(map(str, conflicts))} are dropped. '
+               f'{labels1=}, {labels2=}.')
+        logger.debug(msg, stacklevel=stacklevel + 1)
+    return labels
+
+
+def _is_valid_leg_label(label) -> bool:
+    # TODO this correct?
+    return label is None or isinstance(label, str)
+
+
+def _normalize_idx(idx: int, length: int) -> int:
+    assert -length <= idx < length, 'index out of bounds'
+    if idx < 0:
+        idx += length
+    return idx
 
 
 def _parse_idcs(idcs: T | Sequence[T | EllipsisType], length: int, fill: T = slice(None, None, None)
@@ -3969,46 +2838,6 @@ def _parse_idcs(idcs: T | Sequence[T | EllipsisType], length: int, fill: T = sli
         return idcs + [fill] * num_fill
 
 
-class _TensorIndexHelper:
-    """A helper class that redirects __getitem__ and __setitem__ to an Tensor.
-
-    See :meth:`~tenpy.linalg.tensors.Tensor.with_legs`.
-    """
-    def __init__(self, tensor: Tensor, which_legs: list[int | str]):
-        self.tensor = tensor
-        self.which_legs = which_legs
-
-    def transform_idcs(self, idcs):
-        idcs = _parse_idcs(idcs, length=len(self.which_legs))
-        res = [slice(None, None, None) for _ in range(self.tensor.num_legs)]
-        for which_leg, idx in zip(self.which_legs, idcs):
-            res[self.tensor.get_leg_idx(which_leg)] = idx
-        return res
-
-    def __getitem__(self, idcs):
-        return self.tensor.__getitem__(self.transform_idcs(idcs))
-
-    def __setitem__(self, idcs, value):
-        return self.tensor.__setitem__(self.transform_idcs(idcs), value)
-
-
-def _dual_leg_label(label: str) -> str:
-    """the label that a leg should have after conjugation"""
-    if label is None:
-        return None
-    if label.startswith('(') and label.endswith(')'):
-        return _combine_leg_labels([_dual_leg_label(l) for l in _split_leg_label(label)])
-    if label.endswith('*'):
-        return label[:-1]
-    else:
-        return label + '*'
-
-
-def _combine_leg_labels(labels: list[str | None]) -> str:
-    """the label that a combined leg should have"""
-    return '(' + '.'.join(f'?{n}' if l is None else l for n, l in enumerate(labels)) + ')'
-
-
 def _split_leg_label(label: str | None, num: int = None) -> list[str | None]:
     """undo _combine_leg_labels, i.e. recover the original labels"""
     if label is None:
@@ -4022,70 +2851,25 @@ def _split_leg_label(label: str | None, num: int = None) -> list[str | None]:
         raise ValueError('Invalid format for a combined label')
 
 
-def _no_userdefined_labels(t: Tensor) -> bool:
-    """If the labels of t are consistent with a user who never specifies labels.
+class _TensorIndexHelper:
+    """A helper class that redirects __getitem__ and __setitem__ to a Tensor.
 
-    This includes
-    - The label ``None``
-    - The labels '!' and '!*' (arising on the invariant part of a ChargedTensor)
-    - Results of combining legs that have consistent labels
+    See :meth:`~tenpy.linalg.tensors.Tensor.with_legs`.
     """
-    if all(l is None for l in t.labels):
-        # the most common case
-        return True
-    to_check = list(zip(t.legs, t.labels))  # tuples of (leg, label) pairs to check
-    while len(to_check) > 0:
-        leg, label = to_check.pop(0)
-        if label is None or label in ['!', '!*']:
-            continue
-        if isinstance(leg, ProductSpace):
-            try:
-                split_labels = _split_leg_label(label, len(leg.spaces))
-            except (ValueError, AssertionError):
-                return False
-            to_check.extend(zip(leg.spaces, split_labels))
-            continue
-        return False
-    return True
+    def __init__(self, tensor: Tensor, which_legs: list[int | str]):
+        self.tensor = tensor
+        self.which_legs = [tensor._parse_leg_idx(i)[2] for i in which_legs]
 
+    def transform_idc(self, idcs):
+        idcs = _parse_idcs(idcs, length=len(self.which_legs))
+        res = [slice(None, None, None) for _ in range(self.tensor.num_legs)]
+        for which_leg, idx in zip(self.which_legs, idcs):
+            res[which_leg] = idx
+        return res
 
-def _get_result_labels(legs1: list[str | None], legs2: list[str | None],
-                       relabel1: dict[str, str] | None, relabel2: dict[str, str] | None) -> list[str]:
-    """
-    Utility function to combine two lists of leg labels, such that they can appear on the same tensor.
-    Labels are changed by the mappings relabel1 and relabel2.
-    Any conflicting labels (after relabelling) are dropped
-    """
-    if relabel1 is None:
-        labels1 = legs1
-    else:
-        labels1 = [relabel1.get(leg, leg) for leg in legs1]
-    if relabel2 is None:
-        labels2 = legs2
-    else:
-        labels2 = [relabel2.get(leg, leg) for leg in legs2]
-    conflicting = [label for label in labels1 if (label is not None) and (label in labels2)]
-    labels = labels1 + labels2
-    if conflicting:
-        loglevel = logging.WARNING if config.strict_labels else logging.DEBUG
-        msg = f'Conflicting labels {", ".join(conflicting)} are dropped.'
-        # stacklevel 1 is this function, 2 is the API function using it, 3 could be from the user.
-        logger.log(loglevel, msg, stacklevel=3)
-        labels = [None if label in conflicting else label for label in labels]
-    return labels
+    def __getitem__(self, idcs):
+        return self.tensor.__getitem__(self.transform_idcs(idcs))
 
+    def __setitem__(self, idcs, value):
+        return self.tensor.__setitem__(self.transform_idcs(idcs), value)
 
-def _get_same_labels(labels1: list[str | None], labels2: list[str | None]) -> list[str | None]:
-    """Utility function that compares labels. Per pair of labels: If one is None, the other is chosen.
-    If both are not None and equal, they are chosen. If both are not None, but unequal, None is chosen
-    and a warning is emitted to logger.debug"""
-    labels = []
-    for l1, l2 in zip(labels1, labels2):
-        if l1 is None:
-            labels.append(l2)
-        elif l2 is None or l1 == l2:
-            labels.append(l1)
-        else:
-            logger.debug(f'Conflicting labels {l1} vs. {l2} are dropped.', stacklevel=4)
-            labels.append(None)
-    return labels

--- a/tenpy/linalg/tensors.py
+++ b/tenpy/linalg/tensors.py
@@ -61,7 +61,7 @@ it can be directly contracted with ``A``.
 from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 import operator
-from typing import TypeVar, Sequence, Iterator
+from typing import TypeVar, Sequence
 from numbers import Number, Integral
 import numpy as np
 import warnings

--- a/tenpy/linalg/tensors.py
+++ b/tenpy/linalg/tensors.py
@@ -61,7 +61,6 @@ it can be directly contracted with ``A``.
 from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 import operator
-from types import EllipsisType
 from typing import TypeVar, Sequence, Iterator
 from numbers import Number, Integral
 import numpy as np
@@ -3333,7 +3332,7 @@ def _normalize_idx(idx: int, length: int) -> int:
     return idx
 
 
-def _parse_idcs(idcs: T | Sequence[T | EllipsisType], length: int, fill: T = slice(None, None, None)
+def _parse_idcs(idcs: T | Sequence[T], length: int, fill: T = slice(None, None, None)
                 ) -> list[T]:
     """Parse a single index or sequence of indices to a list of given length by replacing Ellipsis
     (``...``) and missing entries at the back with `fill`.

--- a/tenpy/linalg/tensors.py
+++ b/tenpy/linalg/tensors.py
@@ -367,9 +367,15 @@ class Tensor(metaclass=ABCMeta):
             raise SymmetryError(f'Tensor.size is not defined for symmetry {self.symmetry}')
         return self.parent_space.dim
 
+    def __float__(self):
+        raise TypeError('float() of a tensor is not defined. Use tenpy.item() instead.')
+
     def __eq__(self, other):
         msg = f'{self.__class__.__name__} does not support == comparison. Use tenpy.almost_equal instead.'
         raise TypeError(msg)
+
+    def __complex__(self):
+        raise TypeError('complex() of a tensor is not defined. Use tenpy.item() instead.')
 
     def _parse_leg_idx(self, idx: int | str) -> tuple[bool, int, int]:
         """Parse a leg index or a leg label.

--- a/tenpy/linalg/tensors.py
+++ b/tenpy/linalg/tensors.py
@@ -1126,7 +1126,7 @@ class DiagonalTensor(SymmetricTensor):
         """
         assert tens.num_legs == 2
         assert tens.domain == tens.codomain
-        data = tens.backend.diagonal_data_from_full_tensor(tens, check_offdiagonal=check_offdiagonal)
+        data = tens.backend.diagonal_tensor_from_full_tensor(tens, check_offdiagonal=check_offdiagonal)
         return cls(data=data, leg=tens.codomain.spaces[0], backend=tens.backend, labels=tens.labels)
 
     @classmethod

--- a/tenpy/linalg/trees.py
+++ b/tenpy/linalg/trees.py
@@ -1,4 +1,5 @@
 """TODO module docstring"""
+# Copyright (C) TeNPy Developers, GNU GPLv3
 from __future__ import annotations
 from typing import Iterator
 import numpy as np

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -273,8 +273,9 @@ class Site(Hdf5Exportable):
             if len(self.backend.block_shape(op)) == 1:
                 op = DiagonalTensor.from_diag(op, self.leg, backend=self.backend, labels=['p', 'p*'])
             else:
-                op = tensor_from_block(op, legs=[self.leg, self.leg.dual], backend=self.backend,
-                                       labels=['p', 'p*'])
+                raise NotImplementedError  # TODO
+                # op = tensor_from_block(op, legs=[self.leg, self.leg.dual], backend=self.backend,
+                #                        labels=['p', 'p*'])
         if cls is Tensor:
             if isinstance(op, SymmetricTensor):
                 try:

--- a/tenpy/tools/docs.py
+++ b/tenpy/tools/docs.py
@@ -1,6 +1,5 @@
-"""Tools for handling docstrings.
-"""
-# Copyright 2023 TeNPy Developers, GNU GPLv3
+"""Tools for handling docstrings."""
+# Copyright (C) TeNPy Developers, GNU GPLv3
 
 __all__ = ['amend_parent_docstring']
 

--- a/tenpy/version.py
+++ b/tenpy/version.py
@@ -92,7 +92,6 @@ full_version = _get_full_version()
 def _get_version_summary():
     import numpy
     import scipy
-    import warnings
     summary = ("tenpy {tenpy_ver!s},\n"
                "git revision {git_rev!s} using\n"
                "python {python_ver!s}\n"

--- a/tests/benchmark/misc.py
+++ b/tests/benchmark/misc.py
@@ -7,7 +7,7 @@ from tenpy.linalg.backends.abstract_backend import Backend
 from tenpy.linalg.backends.numpy import NumpyBlockBackend
 from tenpy.linalg.backends.no_symmetry import NoSymmetryBackend
 from tenpy.linalg.backends.abelian import AbelianBackend
-from tenpy.linalg.tensors import BlockDiagonalTensor
+from tenpy.linalg.tensors import SymmetricTensor
 
 
 def random_symmetry_sectors(symmetry: symmetries.Symmetry, np_random: np.random.Generator, len_=None
@@ -172,7 +172,7 @@ def get_random_tensor(symmetry: symmetries.Symmetry, backend: Backend,
             res = res + 1.j * np.random.normal(size=size)
         return res
 
-    return BlockDiagonalTensor.from_numpy_func(func=random_block, legs=legs, backend=backend)
+    return SymmetricTensor.from_numpy_func(func=random_block, legs=legs, backend=backend)
 
 
 def get_qmod(sym):
@@ -205,7 +205,7 @@ def convert_Space_to_LegCharge(leg: spaces.Space, old_tenpy, chinfo=None):
     return old_tenpy.linalg.charges.LegCharge(chinfo, slices, charges, qconj)
 
 
-def convert_Tensor_to_Array(a: BlockDiagonalTensor, old_tenpy, chinfo=None):
+def convert_Tensor_to_Array(a: SymmetricTensor, old_tenpy, chinfo=None):
     """Convert a v2.0 Tensor to a v0.x Array
 
     If given, use chinfo, otherwise generate it from `a.symmetry`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,6 @@ The function returned by the fixture ``make_compatible_tensor`` has the followin
 from __future__ import annotations
 import numpy as np
 import pytest
-from typing import Callable
 
 from tenpy.linalg import backends, spaces, symmetries, tensors
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,8 +317,8 @@ def make_compatible_tensor(compatible_backend, compatible_symmetry, make_compati
                 inv_domain = domain.left_multiply(charge_leg, backend=compatible_backend)
             else:
                 inv_domain = [charge_leg, *domain]
-            inv_labels = [tensors.ChargedTensor._CHARGE_LEG_LABEL, *labels]
-            inv_part = make(codomain=codomain, domain=inv_domain, labels=labels,
+            inv_labels = [*labels, tensors.ChargedTensor._CHARGE_LEG_LABEL]
+            inv_part = make(codomain=codomain, domain=inv_domain, labels=inv_labels,
                             max_blocks=max_blocks, max_block_size=max_block_size, empty_ok=empty_ok,
                             all_blocks=all_blocks, cls=tensors.SymmetricTensor)
             res = tensors.ChargedTensor(inv_part, charged_state=[1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,7 +550,7 @@ def randomly_drop_blocks(res: tensors.SymmetricTensor | tensors.DiagonalTensor,
         res.data = backends.FusionTreeData(
             coupled_sectors=res.data.coupled_sectors[which, :],
             blocks=[res.data.blocks[n] for n in which],
-            domain=res.data.domain, codomain=res.data.codomain, dtype=res.data.dtype
+            dtype=res.data.dtype
         )
         return res
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ The function returned by the fixture ``make_compatible_tensor`` has the followin
 
 """
 # Copyright (C) TeNPy Developers, GNU GPLv3
-
+from __future__ import annotations
 import numpy as np
 import pytest
 from typing import Callable

--- a/tests/linalg/test_backend_nonabelian.py
+++ b/tests/linalg/test_backend_nonabelian.py
@@ -10,7 +10,7 @@ from tenpy.linalg.spaces import ProductSpace
 def test_block_sizes(any_symmetry, make_any_space, make_any_sectors, block_backend, num_spaces):
     backend = get_backend('fusion_tree', block_backend)
     spaces = [make_any_space() for _ in range(num_spaces)]
-    domain = ProductSpace(spaces, backend, any_symmetry)
+    domain = ProductSpace(spaces, symmetry=any_symmetry, backend=backend)
 
     for coupled in make_any_sectors(10):
         expect = sum(fusion_tree_backend.forest_block_size(domain, uncoupled, coupled)

--- a/tests/linalg/test_krylov_based.py
+++ b/tests/linalg/test_krylov_based.py
@@ -11,6 +11,7 @@ from tenpy.linalg import krylov_based, sparse, tensors, random_matrix, spaces
 
 @pytest.mark.parametrize(['N_cache', 'tol'], [(10, 5.e-13), (20, 5.e-14)])
 def test_lanczos_gs(compatible_backend, make_compatible_space, N_cache, tol):
+    pytest.skip()  # FIXME
     # generate hermitian test array
     leg = make_compatible_space()
     backend = compatible_backend

--- a/tests/linalg/test_krylov_based.py
+++ b/tests/linalg/test_krylov_based.py
@@ -9,9 +9,13 @@ import tenpy as tp
 from tenpy.linalg import krylov_based, sparse, tensors, random_matrix, spaces
 
 
+pytest.skip("krylov_based not yet revised", allow_module_level=True)  # TODO
+
+
 @pytest.mark.parametrize(['N_cache', 'tol'], [(10, 5.e-13), (20, 5.e-14)])
 def test_lanczos_gs(compatible_backend, make_compatible_space, N_cache, tol):
-    pytest.skip()  # FIXME
+    # TODO revise this. purge the "dummy" language, its now "charged"
+    
     # generate hermitian test array
     leg = make_compatible_space()
     backend = compatible_backend
@@ -22,10 +26,10 @@ def test_lanczos_gs(compatible_backend, make_compatible_space, N_cache, tol):
         # and GUE((1, 9)) generates blocks with shape (9, 9) without error!!
         # should GUE etc be Tensor classmethods?
         with pytest.raises(AssertionError, match='not a square matrix shape'):
-            H = tensors.BlockDiagonalTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
+            H = tensors.SymmetricTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
         return
     
-    H = tensors.BlockDiagonalTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
+    H = tensors.SymmetricTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
 
     if isinstance(H.backend, tp.linalg.backends.FusionTreeBackend) and isinstance(leg.symmetry, tp.ProductSymmetry):
         # TODO
@@ -115,10 +119,10 @@ def test_lanczos_evolve(compatible_backend, make_compatible_space, N_cache, tol)
         # and GUE((1, 9)) generates blocks with shape (9, 9) without error!!
         # should GUE etc be Tensor classmethods?
         with pytest.raises(AssertionError, match='not a square matrix shape'):
-            H = tensors.BlockDiagonalTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
+            H = tensors.SymmetricTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
         return
     
-    H = tensors.BlockDiagonalTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
+    H = tensors.SymmetricTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
     H_op = sparse.TensorLinearOperator(H, which_leg=1)
 
     if isinstance(H.backend, tp.linalg.backends.FusionTreeBackend) and isinstance(leg.symmetry, tp.ProductSymmetry):
@@ -167,10 +171,10 @@ def test_arnoldi(compatible_backend, make_compatible_space, which, N_max=20):
         # and GUE((1, 9)) generates blocks with shape (9, 9) without error!!
         # should GUE etc be Tensor classmethods?
         with pytest.raises(AssertionError, match='not a square matrix shape'):
-            H = tensors.BlockDiagonalTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
+            H = tensors.SymmetricTensor.from_numpy_func(random_matrix.GUE, legs=[leg, leg.dual], backend=backend)
         return
     
-    H = tensors.BlockDiagonalTensor.from_numpy_func(func, legs=[leg, leg.dual], backend=backend)
+    H = tensors.SymmetricTensor.from_numpy_func(func, legs=[leg, leg.dual], backend=backend)
     H_op = sparse.TensorLinearOperator(H, which_leg=1)
 
     if isinstance(H.backend, tp.linalg.backends.FusionTreeBackend) and isinstance(leg.symmetry, tp.ProductSymmetry):

--- a/tests/linalg/test_krylov_based.py
+++ b/tests/linalg/test_krylov_based.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.linalg import expm
 
 import tenpy as tp
-from tenpy.linalg import krylov_based, sparse, tensors, random_matrix, spaces
+from tenpy.linalg import krylov_based, sparse, tensors, random_matrix
 
 
 pytest.skip("krylov_based not yet revised", allow_module_level=True)  # TODO

--- a/tests/linalg/test_matrix_operations.py
+++ b/tests/linalg/test_matrix_operations.py
@@ -400,7 +400,7 @@ def test_eigh(make_compatible_tensor, make_compatible_space, real, sort, new_leg
     assert U.dtype == T.dtype
 
     print('checking legs and labels')
-    new_leg = spaces.ProductSpace([a, b]).as_VectorSpace().dual
+    new_leg = spaces.ProductSpace([a, b]).as_ElementarySpace().dual
     if new_leg.is_dual != new_leg_dual:
         new_leg = new_leg.flip_is_dual()
     assert D.legs == [new_leg.dual, new_leg]

--- a/tests/linalg/test_matrix_operations.py
+++ b/tests/linalg/test_matrix_operations.py
@@ -4,7 +4,6 @@ import numpy as np
 import scipy
 import numpy.testing as npt
 import pytest
-import warnings
 
 from tenpy.linalg import tensors, matrix_operations, spaces, ProductSymmetry, backends
 

--- a/tests/linalg/test_matrix_operations.py
+++ b/tests/linalg/test_matrix_operations.py
@@ -9,6 +9,9 @@ import warnings
 from tenpy.linalg import tensors, matrix_operations, spaces, ProductSymmetry, backends
 
 
+pytest.skip("matrix_operations not yet revised", allow_module_level=True)  # TODO
+
+
 def assert_permuted_eye(arr):
     """If the input 2D array is approximately equal to the identity up to independent
     permutations of rows and columns"""
@@ -32,7 +35,7 @@ def assert_permuted_eye(arr):
 def test_svd(make_compatible_tensor, new_vh_leg_dual, all_labels, l_labels, r_labels):
     assert set(l_labels + r_labels) == set(all_labels)
     print(f'leg bipartition {all_labels} -> {l_labels} & {r_labels}')
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(labels=all_labels, max_block_size=3)
+    T: tensors.SymmetricTensor = make_compatible_tensor(labels=all_labels, max_block_size=3)
     #  T_dense = T.to_numpy()
 
     if isinstance(T.backend, backends.FusionTreeBackend):
@@ -77,7 +80,7 @@ def test_svd(make_compatible_tensor, new_vh_leg_dual, all_labels, l_labels, r_la
 @pytest.mark.parametrize('svd_min, normalize_to', [(1e-14, None), (1e-4, None), (1e-4, 2.7)])
 @pytest.mark.parametrize('new_vh_leg_dual', [True, False])
 def test_truncated_svd(make_compatible_tensor, new_vh_leg_dual, svd_min, normalize_to):
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(
+    T: tensors.SymmetricTensor = make_compatible_tensor(
         labels=['l1', 'r2', 'l2', 'r1'], max_block_size=3
     )
 
@@ -126,7 +129,7 @@ def test_truncated_svd(make_compatible_tensor, new_vh_leg_dual, svd_min, normali
 @pytest.mark.parametrize('new_vh_leg_dual', [True, False])
 @pytest.mark.parametrize('compute_u, compute_vh', [(True, False), (False, True), (False, False)])
 def test_eig_based_svd(make_compatible_tensor, compute_u, compute_vh, new_vh_leg_dual):
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(
+    T: tensors.SymmetricTensor = make_compatible_tensor(
         labels=['l1', 'r2', 'l2', 'r1'], max_block_size=3,
         all_blocks=True,  # TODO debug with missing blocks!
     )
@@ -203,7 +206,7 @@ def test_eig_based_svd(make_compatible_tensor, compute_u, compute_vh, new_vh_leg
 @pytest.mark.parametrize('compute_u, compute_vh', [(False, True), (True, False), (False, False)])
 def test_truncated_eig_based_svd(make_compatible_tensor, compute_u, compute_vh, new_vh_leg_dual, svd_min,
                                  normalize_to):
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(
+    T: tensors.SymmetricTensor = make_compatible_tensor(
         labels=['l1', 'r2', 'l2', 'r1'], max_block_size=3,
         all_blocks=True,  # TODO debug with missing blocks!
     )
@@ -284,7 +287,7 @@ def test_truncated_eig_based_svd(make_compatible_tensor, compute_u, compute_vh, 
 @pytest.mark.parametrize('full', [True, False])
 @pytest.mark.parametrize('new_r_leg_dual', [True, False])
 def test_qr(make_compatible_tensor, new_r_leg_dual, full):
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(
+    T: tensors.SymmetricTensor = make_compatible_tensor(
         labels=['l1', 'r2', 'l2', 'r1'], max_block_size=3
     )
 
@@ -325,7 +328,7 @@ def test_qr(make_compatible_tensor, new_r_leg_dual, full):
 @pytest.mark.parametrize('full', [True, False])
 @pytest.mark.parametrize('new_l_leg_dual', [True, False])
 def test_lq(make_compatible_tensor, new_l_leg_dual, full):
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(
+    T: tensors.SymmetricTensor = make_compatible_tensor(
         labels=['l1', 'r2', 'l2', 'r1'], max_block_size=3
     )
 
@@ -376,7 +379,7 @@ def test_lq(make_compatible_tensor, new_l_leg_dual, full):
 def test_eigh(make_compatible_tensor, make_compatible_space, real, sort, new_leg_dual):
     a = make_compatible_space()
     b = make_compatible_space()
-    T: tensors.BlockDiagonalTensor = make_compatible_tensor(
+    T: tensors.SymmetricTensor = make_compatible_tensor(
         legs=[a, b.dual, b, a.dual], real=real, labels=['a', 'b*', 'b', 'a*']
     )
 

--- a/tests/linalg/test_spaces.py
+++ b/tests/linalg/test_spaces.py
@@ -437,7 +437,7 @@ def test_str_repr(make_any_space, str_max_lines=20, repr_max_lines=20):
         print(res)
 
 
-# FIXME move to some testing tools module?
+# TODO move to some testing tools module?
 def assert_spaces_equal(space1: spaces.Space, space2: spaces.Space):
     if isinstance(space1, spaces.ElementarySpace):
         assert isinstance(space2, spaces.ElementarySpace), 'mismatching types'

--- a/tests/linalg/test_sparse.py
+++ b/tests/linalg/test_sparse.py
@@ -7,14 +7,17 @@ import scipy
 
 from tenpy.linalg import sparse, tensors, spaces, backends
 from tenpy.linalg.backends.backend_factory import get_backend
-from tenpy.linalg.tensors import Tensor, BlockDiagonalTensor, Shape, Dtype, almost_equal
+from tenpy.linalg.tensors import Tensor, SymmetricTensor, Dtype, almost_equal
+
+pytest.skip("sparse not yet revised", allow_module_level=True)  # TODO
+
 
 
 # define a few simple operators to test the wrappers:
 
 
 class ScalingDummyOperator(sparse.LinearOperator):
-    def __init__(self, factor, vector_shape: Shape):
+    def __init__(self, factor, vector_shape: 'Shape'):
         super().__init__(vector_shape=vector_shape, dtype=Dtype.complex128)
         self.factor = factor
         self.some_weird_attribute = 'arbitrary value'
@@ -27,7 +30,7 @@ class ScalingDummyOperator(sparse.LinearOperator):
 
     def to_tensor(self, backend=None) -> Tensor:
         assert backend is not None, 'backend kwarg is needed for ScalingDummyOperator.to_tensor'
-        return self.factor * BlockDiagonalTensor.eye(
+        return self.factor * SymmetricTensor.eye(
             legs=self.vector_shape.legs, backend=backend, labels=self.vector_shape.labels
         )
 
@@ -36,7 +39,7 @@ class ScalingDummyOperator(sparse.LinearOperator):
 
 
 class TensorDummyOperator(sparse.LinearOperator):
-    def __init__(self, tensor: BlockDiagonalTensor):
+    def __init__(self, tensor: SymmetricTensor):
         assert tensor.labels == ['a', 'b*', 'a*', 'b']
         acts_on = ['a', 'b']
         # TODO should we be strict about num_domain_legs here?
@@ -204,7 +207,7 @@ def test_NumpyArrayLinearOperator_sector(make_compatible_space, make_compatible_
             H, legs1=['a*', 'b*'], legs2=['a', 'b'], charge_sector=sector
         )
     psi_init = tensors.ChargedTensor.random_uniform(legs=[a, b], charge=sector, labels=['a', 'b'],
-                                                    dummy_leg_state=[1])
+                                                    charged_state=[1])
     psi_init_np = H_op.tensor_to_flat_array(psi_init)
     #
     E, psi = scipy.sparse.linalg.eigsh(H_op, k, v0=psi_init_np, which='SA')

--- a/tests/linalg/test_tensors.py
+++ b/tests/linalg/test_tensors.py
@@ -1418,7 +1418,7 @@ def OLD_test_Tensor_tofrom_dense_block_trivial_sector(make_compatible_tensor):
                                        100)
 
 
-def OLD_test_ChargedTensor_tofrom_flat_block_single_sector(compatible_symmetry, make_compatible_sectors,
+def OLD_test_ChargedTensor_tofrom_dense_block_single_sector(compatible_symmetry, make_compatible_sectors,
                                                        make_compatible_tensor):
     pytest.xfail(reason='unclear')  # TODO
     # TODO revise this. purge the "dummy" language, its now "charged"

--- a/tests/linalg/test_tensors.py
+++ b/tests/linalg/test_tensors.py
@@ -185,23 +185,6 @@ def test_SymmetricTensor(make_compatible_tensor, make_compatible_space, leg_nums
     _ = str(zero_tens)
     _ = repr(zero_tens)
 
-    # TODO reactivate
-    # print('check addition and multiplication')
-    # numpy_block2 = T2.to_numpy()
-    # npt.assert_allclose((-T).to_numpy(), -numpy_block)
-    # npt.assert_allclose((42.3 * T).to_numpy(), 42.3 * numpy_block)
-    # npt.assert_allclose((T / 2.j).to_numpy(), numpy_block / 2.j)
-    # npt.assert_allclose((T + T2).to_numpy(), numpy_block + numpy_block2)
-    # npt.assert_allclose((T - T2).to_numpy(), numpy_block - numpy_block2)
-
-    # TODO reactivate
-    # print('check float conversion etc')
-    # a, b, c, d = [make_compatible_space(max_sectors=1, max_mult=1) for _ in range(4)]
-    # T_scalar: tensors.SymmetricTensor = make_compatible_tensor([a, b], [c, d])
-    # value = T_scalar.to_numpy().item()
-    # npt.assert_allclose(float(T_scalar), value)
-    # npt.assert_allclose(complex(T_scalar), value)
-
 
 def test_DiagonalTensor(make_compatible_tensor):
     T: tensors.DiagonalTensor = make_compatible_tensor(cls=tensors.DiagonalTensor)
@@ -715,6 +698,151 @@ def test_str_repr(make_compatible_tensor, str_max_lines=30, repr_max_lines=30):
         assert len(res) <= str_max_len
         assert res.count('\n') <= str_max_lines
         print(res)
+
+
+# TENSOR FUNCTIONS
+
+
+def test_add_trivial_leg():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_elementwise_functions():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_almost_equal():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_apply_mask():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_bend_legs():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_combine_legs():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_conj():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_dagger():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_compose():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_entropy():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_inner():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_is_scalar():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_item():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_linear_combination(make_compatible_tensor_any_class):
+    v, w = make_compatible_tensor_any_class(2)
+    assert v.domain == w.domain
+    assert v.codomain == w.codomain
+    
+    needs_fusion_tensor = type(v) in [tensors.SymmetricTensor, tensors.ChargedTensor] \
+        and isinstance(v.backend, backends.FusionTreeBackend)
+    if needs_fusion_tensor and isinstance(v.symmetry, ProductSymmetry):
+        with pytest.raises(NotImplementedError):
+            T_np = v.to_numpy()
+        return
+
+    v_np = v.to_numpy()
+    w_np = w.to_numpy()
+    for valid_scalar in [0, 1., 2. + 3.j, -42]:
+        res = tensors.linear_combination(valid_scalar, v, 2 * valid_scalar, w)
+        expect = valid_scalar * v_np + 2 * valid_scalar * w_np
+        npt.assert_allclose(res.to_numpy(), expect)
+    for invalid_scalar in [None, (1, 2), v, 'abc']:
+        with pytest.raises(TypeError, match='unsupported scalar types'):
+            _ = tensors.linear_combination(invalid_scalar, v, invalid_scalar, w)
+
+
+def test_move_leg():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_norm():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_outer():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_permute_legs():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_scalar_multiply(make_compatible_tensor_any_class):
+    T = make_compatible_tensor_any_class()
+    
+    needs_fusion_tensor = type(T) in [tensors.SymmetricTensor, tensors.ChargedTensor] \
+        and isinstance(T.backend, backends.FusionTreeBackend)
+    if needs_fusion_tensor and isinstance(T.symmetry, ProductSymmetry):
+        with pytest.raises(NotImplementedError):
+            T_np = T.to_numpy()
+        return
+    
+    T_np = T.to_numpy()
+    for valid_scalar in [0, 1., 2. + 3.j, -42]:
+        res = tensors.scalar_multiply(valid_scalar, T)
+        npt.assert_allclose(res.to_numpy(), valid_scalar * T_np)
+    for invalid_scalar in [None, (1, 2), T, 'abc']:
+        with pytest.raises(TypeError, match='unsupported scalar type'):
+            _ = tensors.scalar_multiply(invalid_scalar, T)
+
+
+def test_scale_axis():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_set_as_slice():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_split_legs():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_squeeze_legs():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_tdot():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_trace():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_transpose():
+    pytest.skip('Test not written yet')  # TODO
+
+
+def test_zero_like():
+    pytest.skip('Test not written yet')  # TODO
 
 
 # TODO old test below

--- a/tests/linalg/test_tensors.py
+++ b/tests/linalg/test_tensors.py
@@ -685,6 +685,38 @@ def test_from_block_su2_symm(symmetry_backend, block_backend):
     assert backend.block_allclose(recovered_block, heisenberg_4)
 
 
+def test_str_repr(make_compatible_tensor, str_max_lines=30, repr_max_lines=30):
+    """Check if str and repr work. Automatically, we can only check if they run at all.
+    To check if the output is sensible and useful, a human should look at it.
+    Run ``pytest -rP -k test_str_repr > output.txt`` to see the output.
+    """
+    terminal_width = 80
+    str_max_len = terminal_width * str_max_lines
+    repr_max_len = terminal_width * str_max_lines
+    mps_tens = make_compatible_tensor(labels=['vL', 'p', 'vR'], codomain=1, domain=2)
+    local_op = make_compatible_tensor(labels=['p', 'p*'], codomain=1, domain=1)
+    for t in [mps_tens, local_op]:
+        print()
+        print()
+        print('----------------------')
+        print('__repr__()')
+        print('----------------------')
+        res = repr(t)
+        assert len(res) <= repr_max_len
+        assert res.count('\n') <= repr_max_lines
+        print(res)
+        
+        print()
+        print()
+        print('----------------------')
+        print('__str__()')
+        print('----------------------')
+        res = str(t)
+        assert len(res) <= str_max_len
+        assert res.count('\n') <= str_max_lines
+        print(res)
+
+
 # TODO old test below
 
 
@@ -1298,39 +1330,6 @@ def OLD_test_flip_leg_duality(make_compatible_tensor, which_legs):
     T_np = T.to_numpy()
     res_np = res.to_numpy()
     npt.assert_array_almost_equal_nulp(T_np, res_np, 100)
-
-
-def OLD_test_str_repr(make_compatible_tensor, str_max_lines=30, repr_max_lines=30):
-    """Check if str and repr work. Automatically, we can only check if they run at all.
-    To check if the output is sensible and useful, a human should look at it.
-    Run ``pytest -rP -k test_str_repr > output.txt`` to see the output.
-    """
-    terminal_width = 80
-    str_max_len = terminal_width * str_max_lines
-    repr_max_len = terminal_width * str_max_lines
-    mps_tens = make_compatible_tensor(labels=['vL', 'p', 'vR'])
-    local_state = make_compatible_tensor(labels=['p'])
-    local_op = make_compatible_tensor(labels=['p', 'p*'])
-    for t in [mps_tens, local_state, local_op]:
-        print()
-        print()
-        print('----------------------')
-        print('__repr__()')
-        print('----------------------')
-        res = repr(t)
-        assert len(res) <= repr_max_len
-        assert res.count('\n') <= repr_max_lines
-        print(res)
-        
-        print()
-        print()
-        print('----------------------')
-        print('__str__()')
-        print('----------------------')
-        res = str(t)
-        assert len(res) <= str_max_len
-        assert res.count('\n') <= str_max_lines
-        print(res)
 
 
 def OLD_test_Mask(np_random, make_compatible_space, compatible_backend):

--- a/tests/linalg/test_tensors.py
+++ b/tests/linalg/test_tensors.py
@@ -692,70 +692,70 @@ def OLD_test_tdot(make_compatible_space, make_compatible_sectors, make_compatibl
     # define legs such that a tensor with the following combinations all allow non-zero num_parameters
     # [a, b] , [a, b, c*] , [a, b, d*]
     return  # TODO adapt to domain -> codomain
-    from conftest import find_last_leg
-    a = make_compatible_space()
-    b = find_compatible_leg([a], max_sectors=3, max_mult=3, extra_sectors=make_compatible_sectors(3))
-    c = find_compatible_leg([a, b], max_sectors=3, max_mult=3, extra_sectors=make_compatible_sectors(3)).dual
-    d = find_compatible_leg([a, b], max_sectors=3, max_mult=3, extra_sectors=make_compatible_sectors(3)).dual
-    print([l.dim for l in [a, b, c, d]])
+    # from conftest import find_last_leg
+    # a = make_compatible_space()
+    # b = find_compatible_leg([a], max_sectors=3, max_mult=3, extra_sectors=make_compatible_sectors(3))
+    # c = find_compatible_leg([a, b], max_sectors=3, max_mult=3, extra_sectors=make_compatible_sectors(3)).dual
+    # d = find_compatible_leg([a, b], max_sectors=3, max_mult=3, extra_sectors=make_compatible_sectors(3)).dual
+    # print([l.dim for l in [a, b, c, d]])
     
-    legs_ = [[a, b, c.dual],
-             [d, b.dual, a.dual],
-             [b.dual, a.dual],
-             [a, b]]
-    labels_ = [['a', 'b', 'c*'],
-               ['d', 'b*', 'a*'],
-               ['b*', 'a*'],
-               ['a', 'b']
-               ]
-    tensors_ = [
-        make_compatible_tensor(legs=legs, labels=labels) for legs, labels in zip(legs_, labels_)
-    ]
-    for n, t in enumerate(tensors_):
-        # make sure we are defining tensors which actually contain blocks and are not just zero by
-        # charge conservation
-        assert t.num_parameters > 0, f'tensor {n} has 0 free parameters'
+    # legs_ = [[a, b, c.dual],
+    #          [d, b.dual, a.dual],
+    #          [b.dual, a.dual],
+    #          [a, b]]
+    # labels_ = [['a', 'b', 'c*'],
+    #            ['d', 'b*', 'a*'],
+    #            ['b*', 'a*'],
+    #            ['a', 'b']
+    #            ]
+    # tensors_ = [
+    #     make_compatible_tensor(legs=legs, labels=labels) for legs, labels in zip(legs_, labels_)
+    # ]
+    # for n, t in enumerate(tensors_):
+    #     # make sure we are defining tensors which actually contain blocks and are not just zero by
+    #     # charge conservation
+    #     assert t.num_parameters > 0, f'tensor {n} has 0 free parameters'
 
-    if isinstance(tensors_[0].backend, backends.FusionTreeBackend) and isinstance(a.symmetry, ProductSymmetry):
-        with pytest.raises(NotImplementedError, match='should be implemented by subclass'):
-            dense_ = [t.to_numpy() for t in tensors_]
-        return  # TODO
+    # if isinstance(tensors_[0].backend, backends.FusionTreeBackend) and isinstance(a.symmetry, ProductSymmetry):
+    #     with pytest.raises(NotImplementedError, match='should be implemented by subclass'):
+    #         dense_ = [t.to_numpy() for t in tensors_]
+    #     return  # TODO
     
-    dense_ = [t.to_numpy() for t in tensors_]
+    # dense_ = [t.to_numpy() for t in tensors_]
 
-    checks = [("single leg", 0, 1, 1, 1, 'b', 'b*'),
-              ("two legs", 0, 1, [0, 1], [2, 1], ['a', 'b'], ['a*', 'b*']),
-              ("all legs of first tensor", 2, 0, [0, 1], [1, 0], ['a*', 'b*'], ['a', 'b']),
-              ("all legs of second tensor", 1, 3, [1, 2], [1, 0], ['a*', 'b*'], ['a', 'b']),
-              ("scalar result / inner()", 2, 3, [0, 1], [1, 0], ['a*', 'b*'], ['a', 'b']),
-              ("no leg / outer()", 2, 3, [], [], [], []),
-              ]
-    for comment, i, j, ax_i, ax_j, lbl_i, lbl_j in checks:
-        print('tdot: contract ', comment)
-        expect = np.tensordot(dense_[i], dense_[j], (ax_i, ax_j))
+    # checks = [("single leg", 0, 1, 1, 1, 'b', 'b*'),
+    #           ("two legs", 0, 1, [0, 1], [2, 1], ['a', 'b'], ['a*', 'b*']),
+    #           ("all legs of first tensor", 2, 0, [0, 1], [1, 0], ['a*', 'b*'], ['a', 'b']),
+    #           ("all legs of second tensor", 1, 3, [1, 2], [1, 0], ['a*', 'b*'], ['a', 'b']),
+    #           ("scalar result / inner()", 2, 3, [0, 1], [1, 0], ['a*', 'b*'], ['a', 'b']),
+    #           ("no leg / outer()", 2, 3, [], [], [], []),
+    #           ]
+    # for comment, i, j, ax_i, ax_j, lbl_i, lbl_j in checks:
+    #     print('tdot: contract ', comment)
+    #     expect = np.tensordot(dense_[i], dense_[j], (ax_i, ax_j))
 
-        if isinstance(tensors_[0].backend, backends.FusionTreeBackend):
-            with pytest.raises(NotImplementedError, match='tdot not implemented'):        
-                res1 = tensors.tdot(tensors_[i], tensors_[j], ax_i, ax_j)
-            return  # TODO
+    #     if isinstance(tensors_[0].backend, backends.FusionTreeBackend):
+    #         with pytest.raises(NotImplementedError, match='tdot not implemented'):        
+    #             res1 = tensors.tdot(tensors_[i], tensors_[j], ax_i, ax_j)
+    #         return  # TODO
         
-        res1 = tensors.tdot(tensors_[i], tensors_[j], ax_i, ax_j)
-        res2 = tensors.tdot(tensors_[i], tensors_[j], lbl_i, lbl_j)
-        if len(expect.shape) > 0:
-            res1.test_sanity()
-            res2.test_sanity()
-            res1_d = res1.to_numpy()
-            res2_d = res2.to_numpy()
-            npt.assert_array_almost_equal(res1_d, expect)
-            npt.assert_array_almost_equal(res2_d, expect)
-        else: # got scalar, but we can compare it to 0-dim ndarray
-            npt.assert_almost_equal(res1, expect)
-            npt.assert_almost_equal(res2, expect)
+    #     res1 = tensors.tdot(tensors_[i], tensors_[j], ax_i, ax_j)
+    #     res2 = tensors.tdot(tensors_[i], tensors_[j], lbl_i, lbl_j)
+    #     if len(expect.shape) > 0:
+    #         res1.test_sanity()
+    #         res2.test_sanity()
+    #         res1_d = res1.to_numpy()
+    #         res2_d = res2.to_numpy()
+    #         npt.assert_array_almost_equal(res1_d, expect)
+    #         npt.assert_array_almost_equal(res2_d, expect)
+    #     else: # got scalar, but we can compare it to 0-dim ndarray
+    #         npt.assert_almost_equal(res1, expect)
+    #         npt.assert_almost_equal(res2, expect)
 
-    # TODO check that trying to contract incompatible legs raises
-    #  - opposite is_dual but different dim
-    #  - opposite is_dual and dim but different sectors
-    #  - same dim and sectors but same is_dual
+    # # TODO check that trying to contract incompatible legs raises
+    # #  - opposite is_dual but different dim
+    # #  - opposite is_dual and dim but different sectors
+    # #  - same dim and sectors but same is_dual
 
 
 def OLD_test_outer(make_compatible_tensor):
@@ -1466,31 +1466,31 @@ def OLD_test_apply_Mask_DiagonalTensor(make_compatible_tensor, compatible_backen
 def OLD_test_apply_Mask_ChargedTensor(make_compatible_tensor, num_legs):
     pytest.xfail('Fixture generates ChargedTensor with unspecified charged_state')
     
-    T: tensors.ChargedTensor = make_compatible_tensor(num_legs=num_legs, cls=tensors.ChargedTensor)
-    # first leg
+    # T: tensors.ChargedTensor = make_compatible_tensor(num_legs=num_legs, cls=tensors.ChargedTensor)
+    # # first leg
     
-    if not T.symmetry.is_abelian:
-        # TODO
-        pytest.skip('Need to re-design make_compatible_tensor fixture to generate valid masks.')
+    # if not T.symmetry.is_abelian:
+    #     # TODO
+    #     pytest.skip('Need to re-design make_compatible_tensor fixture to generate valid masks.')
 
-    if isinstance(T.backend, FusionTreeBackend):
-        with pytest.raises(NotImplementedError, match='mask_from_block not implemented'):
-            mask = make_compatible_tensor(legs=[T.legs[0], None], cls=tensors.Mask)
-        return  # TODO
+    # if isinstance(T.backend, FusionTreeBackend):
+    #     with pytest.raises(NotImplementedError, match='mask_from_block not implemented'):
+    #         mask = make_compatible_tensor(legs=[T.legs[0], None], cls=tensors.Mask)
+    #     return  # TODO
     
-    mask = make_compatible_tensor(legs=[T.legs[0], None], cls=tensors.Mask)
-    masked = T.apply_mask(mask, 0)
-    masked.test_sanity()
-    npt.assert_array_almost_equal_nulp(T.to_numpy()[mask.numpymask],
-                                       masked.to_numpy(),
-                                       10)
-    # last leg
-    mask = make_compatible_tensor(legs=[T.legs[-1], None], cls=tensors.Mask)
-    masked = T.apply_mask(mask, -1)
-    masked.test_sanity()
-    npt.assert_array_almost_equal_nulp(T.to_numpy()[..., mask.numpymask],
-                                       masked.to_numpy(),
-                                       10)
+    # mask = make_compatible_tensor(legs=[T.legs[0], None], cls=tensors.Mask)
+    # masked = T.apply_mask(mask, 0)
+    # masked.test_sanity()
+    # npt.assert_array_almost_equal_nulp(T.to_numpy()[mask.numpymask],
+    #                                    masked.to_numpy(),
+    #                                    10)
+    # # last leg
+    # mask = make_compatible_tensor(legs=[T.legs[-1], None], cls=tensors.Mask)
+    # masked = T.apply_mask(mask, -1)
+    # masked.test_sanity()
+    # npt.assert_array_almost_equal_nulp(T.to_numpy()[..., mask.numpymask],
+    #                                    masked.to_numpy(),
+    #                                    10)
 
 
 

--- a/tests/linalg/test_tensors.py
+++ b/tests/linalg/test_tensors.py
@@ -1,5 +1,6 @@
 """A collection of tests for tenpy.linalg.tensors."""
 # Copyright (C) TeNPy Developers, GNU GPLv3
+from __future__ import annotations
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/linalg/test_trees.py
+++ b/tests/linalg/test_trees.py
@@ -117,7 +117,7 @@ def check_to_block(symmetry, backend, uncoupled, np_random, dtype):
         
     uncoupled_dims = symmetry.batch_sector_dim(uncoupled)
     spaces = [ElementarySpace(symmetry, [a]) for a in uncoupled]
-    domain = ProductSpace(spaces, backend)
+    domain = ProductSpace(spaces, backend=backend)
     coupled = np_random.choice(domain.sectors)
     coupled_dim = symmetry.sector_dim(coupled)
     all_trees = list(trees.fusion_trees(symmetry, uncoupled, coupled))

--- a/tests/linalg/test_trees.py
+++ b/tests/linalg/test_trees.py
@@ -6,7 +6,7 @@ import pytest
 
 from tenpy.linalg import trees
 from tenpy.linalg.symmetries import Symmetry, ProductSymmetry
-from tenpy.linalg.spaces import Space, ElementarySpace, ProductSpace
+from tenpy.linalg.spaces import ElementarySpace, ProductSpace
 from tenpy.linalg.dtypes import Dtype
 from tenpy.linalg.backends.backend_factory import get_backend
 

--- a/tests/linalg/test_trees.py
+++ b/tests/linalg/test_trees.py
@@ -6,7 +6,7 @@ import pytest
 
 from tenpy.linalg import trees
 from tenpy.linalg.symmetries import Symmetry, ProductSymmetry
-from tenpy.linalg.spaces import VectorSpace, ProductSpace
+from tenpy.linalg.spaces import Space, ElementarySpace, ProductSpace
 from tenpy.linalg.dtypes import Dtype
 from tenpy.linalg.backends.backend_factory import get_backend
 
@@ -59,7 +59,7 @@ def test_fusion_trees(any_symmetry: Symmetry, make_any_sectors, np_random):
     uncoupled = some_sectors[:5]
     are_dual = np_random.choice([True, False], size=len(uncoupled), replace=True)
     # find the allowed coupled sectors
-    allowed = ProductSpace([VectorSpace(any_symmetry, [a]) for a in uncoupled]).sectors
+    allowed = ProductSpace([ElementarySpace(any_symmetry, [a]) for a in uncoupled]).sectors
     some_allowed = np_random.choice(allowed, axis=0)
     print(f'  uncoupled={", ".join(map(str, uncoupled))}   coupled={some_allowed}')
     it = trees.fusion_trees(any_symmetry, uncoupled, some_allowed, are_dual=are_dual)
@@ -116,9 +116,9 @@ def check_to_block(symmetry, backend, uncoupled, np_random, dtype):
         expect_dtype = dtype
         
     uncoupled_dims = symmetry.batch_sector_dim(uncoupled)
-    spaces = [VectorSpace(symmetry, [a]) for a in uncoupled]
+    spaces = [ElementarySpace(symmetry, [a]) for a in uncoupled]
     domain = ProductSpace(spaces, backend)
-    coupled = np_random.choice(domain._non_dual_sectors)
+    coupled = np_random.choice(domain.sectors)
     coupled_dim = symmetry.sector_dim(coupled)
     all_trees = list(trees.fusion_trees(symmetry, uncoupled, coupled))
     all_blocks = [t.as_block(backend, dtype) for t in all_trees]

--- a/tests/networks/test_site.py
+++ b/tests/networks/test_site.py
@@ -32,7 +32,7 @@ def test_site(np_random, block_backend, symmetry_backend, use_sym):
         sym = la.no_symmetry
     dim = 8
     some_sectors = random_symmetry_sectors(sym, num=dim, sort=False, np_random=np_random)
-    leg = la.VectorSpace.from_basis(sym, np_random.choice(some_sectors, size=dim, replace=True))
+    leg = la.ElementarySpace.from_basis(sym, np_random.choice(some_sectors, size=dim, replace=True))
     assert leg.dim == dim
     op1 = la.BlockDiagonalTensor.random_uniform([leg, leg.dual], backend, labels=['p', 'p*'])
     labels = [f'x{i:d}' for i in range(10, 10 + dim)]

--- a/tests/networks/test_site.py
+++ b/tests/networks/test_site.py
@@ -14,6 +14,10 @@ from tenpy.networks import site
 from conftest import random_symmetry_sectors
 
 
+
+pytest.skip("site not yet revised", allow_module_level=True)  # TODO
+
+
 def commutator(A, B):
     return np.dot(A, B) - np.dot(B, A)
 
@@ -34,7 +38,7 @@ def test_site(np_random, block_backend, symmetry_backend, use_sym):
     some_sectors = random_symmetry_sectors(sym, num=dim, sort=False, np_random=np_random)
     leg = la.ElementarySpace.from_basis(sym, np_random.choice(some_sectors, size=dim, replace=True))
     assert leg.dim == dim
-    op1 = la.BlockDiagonalTensor.random_uniform([leg, leg.dual], backend, labels=['p', 'p*'])
+    op1 = la.SymmetricTensor.random_uniform([leg, leg.dual], backend, labels=['p', 'p*'])
     labels = [f'x{i:d}' for i in range(10, 10 + dim)]
     s = site.Site(leg, backend=backend, state_labels=labels)
     s.add_symmetric_operator('silly_op', op1)
@@ -44,7 +48,7 @@ def test_site(np_random, block_backend, symmetry_backend, use_sym):
     assert s.all_op_names == {'silly_op', 'Id', 'JW'}
     assert s['silly_op'] is op1
     assert s.get_op('silly_op') is op1
-    op2 = la.BlockDiagonalTensor.random_uniform([leg, leg.dual], backend, labels=['p', 'p*'])
+    op2 = la.SymmetricTensor.random_uniform([leg, leg.dual], backend, labels=['p', 'p*'])
     s.add_symmetric_operator('op2', op2)
     assert s['op2'] is op2
     assert s.get_op('op2') is op2
@@ -187,6 +191,7 @@ def check_operator_availability(s: site.Site, expect_symmetric_ops: dict[str, bo
         assert name in s.charged_ops
         op = s.charged_ops[name]
         assert op.can_use_alone == can_use_alone
+        # TODO revise this. purge the "dummy" language, its now "charged"
         assert op.op_L.dummy_leg.dim == dim
         assert op.op_R.dummy_leg.dim == dim
 

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -1,6 +1,6 @@
 """Tests if packages and modules define proper ``__all__``."""
 # Copyright (C) TeNPy Developers, GNU GPLv3
-
+from __future__ import annotations
 import types
 import tenpy
 

--- a/tests/tools/io_test.py
+++ b/tests/tools/io_test.py
@@ -9,10 +9,8 @@ and the tenpy version in the filename.
 """
 # Copyright (C) TeNPy Developers, GNU GPLv3
 
-import numpy as np
 import os
 import tenpy
-import types
 
 try:
     from packaging.version import parse as parse_version  # part of setuptools
@@ -73,27 +71,27 @@ def assert_event_handler_example_works(data):
 
 def assert_equal_data(data_imported, data_expected, max_recursion_depth=10):
     """Check that the imported data is as expected."""
-    assert isinstance(data_imported, type(data_expected))
-    if hasattr(data_expected, 'test_sanity'):
-        data_imported.test_sanity()
-    if isinstance(data_expected, dict):
-        assert set(data_imported.keys()) == set(data_expected.keys())
-        if max_recursion_depth > 0:
-            for ki in data_imported.keys():
-                assert_equal_data(data_imported[ki], data_expected[ki], max_recursion_depth - 1)
-    elif isinstance(data_expected, (list, tuple)):
-        if max_recursion_depth > 0:
-            for vi, ve in zip(data_imported, data_expected):
-                assert_equal_data(vi, ve, max_recursion_depth - 1)
-    elif isinstance(data_expected, npc.Array):
-        assert npc.norm(data_imported - data_expected) == 0.  # should be exactly equal!
-    elif isinstance(data_expected, np.ndarray):
-        np.testing.assert_array_equal(data_imported, data_expected)
-    elif isinstance(data_expected, (int, float, np.int64, np.float64, complex, str)):
-        assert data_imported == data_expected
-    elif isinstance(data_expected, (types.FunctionType, type)):
-        # global variables where no copy should be made
-        assert data_imported is data_expected
+    # assert isinstance(data_imported, type(data_expected))
+    # if hasattr(data_expected, 'test_sanity'):
+    #     data_imported.test_sanity()
+    # if isinstance(data_expected, dict):
+    #     assert set(data_imported.keys()) == set(data_expected.keys())
+    #     if max_recursion_depth > 0:
+    #         for ki in data_imported.keys():
+    #             assert_equal_data(data_imported[ki], data_expected[ki], max_recursion_depth - 1)
+    # elif isinstance(data_expected, (list, tuple)):
+    #     if max_recursion_depth > 0:
+    #         for vi, ve in zip(data_imported, data_expected):
+    #             assert_equal_data(vi, ve, max_recursion_depth - 1)
+    # elif isinstance(data_expected, npc.Array):
+    #     assert npc.norm(data_imported - data_expected) == 0.  # should be exactly equal!
+    # elif isinstance(data_expected, np.ndarray):
+    #     np.testing.assert_array_equal(data_imported, data_expected)
+    # elif isinstance(data_expected, (int, float, np.int64, np.float64, complex, str)):
+    #     assert data_imported == data_expected
+    # elif isinstance(data_expected, (types.FunctionType, type)):
+    #     # global variables where no copy should be made
+    #     assert data_imported is data_expected
 
 
 def get_datadir_filename(template="pickled_from_tenpy_{0}.pkl"):

--- a/tests/tools/test_hdf5.py
+++ b/tests/tools/test_hdf5.py
@@ -4,11 +4,9 @@
 
 import io_test
 import os
-import pickle
 import pytest
 import warnings
 from tenpy.tools import hdf5_io
-import numpy as np
 
 h5py = pytest.importorskip('h5py')
 

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -1,8 +1,6 @@
 """A collection of tests for tenpy.tools submodules."""
 # Copyright (C) TeNPy Developers, GNU GPLv3
 
-
-import logging
 import numpy as np
 import numpy.testing as npt
 import itertools as it
@@ -11,7 +9,6 @@ from tenpy import tools
 import warnings
 import pytest
 import os.path
-import sys
 
 
 # TODO use fixtures, e.g. np_random


### PR DESCRIPTION
# Quick summary
(to be expanded)
- Changed how spaces work.
  - Instead of a direct subclass relation ``ProductSpace(VectorSpace)`` we now have ``ProductSpace(Space)`` and ``ElementarySpace(Space)`` inheriting from the same abstract base class.
  - This means ProductSpace is free to just ignore concepts that really only make sense for the ElementarySpace, like basis perm and the distinction between a bra and a ket space
  - Removed the ``_non_dual_sectors`` mechanism. This is because when introducing codomain and domain, the legs that can be contracted with each other are no longer mutually dual, but actually equal.
- Tensor now have a domain and a codomain, which has various implications on attributes, methods, functions, conventions in the backends, ...
- Several additional small changes and refactors that came up during the process
  - E.g. the operations on tensors, and in particular methods such as tdot are no longer organized as methods of the class.
    it turns out that approach made the code to convoluted and spread out over many places
- On convertign to/from dense representations, applying the basis perms is necessary. This is now done in tensors.py, instead of in every backend, to avoid duplicates.

# TODO list

### Misc todo with high prio
- [x] Jakob still has some local todos before tackling the following:
- [x] does FusionTreeData still need domain and codomain attrs, or is it enough if they are in the tensors?
- [x] Support an "opposite" Mask from a small to a large leg.

### Adapt existing features from the v2_alpha branch
The following features already exist in the current v2_alpha branch, but need to be adapted to new conventions and signatures
- [x] `__str__` and `__repr__` of tensor classes. include in tests?
- [x] `__neg__`, `__pos__`, `__add__`, `__sub__`, `__mul__`, `__truediv__` and right versions thereof. reactivate existing lines in tests
- [ ] Most functions in tensors.py have an existing version that is not yet adapted. Most also have existing but outdated tests
- [ ] Getting and Setting elements of tensors needs a revision. Should we even do
- [ ] Adapt the matrix_operations module, reactivate tests. Should this really be its own module?

### New features / new changes
- [ ] Add tests for ChargedTensor (some fragments exist in the OLD_ tests)
- [ ] Mechanism in from_dense_block to discard blocks which are zero up to tolerance? also in diagonal and mask?

### Finishing up and sanity checks
- [ ] Make sure all OLD_ tests from test_tensors have been dealt with
- [ ] Check test coverage of tensors.py
- [ ] Check if all backend methods are still being used or if some have become outdated
- [ ] Check if all ``raise NotImplementedError`` in backends are dealt with.

### TODOs after this
- [ ] Make actions run (deal with private submodule)
- [ ] Adapt the site module? There are additional considerations, see #416 .
- [ ] Adapt the sparse module, reactivate tests that...?
- [ ] Adapt the krylov_based module, reactivate tests