### PR TITLE
Krylov subspace expansion (with TDVP in min)

### DIFF
--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -211,7 +211,7 @@ class TwoSiteTDVPEngine(TDVPEngine):
         elif (self.move_right is False):
             self.one_site_update(i0, 0.5j * self.dt)
         # for the last update of the sweep, where move_right is None, there is no one_site_update
-        
+
         return update_data
 
     def update_env(self, **update_data):
@@ -366,3 +366,6 @@ class TimeDependentTwoSiteTDVP(TimeDependentHAlgorithm,TwoSiteTDVPEngine):
 
     def reinit_model(self):
         TimeDependentSingleSiteTDVP.reinit_model(self)
+
+def KrylovExpansion(psi, H, options):
+    pass

--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -101,12 +101,40 @@ class TDVPEngine(TimeEvolutionAlgorithm, Sweep):
         assert psi.bc == model.lat.bc_MPS
         super().__init__(psi, model, options, **kwargs)
         self.lanczos_options = self.options.subconfig('lanczos_options')
+        self.Krylov_options = self.options.subconfig('Krylov_options')
 
     # run() from TimeEvolutionAlgorithm
 
     def prepare_evolve(self, dt):
-        "Do nothing."
-        pass
+        """Expand the basis using Krylov updates, i.e. the algorithm from https://arxiv.org/abs/2005.06104
+        """
+        Krylov_expansion_dim = self.Krylov_options.get('expansion_dim', 0)
+        if Krylov_expansion_dim > 0:    # Do some basis expansion
+            original_chi = self.psi.chi
+            logger.info(f"Original bond dimension: {original_chi}.")
+            # Get the MPO A that will be used to generate Krylov vectors; {A^k |psi>}
+            # We might want to use the WII MPO or (1 - itH) rather than H
+            Krylov_mpo = self.Krylov_options.get('mpo', self.model.H_MPO)
+            Krylov_trunc_params = self.Krylov_options.get('trunc_params', self.trunc_params)    # How do we truncate the RDMs when extending?
+            Krylov_do_canonicalize = self.Krylov_options.get('do_canonicalize', False)          # Canonicalize the MPS after we extend?
+            if Krylov_mpo is None:  # Random expansion
+                extension_err = self.psi.extend(others=[], trunc_par=Krylov_trunc_params, do_canonicalize=Krylov_do_canonicalize)
+            else:                   # Expansion by MPO application
+                # First generate Krylov basis
+                Krylov_apply_mpo_options = self.Krylov_options['apply_mpo_options']
+                # Needs to contain 'compression_method' and options for doing the MPO application
+                Krylov_extended_basis = []
+                new_psi = self.psi.copy()
+                for i in range(Krylov_expansion_dim):
+                    Krylov_mpo.apply(new_psi, Krylov_apply_mpo_options)
+                    Krylov_extended_basis.append(new_psi.copy())
+                extension_err = self.psi.extend(others=Krylov_extended_basis, trunc_par=Krylov_trunc_params, do_canonicalize=Krylov_do_canonicalize)
+            extended_chi = [B.get_leg('vL').ind_len for B in self.psi._B] + [self.psi._B[-1].get_leg('vR').ind_len]
+            logger.info(f"Extended bond dimension: {extended_chi}.")
+            # Need to clear out left and right environments since the bond dimensions no longer match.
+            # So we will need to recalculate the H envs for the next TDVP step
+            self.env.clear()
+        return
 
     def evolve(self, N_steps, dt):
         """Evolve by ``N_steps * dt``.

--- a/tenpy/algorithms/truncation.py
+++ b/tenpy/algorithms/truncation.py
@@ -49,7 +49,7 @@ from ..tools.hdf5_io import Hdf5Exportable
 import warnings
 from ..tools.params import asConfig
 
-__all__ = ['TruncationError', 'truncate', 'svd_theta']
+__all__ = ['TruncationError', 'truncate', 'svd_theta', 'eig_theta']
 
 
 

--- a/tenpy/linalg/np_conserved.py
+++ b/tenpy/linalg/np_conserved.py
@@ -69,6 +69,7 @@ Overview
     pinv
     norm
     qr
+    lq
     expm
 
 .. rubric:: Eigen systems
@@ -105,7 +106,7 @@ __all__ = [
     'QCUTOFF', 'ChargeInfo', 'LegCharge', 'LegPipe', 'Array', 'zeros', 'ones', 'eye_like', 'diag',
     'concatenate', 'grid_concat', 'grid_outer', 'detect_grid_outer_legcharge', 'detect_qtotal',
     'detect_legcharge', 'trace', 'outer', 'inner', 'tensordot', 'svd', 'pinv', 'norm', 'eigh',
-    'eig', 'eigvalsh', 'eigvals', 'speigs', 'expm', 'qr', 'orthogonal_columns',
+    'eig', 'eigvalsh', 'eigvals', 'speigs', 'expm', 'qr', 'lq', 'orthogonal_columns',
     'to_iterable_arrays', 'polar'
 ]
 
@@ -4085,6 +4086,27 @@ def qr(a,
     q.iset_leg_labels([a_labels[0], label_Q])
     r.iset_leg_labels([label_R, a_labels[1]])
     return q, r
+
+
+def lq(a,
+       mode='reduced',
+       inner_labels=[None, None],
+       cutoff=None,
+       pos_diag_L=False,
+       qtotal_Q=None,
+       inner_qconj=+1):
+    r"""Q-R decomposition of a matrix. See documentation for npc.qr for details.
+    """
+
+    q, r = qr(a.transpose(),
+              mode=mode,
+              inner_labels=inner_labels[::-1],
+              cutoff=cutoff,
+              pos_diag_R=pos_diag_L,
+              qtotal_Q=qtotal_Q,
+              inner_qconj=+1)
+
+    return r.transpose(), q.transpose()
 
 
 def orthogonal_columns(a, new_label=None):

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -4403,6 +4403,32 @@ class MPS(BaseMPSExpectationValue):
         psi.canonical_form_finite(renormalize=False, cutoff=cutoff)
         return psi
 
+    def extend(self, others, trunc_par={'svd_min': 1.e-8}):
+        """Return an MPS which represents ``alpha|self> + beta |others>``.
+
+        Works only for 'finite', 'segment' boundary conditions.
+        For 'segment' boundary conditions, the virtual legs on the very left/right are
+        assumed to correspond to each other (i.e. self and other have the same state outside of
+        the considered segment).
+        Takes into account :attr:`norm`.
+
+        Parameters
+        ----------
+        other : :class:`MPS`
+            Another MPS of the same length to be added with self.
+        alpha, beta : complex float
+            Prefactors for self and other. We calculate
+            ``alpha * |self> + beta * |other>``
+        cutoff : float | None
+            Cutoff of singular values used in the SVDs.
+
+        Returns
+        -------
+        sum : :class:`MPS`
+            An MPS representing ``alpha|self> + beta |other>``.
+            Has same total charge as `self`.
+        """
+        
     def apply_local_op(self, i, op, unitary=None, renormalize=False, cutoff=1.e-13,
                        understood_infinite=False):
         r"""Apply a local (one or multi-site) operator to `self`. In place.


### PR DESCRIPTION
Johannes, here is a rough version of what we discussed this morning. There is a function in `mps.py` that "extends" an MPS (in place) by additional provided MPS (or by random orthogonal vectors if none are provided). This required an LQ decomposition (from transposing the QR you already implemented) and truncated version of an eigenvalue decomposition.

I added this to TDVP in the `prepare_evolve` function in the base TDVP class. So before each L->R->L TDVP sweep, one can optionally expand the current MPS using either "Krylov" vectors generated by a specified MPO (or the MPO used for TDVP evolution) or random vectors. Then one can regular TDVP after this. One added annoyance is that since the bond dimensions of the wavefunction being evolved have changed, we need to clear out the LPs and RPs from the engine environment and recalculate them from scratch.

Questions:
1. Is it possible to update the environments such that we don't have to recalculate them from scratch? I don't see how we can do better than just starting at the right and contracting the new RPs.
2. Currently each time we extend by Krylov vectors, we load a truncation parameters dictionary for use in the eigenvalue decomposition function. This generates lots of logging output, since each loading of the dictionary generates something like
`INFO:tenpy.tools.params:truncation: reading 'chi_max'=None
INFO:tenpy.tools.params:truncation: reading 'chi_min'=None
INFO:tenpy.tools.params:truncation: reading 'degeneracy_tol'=None
INFO:tenpy.tools.params:truncation: reading 'svd_min'=0.01
INFO:tenpy.tools.params:truncation: reading 'trunc_cut'=1e-14`

I've checked with some small systems with exact bond dimension that single-site TDVP with subspace expansion produces results consistent with two-site TDVP. I will do more stringent testing (including using W2 to generate the Krylov vectors) before this should be merged, but if you have any improvements, please let me know.