### PR TITLE
Remove sphinx version restriction

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools>=68.0.0
   - h5py
   - pyyaml
-  - sphinx >=8,<8.2.0
+  - sphinx
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex!=2.6
   - matplotlib

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx >=8,<8.2.0
+Sphinx
 sphinx-rtd-theme
 sphinxcontrib-bibtex
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ io = ["h5py", "pyyaml"]
 test = ["pytest>=6.0"]
 extra = ["bottleneck", "yapf==0.28.0", "docformatter==1.3.1"]
 docbuild = [
-    "Sphinx >=8,<8.2.0", 
+    "Sphinx", 
     "sphinx-rtd-theme", 
     "sphinxcontrib-bibtex", 
     "matplotlib", 


### PR DESCRIPTION
Since https://github.com/spatialaudio/nbsphinx/issues/825 is now fixed, we should be able to use the latest sphinx version again, unrestricted