### PR TITLE
More generic exponentially decaying interactions

### DIFF
--- a/tenpy/networks/terms.py
+++ b/tenpy/networks/terms.py
@@ -1341,6 +1341,16 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
     An easy example would be a ladder, where we want the long-range interactions on the first rung
     only, ``subsites = lat.mps_idx_fix_u(u=0)``, see :meth:`~tenpy.models.lattice.mps_idx_fix_u`.
 
+    Suppose we want long-range (LR) couplings between all sites on a strip of width Ly. The 
+    `subsites` parameters allows us to implement LR couplings along each leg of the strip. We want
+    LR couplings between sites that have both vertical and horizontal offset according to the
+    Euclidean distance. To do this, we use `subsites_start` to do this. For each site in
+    `subsites_start`, we couple to all sites to the right of `subsites`. In our example, the sites
+    in one leg can be coupled to all sites with larger index in another leg.
+
+    .. math ::
+        strength sum_{subsites_start[i] < subsites[j]} lambda^{|j-min(subsites>subsites_start[i])|} A_{subsites_start[i]} B_{subsites[j]}
+
     Parameters
     ----------
     L : int
@@ -1351,7 +1361,7 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
     L : int
         Number of sites.
     exp_decaying_terms : list of tuples
-        Each tuple ``(strength, opname_i, opname_j, lambda, subsites, opname_string)`` represents
+        Each tuple ``(strength, opname_i, opname_j, lambda, subsites, subsites_start, opname_string)`` represents
         one of the terms as described above; see :meth:`add_exponentially_decaying_coupling` for
         more details.
     """
@@ -1366,6 +1376,7 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
                                             op_i,
                                             op_j,
                                             subsites=None,
+                                            subsites_start=None,
                                             op_string='Id'):
         """Add an exponentially decaying long-range coupling.
 
@@ -1391,6 +1402,11 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
         subsites : None | 1D array
             Selects a subset of sites within the MPS unit cell on which the operators act.
             Needs to be sorted. ``None`` selects all sites.
+        subsites_start : None | 1D array
+            When STARTING an exponentially decaying coupling, which sites do we start terms?
+            The starting site is coupled to all other sites (of larger index) in `subsites`.
+            `subsites_start` does not need to be the same as `subsites`.
+            Needs to be sorted. ``None`` selects `subsites`.
         op_string : string
             The operator to be inserted between `A` and `B`; for Fermions this should be ``"JW"``.
         """
@@ -1403,7 +1419,17 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
                 raise ValueError("subsites needs to be sorted; choose a different MPS ordering!")
             assert subsites[0] >= 0
             assert subsites[-1] < self.L
-        self.exp_decaying_terms.append((strength, lambda_, op_i, op_j, subsites, op_string))
+        
+        if subsites_start is None:
+            subsites_start = subsites
+        else:
+            subsites_start = np.array(subsites_start)
+            if len(subsites_start) > 1 and np.any(subsites_start[1:] < subsites_start[:-1]):
+                raise ValueError("subsites needs to be sorted; choose a different MPS ordering!")
+            assert subsites_start[0] >= 0
+            assert subsites_start[-1] < self.L
+
+        self.exp_decaying_terms.append((strength, lambda_, op_i, op_j, subsites, subsites_start, op_string))
 
     def add_to_graph(self, graph, key="exp-decay"):
         """Add terms from :attr:`onsite_terms` to an MPOGraph.
@@ -1430,7 +1456,7 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
         key_nr = 1000  # start with high value such that they get added in the end of the MPO
         finite = (graph.bc == 'finite')
 
-        for (strength, lambda_, op_i, op_j, subsites, op_string) in self.exp_decaying_terms:
+        for (strength, lambda_, op_i, op_j, subsites, subsites_start, op_string) in self.exp_decaying_terms:
             if np.isscalar(lambda_) :
                 lambda_ = np.full(self.L, lambda_)
             while (key_nr, key) in all_states:
@@ -1439,31 +1465,46 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
             all_states.add(label)
             in_subsites = np.zeros(self.L, dtype=np.bool_)
             in_subsites[subsites] = True
-            first_subsite = subsites[0]
+            in_subsites_start = np.zeros(self.L, dtype=np.bool_)
+            in_subsites_start[subsites_start] = True
+            first_subsite = subsites_start[0]
             last_subsite = subsites[-1]
+            assert first_subsite >= 0
             assert last_subsite < self.L
             if not finite:
                 for i in range(self.L):
                     if in_subsites[i]:
-                        graph.add(i, 'IdL', label, op_i, lambda_[i])
                         graph.add(i, label, label, op_string, lambda_[i])
                         graph.add(i, label, 'IdR', op_j, strength)
-                    else:
+                    if in_subsites_start[i]:
+                        graph.add(i, 'IdL', label, op_i, lambda_[i])
+                    if not in_subsites[i]:
                         graph.add(i, label, label, op_string, 1.)
             else:
-                # first subsite
-                graph.add(first_subsite, 'IdL', label, op_i, lambda_[first_subsite])
-                for i in range(first_subsite + 1, last_subsite):
-                    if in_subsites[i]:
-                        graph.add(i, 'IdL', label, op_i, lambda_[i])
-                        graph.add(i, label, label, op_string, lambda_[i])
-                        graph.add(i, label, 'IdR', op_j, strength)
-                    else:
-                        graph.add(i, label, label, op_string, 1.)
-                graph.add(last_subsite, label, 'IdR', op_j, strength)
+                if last_subsite > first_subsite:    # If not, there is no coupling to add.
+                    # If lambda_ is not uniform and subsites_start != subsites, one needs to be very careful.
+                    # Let jj be the index of the first subsite such that subsites > subsites>subsites_start[i].
+                    # The interaction will be pref * lambda[subsites_start[i]] * lambda[jj:jj+r]
+                    # up to desired interaction range r. So the first term is just pref * lambda[subsites_start[i]]
+                    # since we only pick up a lambda on op_i and op_string. When we close a term,
+                    # there is no lambda decay.
+
+                    # first subsite
+                    graph.add(first_subsite, 'IdL', label, op_i, lambda_[first_subsite])
+                    for i in range(first_subsite + 1, last_subsite):
+                        if in_subsites[i]:
+                            graph.add(i, label, label, op_string, lambda_[i])
+                            graph.add(i, label, 'IdR', op_j, strength)
+                        if in_subsites_start[i]:
+                            graph.add(i, 'IdL', label, op_i, lambda_[i])
+                        # If not in subsites, we need to continue on with op_string.
+                        # This is true even if we opened a site.
+                        if not in_subsites[i]:
+                            graph.add(i, label, label, op_string, 1.)
+                    graph.add(last_subsite, label, 'IdR', op_j, strength)
         if graph.max_range is not None:
             graph.max_range = np.inf
-
+            
     def to_TermList(self, cutoff=0.01, bc="finite"):
         """Convert self into a :class:`TermList`.
 
@@ -1484,26 +1525,37 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
         strengths = []
         L = self.L
         for term in self.exp_decaying_terms:
-            strength, lambda_, op_i, op_j, subsites, op_string = term
-            if np.isscalar(lambda_) : 
+            strength, lambda_, op_i, op_j, subsites, subsites_start, op_string = term
+            if np.isscalar(lambda_): 
                 lambda_ = np.full(self.L, lambda_)
-            N = len(subsites)
+            N1 = len(subsites)
             if bc == 'finite':
-                for i2, i in enumerate(subsites):
-                    for d, j in enumerate(subsites[i2:]):
-                        if d == 0:
-                            continue
-                        pref = strength * np.prod(lambda_[subsites[i2:i2 + d]])
-                        if abs(pref) < cutoff:
-                            break
-                        terms.append([(op_i, i), (op_j, j)])
-                        strengths.append(pref)
+                for i2, i in enumerate(subsites_start):
+                    # Find index of first term in subsites larger than subsites_start[i2]
+                    i3 = np.where(subsites > i)[0]
+                    if len(i3):     # There is a site we couple to on the right
+                        i3 = i3[0]  # Get index of first subsite > subsites_start[i2]
+                        for d, j in enumerate(subsites[i3:]):
+                            # First decay term is from subsites_start[i2].
+                            # Then we go to subsites[i3]
+                            pref = strength * np.prod([lambda_[subsites_start[i2]]] + list(lambda_[subsites[i3:i3 + d]]))
+                            if abs(pref) < cutoff:
+                                break
+                            terms.append([(op_i, i), (op_j, j)])
+                            strengths.append(pref)
             elif bc == 'infinite':
-                for i2, i in enumerate(subsites):
-                    for d in range(1, 1000):
-                        j2 = i2 + d
-                        j = subsites[j2 % N] + (j2 // N) * L
-                        pref = strength * np.prod(lambda_[subsites[np.arange(i2, i2 + d) % N]])
+                for i2, i in enumerate(subsites_start):
+                    # Get index of first subsite to the right of the start, inside the MPS unit cell
+                    i3 = np.where(subsites > i)[0]
+                    if len(i3) == 0:    # No subsites in the first unit MPS cell are to the right of i
+                        i3 = N1         # Shift one unit cell over
+                    else:
+                        i3 = i3[0]
+                    for d in range(0, 1000):    # run over subsites INDICES
+                        j2 = i3 + d
+                        j = subsites[j2 % N1] + (j2 // N1) * L
+                        # See finite case for reasoning about decay constants
+                        pref = strength * np.prod([lambda_[subsites_start[i2]]] + list(lambda_[subsites[np.arange(i3, j2) % N1]]))
                         if abs(pref) < cutoff:
                             break
                         terms.append([(op_i, i), (op_j, j)])
@@ -1534,9 +1586,12 @@ class ExponentiallyDecayingTerms(Hdf5Exportable):
         """Check the format of self.exp_decaying_terms."""
         L = self.L
         for term in self.exp_decaying_terms:
-            strength, lambda_, op_i, op_j, subsites, op_string = term
-            for i in subsites:
-                for op in op_i, op_j:
-                    if not sites[i].valid_opname(op):
-                        raise ValueError("Operator {op!r} not in site {i:d}".format(op=op, i=i))
+            strength, lambda_, op_i, op_j, subsites, subsites_start, op_string = term
+            for i in subsites_start:
+                if not sites[i].valid_opname(op_i):
+                    raise ValueError("Operator {op!r} not in site {i:d}".format(op=op_i, i=i))
+                
+            for j in subsites:
+                if not sites[j].valid_opname(op_j):
+                    raise ValueError("Operator {op!r} not in site {i:d}".format(op=op_j, i=j))
         # done

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -291,6 +291,8 @@ def test_coupling_terms_handle_JW():
 
 
 def test_exp_decaying_terms():
+    ## subsites == subsites_start
+    # check finite version
     L = 8
     spin = site.Site(spin_half.leg)
     spin.add_op("X", 2. * np.eye(2))
@@ -331,6 +333,120 @@ def test_exp_decaying_terms():
                   [[("X", 2), ("Y", 2 + 2 * i)] for i in range(1, cutoff_range + 1)] +
                   [[("X", 4), ("Y", 4 + 2 * i)] for i in range(1, cutoff_range + 1)] +
                   [[("X", 6), ("Y", 6 + 2 * i)] for i in range(1, cutoff_range + 1)])  # yapf: disable
+    assert ts.terms == ts_desired
+    strength_desired = np.tile(l**np.arange(1, cutoff_range + 1) * p, 4)
+    assert np.all(ts.strength == strength_desired)
+    G = mpo.MPOGraph(sites, bc='infinite')
+    edt.add_to_graph(G)
+    G.test_sanity()
+    G.add_missing_IdL_IdR()
+    H2 = G.build_MPO()
+    H1 = mpo.MPOGraph.from_term_list(ts, sites, bc='infinite').build_MPO()
+    assert H1.is_equal(H2, cutoff)
+
+
+    ## subsites != subsites_start - 1
+    # check finite version
+    L = 8
+    spin = site.Site(spin_half.leg)
+    spin.add_op("X", 2. * np.eye(2))
+    spin.add_op("Y", 3. * np.eye(2))
+    sites = [spin] * L
+    edt = ExponentiallyDecayingTerms(L)
+    p, l = 3., 0.5
+    edt.add_exponentially_decaying_coupling(p, l, 'X', 'Y', subsites=[1, 3, 5, 7], subsites_start=[0, 2, 4, 6])
+    edt._test_terms(sites)
+    ts = edt.to_TermList(bc='finite', cutoff=0.01)
+    ts_desired = [
+        [("X", 0), ("Y", 1)],
+        [("X", 0), ("Y", 3)],
+        [("X", 0), ("Y", 5)],
+        [("X", 0), ("Y", 7)],
+        [("X", 2), ("Y", 3)],
+        [("X", 2), ("Y", 5)],
+        [("X", 2), ("Y", 7)],
+        [("X", 4), ("Y", 5)],
+        [("X", 4), ("Y", 7)],
+        [("X", 6), ("Y", 7)],
+    ]
+    assert ts.terms == ts_desired
+    assert np.all(ts.strength == p * np.array([l, l**2, l**3, l**4, l, l**2, l**3, l, l**2, l]))
+
+    # check whether the MPO construction works by comparing MPOs
+    # constructed from ts vs. directly
+    H1 = mpo.MPOGraph.from_term_list(ts, sites, bc='finite').build_MPO()
+    G = mpo.MPOGraph(sites, bc='finite')
+    edt.add_to_graph(G)
+    G.test_sanity()
+    G.add_missing_IdL_IdR()
+    H2 = G.build_MPO()
+    assert H1.is_equal(H2)
+
+    # check infinite versions
+    cutoff = 0.01
+    cutoff_range = 8
+    assert p * l**cutoff_range > cutoff > p * l**(cutoff_range + 1)
+    ts = edt.to_TermList(bc='infinite', cutoff=cutoff)
+    ts_desired = ([[("X", 0), ("Y", -1 + 2 * i)] for i in range(1, cutoff_range + 1)] +
+                  [[("X", 2), ("Y", 1 + 2 * i)] for i in range(1, cutoff_range + 1)] +
+                  [[("X", 4), ("Y", 3 + 2 * i)] for i in range(1, cutoff_range + 1)] +
+                  [[("X", 6), ("Y", 5 + 2 * i)] for i in range(1, cutoff_range + 1)])  # yapf: disable
+    assert ts.terms == ts_desired
+    strength_desired = np.tile(l**np.arange(1, cutoff_range + 1) * p, 4)
+    assert np.all(ts.strength == strength_desired)
+    G = mpo.MPOGraph(sites, bc='infinite')
+    edt.add_to_graph(G)
+    G.test_sanity()
+    G.add_missing_IdL_IdR()
+    H2 = G.build_MPO()
+    H1 = mpo.MPOGraph.from_term_list(ts, sites, bc='infinite').build_MPO()
+    assert H1.is_equal(H2, cutoff)
+
+
+    ## subsites != subsites_start - 2
+    # check finite version
+    L = 8
+    spin = site.Site(spin_half.leg)
+    spin.add_op("X", 2. * np.eye(2))
+    spin.add_op("Y", 3. * np.eye(2))
+    sites = [spin] * L
+    edt = ExponentiallyDecayingTerms(L)
+    p, l = 3., 0.5
+    edt.add_exponentially_decaying_coupling(p, l, 'X', 'Y', subsites=[0, 2, 4, 6], subsites_start=[1, 3, 5, 7])
+    edt._test_terms(sites)
+    ts = edt.to_TermList(bc='finite', cutoff=0.01)
+    ts_desired = [
+        [("X", 1), ("Y", 2)],
+        [("X", 1), ("Y", 4)],
+        [("X", 1), ("Y", 6)],
+        [("X", 3), ("Y", 4)],
+        [("X", 3), ("Y", 6)],
+        [("X", 5), ("Y", 6)],
+    ]
+    assert ts.terms == ts_desired
+    assert np.all(ts.strength == p * np.array([l, l**2, l**3, l, l**2, l]))
+
+    # check whether the MPO construction works by comparing MPOs
+    # constructed from ts vs. directly
+    H1 = mpo.MPOGraph.from_term_list(ts, sites, bc='finite').build_MPO()
+    G = mpo.MPOGraph(sites, bc='finite')
+    edt.add_to_graph(G)
+    G.test_sanity()
+    G.add_missing_IdL_IdR()
+    H2 = G.build_MPO()
+    assert H1.is_equal(H2)
+
+    # check infinite versions
+    cutoff = 0.01
+    cutoff_range = 8
+    assert p * l**cutoff_range > cutoff > p * l**(cutoff_range + 1)
+    ts = edt.to_TermList(bc='infinite', cutoff=cutoff)
+    ts_desired = ([[("X", 1), ("Y", 0 + 2 * i)] for i in range(1, cutoff_range + 1)] +
+                  [[("X", 3), ("Y", 2 + 2 * i)] for i in range(1, cutoff_range + 1)] +
+                  [[("X", 5), ("Y", 4 + 2 * i)] for i in range(1, cutoff_range + 1)] +
+                  [[("X", 7), ("Y", 6 + 2 * i)] for i in range(1, cutoff_range + 1)])  # yapf: disable
+    print(ts.terms)
+    print(ts_desired)
     assert ts.terms == ts_desired
     strength_desired = np.tile(l**np.arange(1, cutoff_range + 1) * p, 4)
     assert np.all(ts.strength == strength_desired)
@@ -413,6 +529,77 @@ def test_exp_non_uniform_decaying_terms(bc):
     assert ts.terms == ts_desired
     assert np.all(ts.strength == np.array(strength_desired))
 
+@pytest.mark.parametrize('bc', ['finite', 'infinite'])
+def test_exp_non_uniform_decaying_terms_subsites_start(bc):
+    L = 8
+    subsite_step = 2
+    subsites = np.arange(0, L, subsite_step)
+    subsites_start = np.arange(1, L, subsite_step)
+    cutoff = 1e-2
+    spin = site.Site(spin_half.leg)
+    spin.add_op("X", 2. * np.eye(2))
+    spin.add_op("Y", 3. * np.eye(2))
+    sites = [spin] * L
+
+    edt = ExponentiallyDecayingTerms(L)
+    p = 3.
+    l = 1. / (1 + np.arange(L))
+    edt.add_exponentially_decaying_coupling(p, l, 'X', 'Y', subsites=subsites, subsites_start=subsites_start)
+    edt._test_terms(sites)
+
+    # check if ExponentiallyDecayingTerms.to_TermList and ExponentiallyDecayingTerms.add_to_graph
+    # yield the same MPO
+    ts = edt.to_TermList(bc=bc, cutoff=cutoff)
+    H1 = mpo.MPOGraph.from_term_list(ts, sites, bc=bc).build_MPO()
+    G = mpo.MPOGraph(sites, bc=bc)
+    edt.add_to_graph(G)
+    G.test_sanity()
+    G.add_missing_IdL_IdR()
+    H2 = G.build_MPO()
+    assert H1.is_equal(H2, eps=1e-10 if bc == 'finite' else cutoff)
+    
+    # check term list
+    ts_desired = []
+    strength_desired = []
+    for n, i in enumerate(subsites_start):
+        for m in range(n + 1, 1000):
+            j = subsites[m % len(subsites)] + (m // len(subsites)) * L
+            subsite_idcs = np.arange(n+1, m) % len(subsites)
+            strength = p * np.prod([l[i]] + list(l[subsites[subsite_idcs]]))
+            if bc == 'finite' and m >= len(subsites):
+                break
+            if bc == 'infinite' and strength < cutoff:
+                break
+            ts_desired.append([('X', i), ('Y', j)])
+            strength_desired.append(strength)
+    # check if we build the desired objects correctly: check vs hardcoded result
+    if bc == 'finite':
+        assert ts_desired == [
+            [("X", 1), ("Y", 2)],
+            [("X", 1), ("Y", 4)],
+            [("X", 1), ("Y", 6)],
+            [("X", 3), ("Y", 4)],
+            [("X", 3), ("Y", 6)],
+            [("X", 5), ("Y", 6)],
+        ]
+        #decay_factors = [l[0], l[0] * l[2], l[0] * l[2] * l[4], l[2], l[2] * l[4], l[4]]
+        decay_factors = [l[1], l[1] * l[2], l[1] * l[2] * l[4], l[3], l[3] * l[4], l[5]]
+        assert strength_desired == [p * d for d in decay_factors]
+    else:
+        for (opi, i), (opj, j) in ts_desired:
+            assert opi == 'X'
+            assert opj == 'Y'
+            assert j > i
+            assert (j - i) % subsite_step == 1
+            assert i in subsites_start
+        assert ts_desired[:3] == [[("X", 1), ("Y", 2)], [("X", 1), ("Y", 4)], [("X", 1), ("Y", 6)]]
+        i = ts_desired.index([('X', 3), ('Y', 4)])
+        assert ts_desired[i:i+3] == [[('X', 3), ('Y', 4)], [('X', 3), ('Y', 6)], [('X', 3), ('Y', 8)]]
+        i = ts_desired.index([('X', 5), ('Y', 6)])
+        assert ts_desired[i:i+3] == [[('X', 5), ('Y', 6)], [('X', 5), ('Y', 8)], [('X', 5), ('Y', 10)]]
+    # check term list
+    assert ts.terms == ts_desired
+    assert np.all(ts.strength == np.array(strength_desired))
 
 @pytest.mark.parametrize('bc', ['finite', 'infinite'])
 def test_mpo_to_term_list(bc):


### PR DESCRIPTION
I want to study a model with couplings $e^{-\alpha |\vec{r}_i - \vec{r}_j|}$ on a lattice of dimension $d > 1$. For simplicity, consider a square lattice on a wide strip of width $L_y$ and length $L_x$. We want interactions that decay exponentially with the Euclidean distance between sites $i$ and $j$.

Currently, in `CouplingModel.add_exponentially_decaying_coupling`, there is a `subsites` parameter that allows for an exponentially decaying interaction between a reduced set of sites and not the entire lattice. This is sufficient to add the long-range (LR) interactions along the legs of the strip. This is also sufficient to add LR interactions along the runs of the strip.

However, this is not sufficient to add the couplings between sites that have both a vertical and horizontal offset. This is because `subsites` adds the same interactions between all pairs $(i,j)$ in `subsites` with the same strength that only depends on $|i - j|$. For diagonal interactions, we want $i$ and $j$ to be part of different sets.

We add the `subsites_start` parameter that determines on which set of sites we start an exponentially decaying term, which then is ends on all possible sites $j$ in `subsites`. So imagine leg $a$ is `subsites_start` and leg $b$ is `subsites`. Then, one can fit an exponential to the Euclidean distance. Since we only couple to `subsites` to the right of the starting site in `subsites_start`, one needs to add a separate interaction exchanging the roles of legs $a$ and $b$.

@jhauschild I added tests to `test_terms.py` that confirms backwards compatability and that the new functionality works (as far as small scale tests inspired by what was done before).