### PR TITLE
Fix segment DMRG

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -46,9 +46,7 @@ jobs:
     - name: Run pytest on notebooks
       # Note: we exclude the dmrg mixer notebook 12, since it runs very long.
       # Note: unlike in the codebase, we ignore warnings (``-W ignore`` flag)
-      # TODO: Excluding 14 temporarily, until it is debugged.
       run: |
         pytest --nbmake notebooks \
           --ignore=notebooks/12_dmrg_mixer.ipynb \
-          --ignore=notebooks/14_segment_half_infinite.ipynb \
           -W ignore

--- a/doc/changelog/latest/pr_529.txt
+++ b/doc/changelog/latest/pr_529.txt
@@ -1,0 +1,1 @@
+- Fixed a typo in segment DMRG that resulted in an exception.

--- a/tenpy/algorithms/dmrg.py
+++ b/tenpy/algorithms/dmrg.py
@@ -624,8 +624,9 @@ class DMRGEngine(IterativeSweeps):
             psi.set_B(j, A_new, form='A')
 
             old_UL, old_VR = psi.segment_boundaries
-            new_UL = npc.tensordot(old_UL, U, axes=['vR', 'vL'])
-            psi.segment_boundaries = (new_UL, old_VR)
+            if old_UL is not None:
+                new_UL = npc.tensordot(old_UL, U, axes=['vR', 'vL'])
+                psi.segment_boundaries = (new_UL, old_VR)
 
             for env in self._all_envs:
                 update_ket = env.ket is psi
@@ -648,8 +649,9 @@ class DMRGEngine(IterativeSweeps):
             psi.set_B(j, B_new, form='B')
 
             old_UL, old_VR = psi.segment_boundaries
-            new_VR = npc.tensordot(V, old_VR, axes=['vR', 'vL'])
-            psi.segment_boundaries = (old_UL, new_VR)
+            if old_VR is not None:
+                new_VR = npc.tensordot(V, old_VR, axes=['vR', 'vL'])
+                psi.segment_boundaries = (old_UL, new_VR)
 
             for env in self._all_envs:
                 update_ket = env.ket is psi

--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -5610,16 +5610,26 @@ class BaseEnvironment(metaclass=ABCMeta):
                 vR_ket = self.ket.get_B(self.L - 1 + start_env_sites, 'B').get_leg('vR')
                 vR_bra = self.bra.get_B(self.L - 1 + start_env_sites, 'B').get_leg('vR')
         if init_LP is not None:
-            compatible = (init_LP.get_leg('vR') == vL_ket.conj()
-                          and init_LP.get_leg('vR*') == vL_bra)
-            if not compatible:
-                warnings.warn("dropping `init_LP` with incompatible MPS legs")
+            incompatible_legs = []
+            if init_LP.get_leg('vR') != vL_ket.conj():
+                incompatible_legs.append('vR')
+            if init_LP.get_leg('vR*') != vL_bra:
+                incompatible_legs.append('vR*')
+            if incompatible_legs:
+                msg = (f'dropping `init_LP` with incompatible virtual legs: '
+                       f'{", ".join(incompatible_legs)}')
+                warnings.warn(msg, stacklevel=2)
                 init_LP = None
         if init_RP is not None:
-            compatible = (init_RP.get_leg('vL') == vR_ket.conj()
-                          and init_RP.get_leg('vL*') == vR_bra)
-            if not compatible:
-                warnings.warn("dropping `init_RP` with incompatible MPS legs")
+            incompatible_legs = []
+            if init_RP.get_leg('vL') != vR_ket.conj():
+                incompatible_legs.append('vL')
+            if init_RP.get_leg('vL*') != vR_bra:
+                incompatible_legs.append('vL*')
+            if incompatible_legs:
+                msg = (f'dropping `init_RP` with incompatible virtual legs: '
+                       f'{", ".join(incompatible_legs)}')
+                warnings.warn(msg, stacklevel=2)
                 init_RP = None
         return init_LP, init_RP
 


### PR DESCRIPTION
Looks like segment DMRG is broken

- [x] Fix it
- <del>Deal with [this comment](https://github.com/tenpy/tenpy/blob/5d28d17c2918b94f406e08294f761f5cc2bd70de/tenpy/networks/mps.py#L5902) by @sajantanand</del> -> #530 
- [x] Update notebook 14
  - [x] clean up
  - [x] make segment DMRG run
  - [x] make half infinite DMRG run (init_LP is just wrong...? since when?)
  - [x] reactivate it in test-notebooks workflow
  - [x] merge companion PR https://github.com/tenpy/tenpy_notebooks/pull/6
  - [x] bump submodule
- [x] Test coverage
- [x] Also adress the issue in [forum post 691](https://tenpy.johannes-hauschild.de/viewtopic.php?t=691)
- [x] Adress [forum 788](https://tenpy.johannes-hauschild.de/viewtopic.php?t=788) as well
- [x] changelog

Fixes #518 
Fixes #448 
Fixes #340