### PR TITLE
Coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,9 +10,6 @@ on:
   push:
     branches:
       - main
-  # PRs
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/print_coverage_in_PR.yml
+++ b/.github/workflows/print_coverage_in_PR.yml
@@ -9,11 +9,42 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       COV_PERCENT: ${{ steps.save-coverage.outputs.COV_PERCENT }}
+
     steps:
-      #TODO: calculate coverage here....
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools build
+          python -m pip install --upgrade pytest
+          python -m pip install --upgrade coverage
+
+      - name: Build and install tenpy
+        # also installs extra dependencies defined in pyproject.toml
+        run: |
+          python -m build .
+          python -m pip install ".[io, test, extra]"
+
+      - name: Run pytest with coverage
+        # pytest configuration in pyproject.toml
+        # Note: This runs in the repo root directory, which contains the uncompiled tenpy package.
+        #       To use the version we just installed, it is important to run `coverage`
+        #       instead of `python -m coverage`.
+        run: |
+          coverage run -m pytest .
+          coverage report -m --skip-covered --sort=miss
+          coverage json
+
       - name: save coverage
         id: save-coverage
-        run: echo "COV_PERCENT=0.5" >> $GITHUB_OUTPUT
+        run: echo "COV_PERCENT=$(jq .totals.percent_covered coverage.json | xargs printf "%.0f")" >> $GITHUB_OUTPUT
 
   comment:
     needs: [calc_coverage]
@@ -24,5 +55,7 @@ jobs:
       - uses: mshick/add-pr-comment@v2
         with:
           message: |
-            Coverage on new code:  ${{ needs.calc_coverage.outputs.COV_PERCENT }}%
+            Thank you for working on this Pull request!
+            Here are some stats on your progress.
+            The overall test coverage on TenPy, including the changes within this PR, is now ${{ needs.calc_coverage.outputs.COV_PERCENT }}%.
           refresh-message-position: true

--- a/.github/workflows/print_coverage_in_PR.yml
+++ b/.github/workflows/print_coverage_in_PR.yml
@@ -58,4 +58,3 @@ jobs:
             Thank you for working on this Pull request!
             Here are some stats on your progress.
             The overall test coverage on TenPy, including the changes within this PR, is now ${{ needs.calc_coverage.outputs.COV_PERCENT }}%.
-          refresh-message-position: true

--- a/.github/workflows/print_coverage_in_PR.yml
+++ b/.github/workflows/print_coverage_in_PR.yml
@@ -2,7 +2,7 @@ name: Notify about Coverage
 
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   calc_coverage:

--- a/.github/workflows/print_coverage_in_PR.yml
+++ b/.github/workflows/print_coverage_in_PR.yml
@@ -1,0 +1,28 @@
+name: Notify about Coverage
+
+
+on:
+  pull_request:
+
+jobs:
+  calc_coverage:
+    runs-on: ubuntu-latest
+    outputs:
+      COV_PERCENT: ${{ steps.save-coverage.outputs.COV_PERCENT }}
+    steps:
+      #TODO: calculate coverage here....
+      - name: save coverage
+        id: save-coverage
+        run: echo "COV_PERCENT=0.5" >> $GITHUB_OUTPUT
+
+  comment:
+    needs: [calc_coverage]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Coverage on new code:  ${{ needs.calc_coverage.outputs.COV_PERCENT }}%
+          refresh-message-position: true


### PR DESCRIPTION
I have implemented a GitHub automation to automatically calculate the code coverage for every pull request and post the result as a comment below.
This implementations aims to close #349.

As of now, it just calculates the total code coverage, considering the changes within the pull request. It might also be desirable to just print the code coverage from the code affected by the pull request. However, it is not fully clear to me how to implement this yet.
This implementation also updates the comment, whenever new commits are added to the pull request.
You should (hopefully) see how the comment works right below this pull request.