### PR TITLE
Change to license to allow compiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "physics-tenpy"
 dynamic = ["version"]
 description = "Simulation of quantum many-body systems with tensor networks in Python"
 readme = {file = "README.rst", content-type = "text/x-rst"}
-license = "Apache-2.0"
-license-files = ["LICENSE"]
+license = {file = "LICENSE"}
 requires-python = ">=3.10"
 authors = [
     {name = "TeNPy Developer Team"},


### PR DESCRIPTION
I've recently had an issue compiling the cython code. I get the following error.

```
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']

DESCRIPTION:
    `Project license <https://peps.python.org/pep-0621/#license>`_.

GIVEN VALUE:
    "Apache-2.0"

OFFENDING RULE: 'oneOf'

DEFINITION:
    {
        "oneOf": [
[build-system]
__.py", line 103, in setup
    return distutils.core.setup(**attrs)
  File "/sw/hprc/sw/intelpython/2024.1.0_814/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 159, in setup
    dist.parse_config_files()
  File "/sw/hprc/sw/intelpython/2024.1.0_814/lib/python3.9/site-packages/setuptools/dist.py", line 627, in parse_config_files
    pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
  File "/sw/hprc/sw/intelpython/2024.1.0_814/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 67, in apply_configuration
    config = read_configuration(filepath, True, ignore_option_errors, dist)
  File "/sw/hprc/sw/intelpython/2024.1.0_814/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 128, in read_configuration
    validate(subset, filepath)
  File "/sw/hprc/sw/intelpython/2024.1.0_814/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 56, in validate
    raise ValueError(f"{error}\n{summary}") from None
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
``` 

ChatGPT gave me the change I made, after which I can compile the code.