### PR TITLE
Adding 'expectation_value_term_list' to BaseMPSExpectationValue

### DIFF
--- a/tenpy/networks/mps.py
+++ b/tenpy/networks/mps.py
@@ -956,7 +956,10 @@ class BaseMPSExpectationValue(MPSGeometry, metaclass=ABCMeta):
         return self.expectation_value_multi_sites(ops, i_min)
     
     def expectation_value_term_list(self, term_list):
-        """Computes the expectation value of a an operator given as a term_list"""
+        """Computes the expectation value of an operator given as a term_list
+        which contains terms and strength.
+        """
+
         sum = 0
         for term, strength in zip(term_list.terms, term_list.strength):
             sum += strength*self.expectation_value_term(term)


### PR DESCRIPTION
Hallo Johannes, 
hier ist Timo. Ich habe die Funktion 'expectation_value_term_list' in tenpy geschrieben/rüberkopiert. Ich habe sie in die Klasse, in der auch 'expectation_value_term' drin war gepackt, also in BaseMPSExpectationValue.
Ich wusste nicht genau, wie viel und was genau ich schreiben sollte in der Beschreibung, deshalb habe ich es jetzt recht kurz gehalten. Ich schicke es hier einfach einmal mit:
    def expectation_value_term_list(self, term_list):
        """Computes the expectation value of an operator given as a term_list
        which contains terms and strength.
        """

        sum = 0
        for term, strength in zip(term_list.terms, term_list.strength):
            sum += strength*self.expectation_value_term(term)
        return sum
        
Viele Grüße und vielen Dank nochmal!
Timo