### PR TITLE
Improve models

### DIFF
--- a/doc/changelog/latest/pr_492.txt
+++ b/doc/changelog/latest/pr_492.txt
@@ -1,0 +1,2 @@
+- Add config options to control what is conserved for the :class:`~tenpy.models.xxz_chain.XXZChain`
+  and :class:`~tenpy.models.pxp.PXPChain`.

--- a/tenpy/models/mixed_xk.py
+++ b/tenpy/models/mixed_xk.py
@@ -355,16 +355,25 @@ class MixedXKModel(CouplingMPOModel):
     All parameters are collected in a single dictionary `model_params`, which
     is turned into a :class:`~tenpy.tools.params.Config` object.
 
-    Parameters
-    ----------
-    xy_lattice : ``"Square"``
-        Chooses Real-space lattice geometry.
-        TODO: Currently, only "Square" is implemented.
-
     Attributes
     ----------
     real_space_lattice : TODO ???
         Real-space lattice geometry.
+
+    Options
+    -------
+    .. cfg:config :: MixedXKModel
+        :include: CouplingMPOModel
+
+        xy_lattice : 'Square'
+            The real-space lattice geometry. Currently, only "Square" is implemented.
+        Lx, Ly : int
+            Dimension of the (real-space) lattice.
+        ring_order : 1D array
+            The :attr:`~MixedXKLattice.ring_order` of the xk lattice. Length ``Ly*N_orb``
+        conserve_k : bool
+            If the y-momentum should be conserved.
+
     """
     def init_lattice(self, model_params, N_orb, chinfo, charges):
         """Initialize a MixedXKLattice for the given model parameters.
@@ -726,6 +735,14 @@ class SpinlessMixedXKSquare(MixedXKModel):
 
     Spinless Fermions with a single orbital (`N_orb` = 1) on a square lattice,
     nearest neighbor hopping (`t`) and nearest-neighbor interaction (`V`).
+
+    Options
+    -------
+    .. cfg:config :: SpinlessMixedXKSquare
+        :include: MixedXKModel
+
+        t, V : float | array
+            Couplings as defined for the Hamiltonian above.
     """
     def init_lattice(self, model_params):
         N_orb = 1  # simplest case possible
@@ -773,6 +790,14 @@ class HubbardMixedXKSquare(MixedXKModel):
 
     Spinful fermions, no extra orbitals (`N_orb` = 2 for up and down), on a square lattice,
     nearest-neighbor hopping (`t`) + onsite interactions (`U`)
+
+    Options
+    -------
+    .. cfg:config :: HubbardMixedXKSquare
+        :include: MixedXKModel
+
+        t, U : float | array
+            Couplings as defined for the Hamiltonian above.
     """
     def init_lattice(self, model_params):
         N_orb = 2  # for spin up (l=0) and down (l=1)

--- a/tenpy/models/mixed_xk.py
+++ b/tenpy/models/mixed_xk.py
@@ -355,11 +355,6 @@ class MixedXKModel(CouplingMPOModel):
     All parameters are collected in a single dictionary `model_params`, which
     is turned into a :class:`~tenpy.tools.params.Config` object.
 
-    Attributes
-    ----------
-    real_space_lattice : TODO ???
-        Real-space lattice geometry.
-
     Options
     -------
     .. cfg:config :: MixedXKModel
@@ -374,7 +369,15 @@ class MixedXKModel(CouplingMPOModel):
         conserve_k : bool
             If the y-momentum should be conserved.
 
+    Attributes
+    ----------
+    real_space_lattice : :class:`~tenpy.models.lattice.Lattice`
+        The original real-space geometry.
+        The :attr:`lat` of the model, which is used for calculation is a :class:`MixedXKLattice`
+        resulting from this real-space lattice.
+
     """
+
     def init_lattice(self, model_params, N_orb, chinfo, charges):
         """Initialize a MixedXKLattice for the given model parameters.
 

--- a/tenpy/models/pxp.py
+++ b/tenpy/models/pxp.py
@@ -26,6 +26,16 @@ class PXPChain(CouplingMPOModel):
     The model arises from the strong-interaction limit of Rydberg atom chains in the seminal
     experiment of :doi:`10.1038/nature24622`, which found long oscillations now attributed to
     quantum many-body scars in the PXP model.
+
+    Options
+    -------
+    .. cfg:config :: PXPChain
+        :include: CouplingMPOModel
+
+        conserve : 'best' | 'parity' | None
+            What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
+        J, J_boundary : float | array
+            Couplings as defined for the Hamiltonian above.
     """
 
     default_lattice = Chain
@@ -33,7 +43,11 @@ class PXPChain(CouplingMPOModel):
     # otherwise more P's need to be added
 
     def init_sites(self, model_params):
-        s = SpinHalfSite(conserve=None)
+        conserve = model_params.get('conserve', 'best', None)
+        if conserve == 'best':
+            conserve = 'parity'
+        assert conserve != 'Sz'
+        s = SpinHalfSite(conserve=conserve)
         s.add_op('X', s.get_op('Sigmax'), hc='X') # X is already defined under other name
         # but P is not, so we add it (as projector onto the state 0, i.e. the up spin).
         s.add_op('P', np.array([[1., 0.], [0., 0.]]), hc='P', permute_dense=True)

--- a/tenpy/models/xxz_chain.py
+++ b/tenpy/models/xxz_chain.py
@@ -39,6 +39,8 @@ class XXZChain(CouplingModel, NearestNeighborModel, MPOModel):
 
         L : int
             Length of the chain.
+        conserve : 'parity' | None
+            What should be conserved. See :class:`~tenpy.networks.Site.SpinHalfSite`.
         Jxx, Jz, hz : float | array
             Coupling as defined for the Hamiltonian above.
             Defaults to ``Jxx=Jz=1`` without field ``hz=0``.
@@ -56,12 +58,20 @@ class XXZChain(CouplingModel, NearestNeighborModel, MPOModel):
         Jz = model_params.get('Jz', 1., 'real_or_array')
         hz = model_params.get('hz', 0., 'real_or_array')
         bc_MPS = model_params.get('bc_MPS', 'finite', str)
+        conserve = model_params.get('conserve', 'best', str)
+        if conserve == 'best':
+            conserve = 'Sz'
         sort_charge = model_params.get('sort_charge', True, bool)
         # 1-3):
         USE_PREDEFINED_SITE = False
         if not USE_PREDEFINED_SITE:
             # 1) charges of the physical leg. The only time that we actually define charges!
-            leg = npc.LegCharge.from_qflat(npc.ChargeInfo([1], ['2*Sz']), [1, -1])
+            if conserve == 'Sz':
+                leg = npc.LegCharge.from_qflat(npc.ChargeInfo([1], ['2*Sz']), [1, -1])
+            elif conserve == 'parity':
+                leg = npc.LegCharge.from_qflat(npc.ChargeInfo([2], ['parity_Sz']), [1, 0])
+            else:
+                leg = npc.LegCharge.from_trivial(2)
             # 2) onsite operators
             Sp = [[0., 1.], [0., 0.]]
             Sm = [[0., 0.], [1., 0.]]
@@ -72,7 +82,7 @@ class XXZChain(CouplingModel, NearestNeighborModel, MPOModel):
         else:
             # there is a site for spin-1/2 defined in TeNPy, so just we can just use it
             # replacing steps 1-3)
-            site = SpinHalfSite(conserve='Sz', sort_charge=sort_charge)
+            site = SpinHalfSite(conserve=conserve, sort_charge=sort_charge)
         # 4) lattice
         bc = 'open' if bc_MPS == 'finite' else 'periodic'
         lat = Chain(L, site, bc=bc, bc_MPS=bc_MPS)
@@ -107,7 +117,10 @@ class XXZChain2(CouplingMPOModel, NearestNeighborModel):
 
     def init_sites(self, model_params):
         sort_charge = model_params.get('sort_charge', True, bool)
-        return SpinHalfSite(conserve='Sz', sort_charge=sort_charge)  # use predefined Site
+        conserve = model_params.get('conserve', 'best', str)
+        if conserve == 'best':
+            conserve = 'Sz'
+        return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)  # use predefined Site
 
     def init_terms(self, model_params):
         # read out parameters

--- a/tests/test_model_pxp.py
+++ b/tests/test_model_pxp.py
@@ -1,9 +1,11 @@
 
 # Copyright (C) TeNPy Developers, Apache license
+import pytest
 from tenpy.models.pxp import PXPChain
 from test_model import check_general_model
 
 
-def test_XXZChain_general():
-    check_general_model(PXPChain, dict(L=10, J=1., bc_MPS='finite'),
+@pytest.mark.parametrize('conserve', ['best', 'parity', 'None'])
+def test_XXZChain_general(conserve):
+    check_general_model(PXPChain, dict(L=10, J=1., bc_MPS='finite', conserve=conserve),
                         {'bc_MPS': ['finite', 'infinite']})

--- a/tests/test_model_xxz_chain.py
+++ b/tests/test_model_xxz_chain.py
@@ -1,6 +1,7 @@
 """test of :class:`tenpy.models.XXZChain`."""
 # Copyright (C) TeNPy Developers, Apache license
 
+import pytest
 import numpy as np
 import numpy.testing as npt
 import pprint
@@ -10,8 +11,9 @@ from tenpy.models.xxz_chain import XXZChain, XXZChain2
 from test_model import check_general_model
 
 
-def test_XXZChain():
-    pars = dict(L=4, Jxx=1., Jz=1., hz=0., bc_MPS='finite', sort_charge=True)
+@pytest.mark.parametrize('conserve', ['Sz', 'parity', 'None'])
+def test_XXZChain(conserve):
+    pars = dict(L=4, Jxx=1., Jz=1., hz=0., bc_MPS='finite', sort_charge=True, conserve=conserve)
     chain = XXZChain(pars)
     chain.test_sanity()
     for Hb in chain.H_bond[1:]:  # check bond eigenvalues
@@ -50,15 +52,18 @@ def test_XXZChain():
     chain.test_sanity()
 
 
-def test_XXZChain_general(tol=1.e-14):
-    check_general_model(XXZChain, dict(L=4, Jxx=1., hz=0., bc_MPS='finite', sort_charge=True), {
-        'Jz': [0., 1., 2.],
-        'hz': [0., 0.2]
-    })
-    check_general_model(XXZChain2, dict(L=4, Jxx=1., hz=0., bc_MPS='finite', sort_charge=True), {
-        'Jz': [0., 1., 2.],
-        'hz': [0., 0.2]
-    })
+@pytest.mark.parametrize('conserve', ['Sz', 'parity', 'None'])
+def test_XXZChain_general(conserve, tol=1.e-14):
+    check_general_model(
+        XXZChain,
+        dict(L=4, Jxx=1., hz=0., bc_MPS='finite', sort_charge=True, conserve=conserve),
+        dict(Jz=[0., 1., 2.], hz=[0., 0.2])
+    )
+    check_general_model(
+        XXZChain2,
+        dict(L=4, Jxx=1., hz=0., bc_MPS='finite', sort_charge=True, conserve=conserve),
+        dict(Jz=[0., 1., 2.], hz=[0., 0.2])
+    )
     model_param = dict(L=3, Jxx=1., Jz=1.5, hz=0.25, bc_MPS='finite', sort_charge=True)
     m1 = XXZChain(model_param)
     m2 = XXZChain2(model_param)


### PR DESCRIPTION
- Make sure all models have `conserve` as a config param, skipping mixed xk
- Support parity conservation in PXP model
- Clean up doc of mixed xk model a bit