### PR TITLE
fix consistency check to work with imaginary time evolution in ExpMPOEvolution

### DIFF
--- a/doc/changelog/latest/fix-consisteny-check.txt
+++ b/doc/changelog/latest/fix-consisteny-check.txt
@@ -1,0 +1,1 @@
+- fix consistency check to work with imaginary time evolution in ExpMPOEvolution. More generally, continue program if consistency checks failed, and just log the error.

--- a/doc/intro/simulations.rst
+++ b/doc/intro/simulations.rst
@@ -197,7 +197,7 @@ Most simulation classes have only a few :attr:`~tenpy.simulations.Simulation.def
 add more with the :cfg:option:`Simulation.connect_measurements` parameters. Each measurement is simply a function that is
 called whenever the simulation wants to measure, e.g. with the initial state, at the end of the simulation, and for time
 evolutions also during the evolution. The default measurement functions are defined in
-the module :mod:`tenpy.simulations.measurement`; :func:`~tenpy.simulations.measurement.measurement_index` documents what
+the module :mod:`tenpy.simulations.measurement`; :func:`~tenpy.simulations.measurement.m_measurement_index` documents what
 arguments a measurement function should have. 
 In the simplest case, you just specify the module and function name, but you can also add more arguments, as the
 following example shows.

--- a/tenpy/algorithms/mpo_evolution.py
+++ b/tenpy/algorithms/mpo_evolution.py
@@ -86,7 +86,8 @@ class ExpMPOEvolution(TimeEvolutionAlgorithm):
         self._U_param = U_param
         logger.info("Calculate U for %s", U_param)
         consistency_check(dt, self.options, 'max_dt', 1.,
-                          'delta_t > ``max_delta_t`` is unreasonably large for trotterization.')
+                          'delta_t > ``max_delta_t`` is unreasonably large for trotterization.',
+                          compare='abs()<=')
         H_MPO = self.model.H_MPO
         if order == 1:
             U_MPO = H_MPO.make_U(dt * -1j, approximation=approximation)

--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -117,7 +117,7 @@ class TDVPEngine(TimeEvolutionAlgorithm, Sweep):
         """
         consistency_check(dt, self.options, 'max_dt', 1.,
                           'dt > ``max_dt`` is unreasonably large for TDVP.',
-                          compare=lambda dt, max_dt: abs(dt) <= max_dt)
+                          compare='abs()<=')
         self.dt = dt
         trunc_err = TruncationError()
         for _ in range(N_steps):

--- a/tenpy/models/lattice.py
+++ b/tenpy/models/lattice.py
@@ -572,7 +572,7 @@ class Lattice:
         ----------
         factor : int
             The new number of sites in the MPS unit cell will be increased from `N_sites` to
-            ``factor*N_sites_per_ring``. Since MPS unit cells are repeated in the `x`-direction
+            ``factor*N_sites``. Since MPS unit cells are repeated in the `x`-direction
             in our convention, the lattice shape goes from
             ``(Lx, Ly, ..., Lu)`` to ``(Lx*factor, Ly, ..., Lu)``.
         """

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -1287,7 +1287,7 @@ class CouplingModel(Model):
 
         The coupling `strength` may vary spatially if the given `strength` is a numpy array.
         The correct shape of this array is the `coupling_shape` returned by
-        :meth:`tenpy.models.lattice.possible_multi_couplings` and depends on the boundary
+        :meth:`tenpy.models.lattice.Lattice.possible_multi_couplings` and depends on the boundary
         conditions. The ``shift(...)`` depends on the `dx` entries of `ops`
         and is chosen such that the first entry ``strength[0, 0, ...]`` of `strength`
         is the prefactor for the first possible coupling

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -664,7 +664,7 @@ class BaseMPSExpectationValue(metaclass=ABCMeta):
 
             >>> a = psi.expectation_value_term([('Sx', 2), ('Sz', 4)])
             >>> b = psi.expectation_value_term([('Sz', 4), ('Sx', 2)])
-            >>> c = psi.expectation_value_multi_sites(['Sz', 'Id', 'Sx'], i0=2)
+            >>> c = psi.expectation_value_multi_sites(['Sx', 'Id', 'Sz'], i0=2)
             >>> assert a == b == c
         """
         # strategy: translate term into a list "ops" to be used for `expectation_value_multi_sites`

--- a/tenpy/tools/misc.py
+++ b/tenpy/tools/misc.py
@@ -8,6 +8,8 @@ from .params import Config
 from collections.abc import Mapping
 import os.path
 import warnings
+import logging
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'to_iterable', 'to_iterable_of_len', 'to_array', 'anynan', 'argsort', 'lexsort',
@@ -920,6 +922,20 @@ class BetaWarning(UserWarning):
     pass
 
 
+_consistency_compare_funcs = {
+    '<=': operator.le,
+    '<': operator.lt,
+    '>': operator.gt,
+    '>=': operator.ge,
+    '!=': operator.ne,
+    '==': operator.eq,
+    'abs()<=': lambda x,y: abs(x) <= y,
+    'abs()<': lambda x,y: abs(x) < y,
+    'abs()>': lambda x,y: abs(x) > y,
+    'abs()>=': lambda x,y: abs(x) >= y,
+}
+
+
 def consistency_check(value, options, threshold_key, threshold_default, msg, compare='<='):
     """Perform a consistency check, raising an error if it is violated.
 
@@ -973,21 +989,17 @@ def consistency_check(value, options, threshold_key, threshold_default, msg, com
     if threshold is None:
         warn_instead = True
         threshold = threshold_default
-    compare_func = {'<=': operator.le, '<': operator.lt, '>': operator.gt, '>=': operator.ge,
-                    '!=': operator.ne, '==': operator.eq}.get(compare, compare)
+    compare_func = _consistency_compare_funcs.get(compare, compare)
 
     try:
         check_passed = compare_func(value, threshold)
     except Exception as e:
-        msg = (f'During the consistency check for ``{threshold_key}``, performing the check '
-               f'caused a {type(e).__name__}. This is likely due to a bug. Please report it on '
-               f'github.com/tenpy/tenpy. ')
-        if warn_instead:
-            warnings.warn(msg, category=UserWarning, stacklevel=2)
-        else:
-            msg = msg + (f'As a workaround, try setting  ``{threshold_key}=None`` '
-                         f'in the {options.name} options.')
-            raise RuntimeError(msg) from e
+        # note: logger.exception adds traceback info
+        logger.exception("Error during consistency_check for ``%s``. This is likely due to a bug "
+                         "like incompatible types in the consistency check. "
+                         "Consider to report it on https://github.com/tenpy/tenpy/issues/. ",
+                         threshold_key)
+        check_passed = True
 
     if not check_passed:
         if warn_instead:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -332,6 +332,12 @@ def test_fixes_consistency_check_IrregularLattice():
     _ = tenpy.algorithms.dmrg.run(psi, model, dmrg_params)
 
 
+def test_failing_consistency_check():
+    # compare function fails due to complex not being comparable with <=
+    tools.misc.consistency_check(1.2 + 1.j, {}, 'a', 1., '<')
+    # this should raise a logger error and print the taceback there,
+    # but the program should continue
+
 if __name__ == "__main__":
     import tempfile
     from pathlib import Path


### PR DESCRIPTION
ExpMPOEvolution did not allow to run imaginary time evolution due to consistency checks failing with complex numbers...