### PR TITLE
Log and store trunaction errors for `RealTimeEvolution`

### DIFF
--- a/tenpy/simulations/simulation.py
+++ b/tenpy/simulations/simulation.py
@@ -659,8 +659,11 @@ class Simulation:
     def make_measurements(self):
         """Perform measurements and merge the results into ``self.results['measurements']``."""
         self.logger.info("make measurements")
+        m_start_time = time.time()
         results = self.perform_measurements()
         self._merge_measurement_results(results)
+        m_end_time = time.time()
+        self.logger.info(f"measurements took {m_end_time-m_start_time:.2f}s")
 
     def _merge_measurement_results(self, results):
         """Merge dictionary `results` from measurements into ``self.results['measurement']``."""

--- a/tenpy/simulations/time_evolution.py
+++ b/tenpy/simulations/time_evolution.py
@@ -39,6 +39,8 @@ class RealTimeEvolution(Simulation):
     default_algorithm = 'TEBDEngine'
     default_measurements = Simulation.default_measurements + [
         ('tenpy.simulations.measurement', 'm_evolved_time'),
+        ('simulation_method', 'wrap eps_error'),
+        ('simulation_method', 'wrap ov_error')
     ]
 
     def __init__(self, options, **kwargs):
@@ -54,9 +56,9 @@ class RealTimeEvolution(Simulation):
         while True:
             if np.real(self.engine.evolved_time) >= self.final_time:
                 break
-            self.logger.info("evolve to time %.2f, max chi=%d", self.engine.evolved_time.real,
-                             max(self.psi.chi))
-            self.engine.run()
+
+            self.engine.run()  # already logs time, chi_max, S, deltaS (through .run() of TimeEvolutionAlgorithm)
+            self.logger.info(f"total {self.engine.trunc_err} (only from truncation of Schmidt values)")
             # for time-dependent H (TimeDependentExpMPOEvolution) the engine can re-init the model;
             # use it for the measurements....
             self.model = self.engine.model
@@ -82,6 +84,39 @@ class RealTimeEvolution(Simulation):
         We already performed a set of measurements after the evolution in :meth:`run_algorithm`.
         """
         pass
+
+    def eps_error(self):
+        """Accumulated eps error since the start of the time-evolution.
+
+        To get the eps error induced at each loop of ``'N_steps'`` in the time evolution,
+        a finite difference scheme could be used as the eps errors get simply
+        added i.e., ``np.diff(eps_error)``.
+        Utility measurement method similar to :meth:`walltime`, but appended to
+        ``default_measurements`` of this simulation class.
+
+        .. warning ::
+
+            This is only the sum of the discarded Schmidt values and does not take into
+            account e.g., errors induced by time discretization. See :mod:`~tenpy.algorithms.truncation`.
+
+        Returns
+        -------
+        eps : float
+            Accumulated eps error (sum of the discarded Schmidt values) since the start of the time-evolution.
+        """
+        return self.engine.trunc_err.eps
+
+    def ov_error(self):
+        """Total ov error of the time-evolution.
+
+        Similar to :meth:`eps_error`, but for the overlap (which gets multiplied at each step).
+
+        Returns
+        -------
+        ov : float
+            Total ov error since the start of the time-evolution.
+        """
+        return self.engine.trunc_err.ov
 
 
 class TimeDependentCorrelation(RealTimeEvolution):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -7,6 +7,7 @@ import sys
 
 import tenpy
 from tenpy.algorithms.algorithm import Algorithm
+from tenpy.algorithms.truncation import TruncationError
 from tenpy.simulations.simulation import *
 from tenpy.simulations.ground_state_search import GroundStateSearch
 from tenpy.simulations.time_evolution import RealTimeEvolution, SpectralSimulation, SpectralSimulationEvolveBraKet
@@ -22,6 +23,7 @@ class DummyAlgorithm(Algorithm):
         self.evolved_time = self.options.get('start_time', 0.)
         init_env_data = {} if resume_data is None else resume_data['init_env_data']
         self.env = DummyEnv(**init_env_data)
+        self.trunc_err = TruncationError()
         if not hasattr(self.psi, "dummy_counter"):
             self.psi.dummy_counter = 0  # note: doesn't get saved!
             # But good enough to check `run_seq_simulations`


### PR DESCRIPTION
Currently the truncation error is computed, but neither logged or saved for a `RealTimeEvolution`.
This PR logs the `TruncationError` (accumulated at least for eps and latest for ov) in the `run_algorithm` method of the `RealTimeEvolution` class - the logging could also be done at the level of the `TimeEvolutionAlgorithm` but logging the error for one individual step might be more useful here? 
In the `RealTimeEvolution` class, the ov and eps errors are also recorded as measurements (added to the `default_measurements` of that class).
Furthermore, the redundant (and confusing) logging line before running the engine in the `run_algorithm` method was removed, the same information is already logged by the `TimeEvolutionAlgorithm`.

Lastly, as some measurements can take quite a while, I thought it might be useful to also report the time it took for all measurements to complete (this was done in `make_measurements` of the `Simulation` class).