### PR TITLE
Fix LegCharge `__eq__` comparison

### DIFF
--- a/doc/changelog/latest/fix_leg_charge_comparison.txt
+++ b/doc/changelog/latest/fix_leg_charge_comparison.txt
@@ -1,0 +1,1 @@
+- Fixed a bug in the comparison of :class:`~tenpy.linalg.charges.LegCharge`s, see :issue:`470`.

--- a/tenpy/linalg/charges.py
+++ b/tenpy/linalg/charges.py
@@ -849,10 +849,12 @@ class LegCharge:
         if self.charges is other.charges and self.qconj == other.qconj and \
                 (self.slices is other.slices or np.all(self.slices == other.slices)):
             return True  # optimize: don't need to check all charges explicitly
-        if not np.array_equal(self.slices, other.slices) or \
-                not np.array_equal(self.charges * self.qconj, other.charges * other.qconj):
+        if not np.array_equal(self.slices, other.slices):
             return False
-        return True
+        return np.array_equal(
+            self.chinfo.make_valid(self.charges * self.qconj),
+            self.chinfo.make_valid(other.charges * other.qconj)
+        )
 
     def __ne__(self, other):
         r"""Define `self != other` as `not (self == other)`"""

--- a/tests/test_charges.py
+++ b/tests/test_charges.py
@@ -150,3 +150,9 @@ def test__sliced_copy():
     npt.assert_equal(y[1:5, 0:3, 4:6], z)
     charges._sliced_copy(y, y_beg, y_cpy, y_beg, shape)
     npt.assert_equal(y, y_cpy)
+
+
+def test_fixes_issue_470():
+    z2 = charges.ChargeInfo([2])
+    leg = charges.LegCharge(z2, [0,1,2], [[0],[1]])
+    leg.test_equal(leg.conj())


### PR DESCRIPTION
Fixes #470 

The qmod was not considered.

We have an "optimized" check that is faster in the case where the
two legs being compared share the same instance of the charges array
This case is unaffected by the bug, which is probably why it took so
long to surface.