### PR TITLE
Fix `unit_cell_width` check in `MPS.extract_segment`

### DIFF
--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -3463,7 +3463,7 @@ class MPS(BaseMPSExpectationValue):
             Copy of self with 'segment' boundary conditions.
 
         """
-        unit_cell_width, remainder = divmod(last - first, self.N_sites_per_hor_spacing)
+        unit_cell_width, remainder = divmod(last - first + 1, self.N_sites_per_hor_spacing)
         if remainder != 0:
             raise ValueError(f'Number of sites must be an integer multiple of {self.N_sites_per_hor_spacing}.')
         sites = [self.get_site(i) for i in range(first, last + 1)]


### PR DESCRIPTION
Fixes #598. The only issue seems to be that the length of the segment is calculated incorrectly, so the commensuration check fails.
I checked that the equivalent line for MPOs is correct.