### PR TITLE
Single site bug

### DIFF
--- a/doc/changelog/latest/pr_520.txt
+++ b/doc/changelog/latest/pr_520.txt
@@ -1,0 +1,3 @@
+- Fixed a bug in single-site DMRG, where ``mixer_activate`` failed if ``mixer = None``
+- Fixed a bug where DMRG using a ``chi_list`` caused the environment sweeps to use the default
+  ``chi_max``, which is ``100`` and implies unintentional heavy truncation in most settings.

--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -1117,7 +1117,7 @@ class SingleSiteDMRGEngine(DMRGEngine):
 
     def mixer_activate(self):
         super().mixer_activate()
-        if not self.mixer.can_decompose_1site:
+        if not (self.mixer is None) and not self.mixer.can_decompose_1site:
             msg = (f'Using {self.mixer.__class__.__name__} with single-site DMRG is inefficient. '
                    f'The resulting algorithm has two-site costs!')
             warnings.warn(msg)

--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -379,9 +379,11 @@ class Sweep(Algorithm):
             # If chi_list is used, no chi_max is set.
             # When doing env sweeps, we need to make sure chi_max is set otherwise it defaults to 100
             # We set it to the current max chi
-            new_chi_max = self.trunc_params.get('chi_max', int(np.max(self.psi.chi)), int)
-            logger.info("Setting chi_max for env sweeps=%d", new_chi_max)
-            self.trunc_params['chi_max'] = new_chi_max
+            chi_max = self.trunc_params.get('chi_max', None, int)
+            if chi_max is None:
+                chi_max = int(np.max(self.psi.chi))
+                logger.info("Setting chi_max for env sweeps=%d", chi_max)
+                self.trunc_params['chi_max'] = chi_max
 
         # the actual sweep
         for i0, move_right, update_LP_RP in schedule:

--- a/tenpy/algorithms/mps_common.py
+++ b/tenpy/algorithms/mps_common.py
@@ -375,6 +375,13 @@ class Sweep(Algorithm):
                 self.trunc_params['chi_max'] = new_chi_max
                 if self.options.get('chi_list_reactivates_mixer', True, bool):
                     self.mixer_activate()
+        if not optimize and self.chi_list is not None:
+            # If chi_list is used, no chi_max is set.
+            # When doing env sweeps, we need to make sure chi_max is set otherwise it defaults to 100
+            # We set it to the current max chi
+            new_chi_max = self.trunc_params.get('chi_max', int(np.max(self.psi.chi)), int)
+            logger.info("Setting chi_max for env sweeps=%d", new_chi_max)
+            self.trunc_params['chi_max'] = new_chi_max
 
         # the actual sweep
         for i0, move_right, update_LP_RP in schedule:


### PR DESCRIPTION
Continuation of #508

> This PR address two bugs in DMRG, found by Stefan Divic.
> 
> 1. If using `chi_list` to perform sequential DMRG sweeps with increasing bond dimension, no `chi_max` is set for the environment sweeps. Thus, these default to `chi_max=100` and severely truncate the MPS. Now, if one is doing `chi_max` and `optimize=False` (env sweeps), I set `chi_max` to be the maximum bond dimension of the current chi.
> 2. In SingleSiteDMRG, `mixer_activate` failed if `mixer = None`. I added to the if statement to avoid this.

