### PR TITLE
Fix for Issue #431

### DIFF
--- a/tenpy/version.py
+++ b/tenpy/version.py
@@ -67,9 +67,10 @@ def _get_git_description():
         descr = subprocess.check_output(['git', 'describe', '--tags', '--long'],
                                         cwd=os.path.dirname(os.path.abspath(__file__)),
                                         stderr=subprocess.STDOUT).decode().strip()
+        n_commits = int(descr.split('-')[1])
     except:
-        return 0
-    return int(descr.split('-')[1])
+        n_commits = 0
+    return n_commits
 
 
 #: the hash of the last git commit (if available)


### PR DESCRIPTION
Include the conversion to an integer in the try clause of `_get_git_description`, otherwise return zero.
This does at least not cause an Error and just returns 0.

However, it's probably possible to separate other output from the output of `git describe --tags --long`  and recover the correct number of commits.