### PR TITLE
Non uniform decay rates

### DIFF
--- a/doc/changelog/latest/non_uniform_decay_rates.txt
+++ b/doc/changelog/latest/non_uniform_decay_rates.txt
@@ -1,3 +1,3 @@
 Changed
 ^^^^^^^
-- `ExponentiallyDecayingCouplingTerms` now accepts a 1D array for the decay rate `lambda_` with size `L`.  (:issue: `176`).
+- `ExponentiallyDecayingCouplingTerms` now accepts a 1D array of size `L` for the decay rate `lambda_`.  (:issue: `176`).

--- a/doc/changelog/latest/non_uniform_decay_rates.txt
+++ b/doc/changelog/latest/non_uniform_decay_rates.txt
@@ -1,0 +1,3 @@
+Changed
+^^^^^^^
+- `ExponentiallyDecayingCouplingTerms` now accepts a 1D array for the decay rate `lambda_` with size `L`.  (:issue: `176`).

--- a/tenpy/models/model.py
+++ b/tenpy/models/model.py
@@ -1511,7 +1511,7 @@ class CouplingModel(Model):
         ----------
         strength : float
             Overall prefactor.
-        lambda_ : float
+        lambda_ : float | 1D array
             Decay-rate
         op_i, op_j : string
             Names for the operators.

--- a/tenpy/networks/terms.py
+++ b/tenpy/networks/terms.py
@@ -1389,6 +1389,7 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
         op_string : string
             The operator to be inserted between `A` and `B`; for Fermions this should be ``"JW"``.
         """
+        assert (np.isscalar(lambda_) or len(lambda_) == self.L)
         if subsites is None:
             subsites = np.arange(self.L)
         else:

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -342,6 +342,7 @@ def test_exp_decaying_terms():
     H1 = mpo.MPOGraph.from_term_list(ts, sites, bc='infinite').build_MPO()
     assert H1.is_equal(H2, cutoff)
 
+# TODO: More testing? Like previous test?
 def test_exp_non_uniform_decaying_terms():
     L = 8
     spin = site.Site(spin_half.leg)
@@ -363,7 +364,6 @@ def test_exp_non_uniform_decaying_terms():
     ]
     assert ts.terms == ts_desired
     assert np.all(ts.strength == p * np.array([l[0], l[0]**2, l[0]**3, l[2], l[2]**2, l[4]]))
-    # TODO: More testing? Like previous test
 
 @pytest.mark.parametrize('bc', ['finite', 'infinite'])
 def test_mpo_to_term_list(bc):

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -342,6 +342,28 @@ def test_exp_decaying_terms():
     H1 = mpo.MPOGraph.from_term_list(ts, sites, bc='infinite').build_MPO()
     assert H1.is_equal(H2, cutoff)
 
+def test_exp_non_uniform_decaying_terms():
+    L = 8
+    spin = site.Site(spin_half.leg)
+    spin.add_op("X", 2. * np.eye(2))
+    spin.add_op("Y", 3. * np.eye(2))
+    sites = [spin] * L
+    edt = ExponentiallyDecayingTerms(L)
+    p, l = 3., np.array([0.2,0.2,0.25,0.5, 0.5, 0.25, 0.2, 0.2])
+    edt.add_exponentially_decaying_coupling(p, l, 'X', 'Y', subsites=[0, 2, 4, 6])
+    edt._test_terms(sites)
+    ts = edt.to_TermList(bc='finite', cutoff=0.01)
+    ts_desired = [
+        [("X", 0), ("Y", 2)],
+        [("X", 0), ("Y", 4)],
+        [("X", 0), ("Y", 6)],
+        [("X", 2), ("Y", 4)],
+        [("X", 2), ("Y", 6)],
+        [("X", 4), ("Y", 6)],
+    ]
+    assert ts.terms == ts_desired
+    assert np.all(ts.strength == p * np.array([l[0], l[0]**2, l[0]**3, l[2], l[2]**2, l[4]]))
+    # TODO: More testing? Like previous test
 
 @pytest.mark.parametrize('bc', ['finite', 'infinite'])
 def test_mpo_to_term_list(bc):


### PR DESCRIPTION
This implements the non-uniform decay rates discussed in #176. `lambda_` can now be a 1D array with the size of the MPS `L`.  I've added a very basic test for `bc = "finite"`.

Looking at other closed PRs, it seems maybe I should have not included the changelog .txt description? Let me know, I can remove it.

If a scalar is given, I could have transformed `lambda_` to a 1D array early on for a simplified implementation, but I'm assuming that if a scalar is given, it should remain as such in the class attribute `exp_decaying_terms`. 
