### PR TITLE
Fix the action that checks the doc build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -31,8 +31,6 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        miniforge-variant: Mambaforge
-        use-mamba: true
         activate-environment: tenpydoc
         environment-file: doc/environment.yml
         python-version: 3.11


### PR DESCRIPTION
We need some version / variant of conda int that action to install some packages needed for the doc build.
It seems the currently configured mambaforge is no longer working.