### PR TITLE
H from ED dropped small exp decaying terms

### DIFF
--- a/tenpy/algorithms/exact_diag.py
+++ b/tenpy/algorithms/exact_diag.py
@@ -455,7 +455,7 @@ def _get_Hamiltonian_from_couplings(model, sparse: bool, undo_sort_charge: bool)
     ct = model.all_coupling_terms()
     ct.remove_zeros()
     edt = model.exp_decaying_terms
-    term_list = ot.to_TermList() + ct.to_TermList() + edt.to_TermList()
+    term_list = ot.to_TermList() + ct.to_TermList() + edt.to_TermList(cutoff=0.0)
 
     sites = model.lat.mps_sites()
     dims = [s.leg.ind_len for s in sites]

--- a/tenpy/networks/terms.py
+++ b/tenpy/networks/terms.py
@@ -797,7 +797,7 @@ class CouplingTerms(Hdf5Exportable):
         # done
 
     def to_TermList(self):
-        """Convert :attr:`onsite_terms` into a :class:`TermList`.
+        """Convert :attr:`coupling_terms` into a :class:`TermList`.
 
         Returns
         -------
@@ -1249,7 +1249,7 @@ class MultiCouplingTerms(CouplingTerms):
         # done
 
     def to_TermList(self):
-        """Convert :attr:`coupling_terms` into a :class:`TermList`.
+        """Convert :attr:`terms_left` and :attr:`terms_right` into a :class:`TermList`.
 
         Returns
         -------

--- a/tests/test_exact_diag.py
+++ b/tests/test_exact_diag.py
@@ -10,7 +10,7 @@ import pytest
 import tenpy.linalg.np_conserved as npc
 from tenpy.algorithms import exact_diag
 from tenpy.linalg.krylov_based import LanczosGroundState
-from tenpy.models import TFIChain, XXZChain, TFIModel
+from tenpy.models import TFIChain, TFIModel, XXZChain
 from tenpy.networks import MPS, SpinHalfSite
 
 

--- a/tests/test_exact_diag.py
+++ b/tests/test_exact_diag.py
@@ -81,6 +81,7 @@ def get_tfi_Hamiltonian(L, J, g, up_down_basis=True):
         H_expect = H_expect - J * reduce(np.kron, ops)
     return H_expect
 
+
 def get_tfi_Hamiltonian_exp_decay(L, g, pref, lambda_, up_down_basis=True):
     if up_down_basis:
         sz = np.array([[1, 0], [0, -1]], float)
@@ -94,11 +95,12 @@ def get_tfi_Hamiltonian_exp_decay(L, g, pref, lambda_, up_down_basis=True):
         ops = [eye] * L
         ops[i] = sz
         H_expect = H_expect - g * reduce(np.kron, ops)
-        for j in range(i+1, L):
+        for j in range(i + 1, L):
             ops = [eye] * L
             ops[i] = ops[j] = sx
-            H_expect = H_expect - pref * lambda_**(j - i) * reduce(np.kron, ops)
+            H_expect = H_expect - pref * lambda_ ** (j - i) * reduce(np.kron, ops)
     return H_expect
+
 
 @pytest.mark.parametrize('undo_sort_charge', [True, False])
 @pytest.mark.parametrize('conserve', ['best', 'None'])
@@ -154,6 +156,7 @@ def test_get_numpy_Hamiltonian(undo_sort_charge, conserve, use_ED, J=1, g=4.3291
         H_res = exact_diag.get_numpy_Hamiltonian(model, undo_sort_charge=undo_sort_charge)
     assert np.allclose(H_res, H_expect)
 
+
 @pytest.mark.parametrize('undo_sort_charge', [True, False])
 @pytest.mark.parametrize('conserve', ['best', 'None'])
 @pytest.mark.parametrize('use_ED', [True, False])
@@ -161,9 +164,11 @@ def test_get_numpy_Hamiltonian_exp_decay(undo_sort_charge, conserve, use_ED, J=0
     L = 6 if use_ED else 10  # using ED is a bit slow (overhead from combine? or is np.ix_ slow?)
     model = TFIModel(dict(L=L, conserve=conserve, J=J, g=g, lattice='Chain'))
     model.manually_call_init_H = True
-    model.add_exponentially_decaying_coupling(-1*pref, lambda_, 'Sigmax', 'Sigmax')
+    model.add_exponentially_decaying_coupling(-1 * pref, lambda_, 'Sigmax', 'Sigmax')
     model.init_H_from_terms()
-    H_expect = get_tfi_Hamiltonian_exp_decay(L=L, g=g, pref=pref, lambda_=lambda_, up_down_basis=undo_sort_charge or conserve == 'None')
+    H_expect = get_tfi_Hamiltonian_exp_decay(
+        L=L, g=g, pref=pref, lambda_=lambda_, up_down_basis=undo_sort_charge or conserve == 'None'
+    )
     if use_ED:
         # default behavior for this model is from couplings. test from full_H explicitly.
         H_res = exact_diag._get_numpy_Hamiltonian_ExactDiag_full_H(
@@ -172,4 +177,3 @@ def test_get_numpy_Hamiltonian_exp_decay(undo_sort_charge, conserve, use_ED, J=0
     else:
         H_res = exact_diag.get_numpy_Hamiltonian(model, undo_sort_charge=undo_sort_charge)
     assert np.allclose(H_res, H_expect)
-

--- a/tests/test_exact_diag.py
+++ b/tests/test_exact_diag.py
@@ -10,7 +10,7 @@ import pytest
 import tenpy.linalg.np_conserved as npc
 from tenpy.algorithms import exact_diag
 from tenpy.linalg.krylov_based import LanczosGroundState
-from tenpy.models import TFIChain, XXZChain
+from tenpy.models import TFIChain, XXZChain, TFIModel
 from tenpy.networks import MPS, SpinHalfSite
 
 
@@ -81,6 +81,24 @@ def get_tfi_Hamiltonian(L, J, g, up_down_basis=True):
         H_expect = H_expect - J * reduce(np.kron, ops)
     return H_expect
 
+def get_tfi_Hamiltonian_exp_decay(L, g, pref, lambda_, up_down_basis=True):
+    if up_down_basis:
+        sz = np.array([[1, 0], [0, -1]], float)
+    else:
+        sz = np.array([[-1, 0], [0, 1]], float)
+    sx = np.array([[0, 1], [1, 0]], float)
+    eye = np.eye(2, dtype=float)
+    ops = [eye] * L
+    H_expect = 0
+    for i in range(L):
+        ops = [eye] * L
+        ops[i] = sz
+        H_expect = H_expect - g * reduce(np.kron, ops)
+        for j in range(i+1, L):
+            ops = [eye] * L
+            ops[i] = ops[j] = sx
+            H_expect = H_expect - pref * lambda_**(j - i) * reduce(np.kron, ops)
+    return H_expect
 
 @pytest.mark.parametrize('undo_sort_charge', [True, False])
 @pytest.mark.parametrize('conserve', ['best', 'None'])
@@ -135,3 +153,23 @@ def test_get_numpy_Hamiltonian(undo_sort_charge, conserve, use_ED, J=1, g=4.3291
     else:
         H_res = exact_diag.get_numpy_Hamiltonian(model, undo_sort_charge=undo_sort_charge)
     assert np.allclose(H_res, H_expect)
+
+@pytest.mark.parametrize('undo_sort_charge', [True, False])
+@pytest.mark.parametrize('conserve', ['best', 'None'])
+@pytest.mark.parametrize('use_ED', [True, False])
+def test_get_numpy_Hamiltonian_exp_decay(undo_sort_charge, conserve, use_ED, J=0, g=4.3291, pref=1, lambda_=0.7839):
+    L = 6 if use_ED else 10  # using ED is a bit slow (overhead from combine? or is np.ix_ slow?)
+    model = TFIModel(dict(L=L, conserve=conserve, J=J, g=g, lattice='Chain'))
+    model.manually_call_init_H = True
+    model.add_exponentially_decaying_coupling(-1*pref, lambda_, 'Sigmax', 'Sigmax')
+    model.init_H_from_terms()
+    H_expect = get_tfi_Hamiltonian_exp_decay(L=L, g=g, pref=pref, lambda_=lambda_, up_down_basis=undo_sort_charge or conserve == 'None')
+    if use_ED:
+        # default behavior for this model is from couplings. test from full_H explicitly.
+        H_res = exact_diag._get_numpy_Hamiltonian_ExactDiag_full_H(
+            model, from_mpo=True, undo_sort_charge=undo_sort_charge
+        )
+    else:
+        H_res = exact_diag.get_numpy_Hamiltonian(model, undo_sort_charge=undo_sort_charge)
+    assert np.allclose(H_res, H_expect)
+


### PR DESCRIPTION
When getting a Numpy Hamiltonian for a model with exponentially decaying terms, `cutoff` was not set so the default value of 0.01 was used. This causes small terms to be dropped and the Numpy Hamiltonian to be incorrect. Now, `cutoff=0.0` is used.

Additionally, I added a test to `tests_exact_dag.py` to check this.