### PR TITLE
Bug in MPO.to_TermList(...) fixed

### DIFF
--- a/tenpy/networks/mpo.py
+++ b/tenpy/networks/mpo.py
@@ -1049,7 +1049,7 @@ class MPO:
                 continue
             partial_L[self.get_IdL(i)] = [([], 1.)]
             if self.finite:
-                max_range = min(max_range, L - i)
+                max_range = min(max_range, L - i - 1)
             for k in range(max_range + 1):
                 j = i + k
                 IdL = self.get_IdL(j)

--- a/tenpy/networks/mpo.py
+++ b/tenpy/networks/mpo.py
@@ -1050,7 +1050,7 @@ class MPO:
             partial_L[self.get_IdL(i)] = [([], 1.)]
             if self.finite:
                 max_range = min(max_range, L - i)
-            for k in range(max_range):
+            for k in range(max_range + 1):
                 j = i + k
                 IdL = self.get_IdL(j)
                 IdR = self.get_IdR(j)


### PR DESCRIPTION
If the variable `max_range` is equal to $M$, then the longest coupling term is $OP_0*OP_M$ (taking `i`$=0$ as an example). Therefore, the range of `k` should be from $0$ to $M$.
For instance, the original function produces no output for the `tf_ising` model, while my modification resolves this issue.