### PR TITLE
Handle zero blocks correctly in truncated `qr`

### DIFF
--- a/tenpy/linalg/np_conserved.py
+++ b/tenpy/linalg/np_conserved.py
@@ -4014,6 +4014,9 @@ def qr(a,
             q_block, r_block = np.linalg.qr(block, mode)
         else:
             q_block, r_block = qr_li(block, cutoff)
+            if q_block.size == 0:
+                # empty blocks would break below
+                continue
         if pos_diag_R:
             r_diag = np.diag(r_block)
             phase = r_diag / np.abs(r_diag)
@@ -4058,6 +4061,10 @@ def qr(a,
     if mode != 'complete':
         q._qdata[:, 1] = map_qind[q._qdata[:, 0]]
         r._qdata[:, 0] = q._qdata[:, 1]  # copy map_qind[q._qdata[:, 0]] from q
+        # filter out zero-size blocks
+        nonzero = q._qdata[:, 1] != -1
+        q._qdata = q._qdata[nonzero]
+        r._qdata = r._qdata[nonzero]
     else:  # mode == 'complete'
         q._qdata[:, 1] = q._qdata[:, 0]
         if len(q_data) < a_leg0.block_number:

--- a/tenpy/tools/math.py
+++ b/tenpy/tools/math.py
@@ -260,6 +260,9 @@ def qr_li(A, cutoff=1.e-15):
     assert len(keep) == R.shape[0]
     Q = Q[:, keep]
     R = R[keep, :]
+    if not np.any(keep):
+        # the next QR decomposition would break
+        return Q, R
     # here, A P = Q R, thus A = Q R inv(P)
     R = R[:, misc.inverse_permutation(P)]
     q, R = scipy.linalg.qr(R, mode='economic', pivoting=False)


### PR DESCRIPTION
I've noticed that `npc.qr` with a cutoff breaks if any of the blocks disappear completely. This PR fixes this behaviour:
* `tools.math.qr_li` returns early if no diagonal elements are kept, before a next QR decomposition would lead to LAPACK errors
* `qr` skips such empty blocks from `q_data`, `r_data` so they don't lead to errors down the line
* and filters the legcharges so they only refer to the nonzero blocks

As far as I can tell, this breaks no currently functioning code. Let me know what tests etc. should be added.