### PR TITLE
fix expected output in the c_mps_mpo example (6 sites, not 4)

### DIFF
--- a/examples/userguide/c_mps_mpo.py
+++ b/examples/userguide/c_mps_mpo.py
@@ -11,7 +11,7 @@ sites = [spin] * N  # repeat entry of list N times
 pstate = ["up", "down"] * (N // 2)  # Neel state
 psi = MPS.from_product_state(sites, pstate, bc="finite")
 print("<Sz> =", psi.expectation_value("Sz"))
-# <Sz> = [ 0.5 -0.5  0.5 -0.5. 0.5 -0.5]
+# <Sz> = [ 0.5 -0.5  0.5 -0.5  0.5 -0.5]
 print("<Sp_i Sm_j> =", psi.correlation_function("Sp", "Sm"), sep="\n")
 # <Sp_i Sm_j> =
 # [[1. 0. 0. 0. 0. 0.]

--- a/examples/userguide/c_mps_mpo.py
+++ b/examples/userguide/c_mps_mpo.py
@@ -11,7 +11,7 @@ sites = [spin] * N  # repeat entry of list N times
 pstate = ["up", "down"] * (N // 2)  # Neel state
 psi = MPS.from_product_state(sites, pstate, bc="finite")
 print("<Sz> =", psi.expectation_value("Sz"))
-# <Sz> = [ 0.5 -0.5  0.5 -0.5]
+# <Sz> = [ 0.5 -0.5  0.5 -0.5. 0.5 -0.5]
 print("<Sp_i Sm_j> =", psi.correlation_function("Sp", "Sm"), sep="\n")
 # <Sp_i Sm_j> =
 # [[1. 0. 0. 0. 0. 0.]


### PR DESCRIPTION
The example describes a N=6 lattice, and the output of the code is `<Sz> = [ 0.5 -0.5  0.5 -0.5  0.5 -0.5]`, not `<Sz> = [ 0.5 -0.5  0.5 -0.5]`.