### PR TITLE
Add ArnoldiEvolution as alternative to LanczosEvolution in TDVP

### DIFF
--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -275,7 +275,12 @@ class TwoSiteTDVPEngine(TDVPEngine):
         else:
             theta = theta.combine_legs([['vL', 'p0'], ['p1', 'vR']], new_axes=[0, 1], qconj=[+1, -1])
         qtotal_i0 = self.psi.get_B(i0, form=None).qtotal
-        U, S, VH, err, renorm = svd_theta(theta, self.trunc_params, qtotal_LR=[qtotal_i0, None], inner_labels=['vR', 'vL'])
+        U, S, VH, err, renorm = svd_theta(
+            theta,
+            self.trunc_params,
+            qtotal_LR=[qtotal_i0, None],
+            inner_labels=['vR', 'vL'],
+        )
         self.psi.norm *= renorm
         B0 = U.split_legs(['(vL.p0)']).replace_label('p0', 'p')
         B1 = VH.split_legs(['(p1.vR)']).replace_label('p1', 'p')

--- a/tenpy/algorithms/tdvp.py
+++ b/tenpy/algorithms/tdvp.py
@@ -36,7 +36,7 @@ import logging
 import warnings
 
 from ..linalg import np_conserved as npc
-from ..linalg.krylov_based import LanczosEvolution
+from ..linalg.krylov_based import ArnoldiEvolution, LanczosEvolution
 from ..linalg.sparse import SumNpcLinearOperator
 from ..linalg.truncation import TruncationError, svd_theta
 from ..tools.misc import consistency_check
@@ -84,6 +84,21 @@ class TDVPEngine(TimeEvolutionAlgorithm, Sweep):
             For large time steps, the projection to the MPS manifold that is the main building block
             of TDVP, can not be a good approximation anymore. We raise in that case.
             Can be downgraded to a warning by setting this option to ``None``.
+        lanczos_params : dict
+            Parameters for the local Krylov subspace time evolution (passed to
+            :class:`~tenpy.linalg.krylov_based.LanczosEvolution` or
+            :class:`~tenpy.linalg.krylov_based.ArnoldiEvolution`). Supports all options
+            of :cfg:config:`KrylovBased`, plus:
+
+            hermitian : bool
+                If ``True`` (default), use :class:`~tenpy.linalg.krylov_based.LanczosEvolution`,
+                which assumes `H` is Hermitian and builds a tridiagonal Krylov projection.
+                Set to ``False`` to use :class:`~tenpy.linalg.krylov_based.ArnoldiEvolution`,
+                which handles non-Hermitian `H` via full Gram-Schmidt orthogonalization and
+                eigendecomposition of the Hessenberg projection.
+            normalize : bool or None
+                Passed to the ``normalize`` argument of the evolution ``run()`` method.
+                If ``None`` (default), each solver class uses its own default.
 
     Attributes
     ----------
@@ -113,6 +128,18 @@ class TDVPEngine(TimeEvolutionAlgorithm, Sweep):
         self.Krylov_params = options.subconfig('Krylov_params')
 
     # run() from TimeEvolutionAlgorithm
+
+    def _krylov_evolve(self, H, theta, dt):
+        """Apply ``exp(dt * H)`` to `theta` using Lanczos or Arnoldi.
+
+        Selects :class:`~tenpy.linalg.krylov_based.LanczosEvolution` (default, Hermitian H) or
+        :class:`~tenpy.linalg.krylov_based.ArnoldiEvolution` (non-Hermitian H) based on the
+        ``hermitian`` key in :attr:`lanczos_params`.
+        """
+        hermitian = self.lanczos_params.get('hermitian', True, bool)
+        cls = LanczosEvolution if hermitian else ArnoldiEvolution
+        normalize = self.lanczos_params.get('normalize', None)
+        return cls(H, theta, self.lanczos_params).run(dt, normalize=normalize)
 
     @property
     def lanczos_options(self):
@@ -242,13 +269,14 @@ class TwoSiteTDVPEngine(TDVPEngine):
         if i0 == L - 2:
             dt = 2.0 * dt  # instead of updating the last pair of sites twice, we double the time
         # update two-site wavefunction
-        theta, N = LanczosEvolution(self.eff_H, theta, self.lanczos_params).run(dt)
+        theta, N = self._krylov_evolve(self.eff_H, theta, dt)
         if self.combine:
             theta.itranspose(['(vL.p0)', '(p1.vR)'])  # shouldn't do anything
         else:
             theta = theta.combine_legs([['vL', 'p0'], ['p1', 'vR']], new_axes=[0, 1], qconj=[+1, -1])
         qtotal_i0 = self.psi.get_B(i0, form=None).qtotal
-        U, S, VH, err, _ = svd_theta(theta, self.trunc_params, qtotal_LR=[qtotal_i0, None], inner_labels=['vR', 'vL'])
+        U, S, VH, err, renorm = svd_theta(theta, self.trunc_params, qtotal_LR=[qtotal_i0, None], inner_labels=['vR', 'vL'])
+        self.psi.norm *= renorm
         B0 = U.split_legs(['(vL.p0)']).replace_label('p0', 'p')
         B1 = VH.split_legs(['(p1.vR)']).replace_label('p1', 'p')
 
@@ -278,7 +306,7 @@ class TwoSiteTDVPEngine(TDVPEngine):
             H1 = SumNpcLinearOperator(H1, H1.adjoint())
         theta = self.psi.get_theta(i, n=1, cutoff=self.S_inv_cutoff)
         theta = H1.combine_theta(theta)
-        theta, _ = LanczosEvolution(H1, theta, self.lanczos_params).run(dt)
+        theta, _ = self._krylov_evolve(H1, theta, dt)
         self.psi.set_B(i, theta.replace_label('p0', 'p'), form='Th')
 
 
@@ -319,7 +347,7 @@ class SingleSiteTDVPEngine(TDVPEngine):
             dt = 2.0 * dt  # instead of updating the last site twice, we double the time
 
         # update one-site wavefunction
-        theta, N = LanczosEvolution(self.eff_H, theta, self.lanczos_params).run(dt)
+        theta, N = self._krylov_evolve(self.eff_H, theta, dt)
         if self.move_right:
             self.right_moving_update(i0, theta)
         else:
@@ -334,7 +362,10 @@ class SingleSiteTDVPEngine(TDVPEngine):
         else:
             theta = theta.combine_legs(['vL', 'p0'], qconj=+1, new_axes=0)
         U, S, VH = npc.svd(theta, qtotal_LR=[theta.qtotal, None], inner_labels=['vR', 'vL'])
-        # no truncation
+        # no truncation; track norm decay for non-Hermitian evolution
+        renorm = npc.norm(S)
+        S /= renorm
+        self.psi.norm *= renorm
         A0 = U.split_legs(['(vL.p0)']).replace_label('p0', 'p')
         self.psi.set_B(i0, A0, form='A')  # left-canonical
         self.psi.set_SR(i0, S)
@@ -353,6 +384,10 @@ class SingleSiteTDVPEngine(TDVPEngine):
         else:
             theta = theta.combine_legs(['p0', 'vR'], qconj=-1, new_axes=1)
         U, S, VH = npc.svd(theta, qtotal_LR=[None, theta.qtotal], inner_labels=['vR', 'vL'])
+        # no truncation; track norm decay for non-Hermitian evolution
+        renorm = npc.norm(S)
+        S /= renorm
+        self.psi.norm *= renorm
         if i0 == 0:
             assert U.shape == (1, 1)
             VH *= U[0, 0]  # just a global phase, but better keep it!
@@ -381,7 +416,7 @@ class SingleSiteTDVPEngine(TDVPEngine):
         H0 = ZeroSiteH(self.env, i)
         if hasattr(self.env, 'H') and self.env.H.explicit_plus_hc:
             H0 = SumNpcLinearOperator(H0, H0.adjoint())
-        theta, _ = LanczosEvolution(H0, theta, self.lanczos_params).run(dt)
+        theta, _ = self._krylov_evolve(H0, theta, dt)
         return theta, H0
 
     def post_update_local(self, **update_data):

--- a/tenpy/linalg/krylov_based.py
+++ b/tenpy/linalg/krylov_based.py
@@ -520,8 +520,7 @@ class ArnoldiEvolution(Arnoldi):
         self._h_krylov[:] = 0.0
         N = self._build_krylov()
         if N > 1:
-            logger.debug('ArnoldiEvolution N=%d, |result[-1]|=%.3e', N,
-                         abs(self._result_krylov[N - 1, 0]))
+            logger.debug('ArnoldiEvolution N=%d, |result[-1]|=%.3e', N, abs(self._result_krylov[N - 1, 0]))
         else:
             logger.debug('ArnoldiEvolution N=1, |h[0,0]|=%.3e', abs(self._h_krylov[0, 0]))
         if N == 1:
@@ -549,7 +548,7 @@ class ArnoldiEvolution(Arnoldi):
             self._result_norm = np.abs(exp_dE)
             self._result_krylov = np.array([[exp_dE / self._result_norm]])
         else:
-            E_kr, v_kr = np.linalg.eig(h[:k + 1, :k + 1])
+            E_kr, v_kr = np.linalg.eig(h[: k + 1, : k + 1])
             # V^{-1} e0 = first column of V^{-1}; use solve for numerical stability
             e0 = np.zeros(k + 1, dtype=complex)
             e0[0] = 1.0

--- a/tenpy/linalg/krylov_based.py
+++ b/tenpy/linalg/krylov_based.py
@@ -456,7 +456,7 @@ class Arnoldi(KrylovBased):
 
 
 class ArnoldiEvolution(Arnoldi):
-    """Compute :math:`\\exp(\\delta H) |\\psi_0\\rangle` using Arnoldi for non-Hermitian `H`.
+    r"""Compute :math:`\\exp(\\delta H) |\\psi_0\\rangle` using Arnoldi for non-Hermitian `H`.
 
     Drop-in replacement for :class:`LanczosEvolution` when `H` is not Hermitian.
     Builds an upper Hessenberg projection of `H` via full Gram-Schmidt orthogonalization
@@ -482,6 +482,7 @@ class ArnoldiEvolution(Arnoldi):
         Prefactor of H in the exponential.
     _result_norm : float
         Norm of the result vector.
+
     """
 
     def __init__(self, H, psi0, options):
@@ -510,6 +511,7 @@ class ArnoldiEvolution(Arnoldi):
             Best approximation for ``expm(delta * H).dot(psi0)``.
         N : int
             Krylov space dimension used.
+
         """
         assert self.N_cache >= self.N_max  # all basis vectors required for back-transform
         self.delta = delta

--- a/tenpy/linalg/krylov_based.py
+++ b/tenpy/linalg/krylov_based.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     'KrylovBased',
     'Arnoldi',
+    'ArnoldiEvolution',
     'LanczosGroundState',
     'LanczosEvolution',
     'GMRES',
@@ -452,6 +453,131 @@ class Arnoldi(KrylovBased):
         P_err = (RitzRes / gap) ** 2
         Delta_E0 = self.Es[k - 1, 0] - E[0]
         return P_err < self.P_tol and Delta_E0 < self.E_tol
+
+
+class ArnoldiEvolution(Arnoldi):
+    """Compute :math:`\\exp(\\delta H) |\\psi_0\\rangle` using Arnoldi for non-Hermitian `H`.
+
+    Drop-in replacement for :class:`LanczosEvolution` when `H` is not Hermitian.
+    Builds an upper Hessenberg projection of `H` via full Gram-Schmidt orthogonalization
+    (Arnoldi iteration), then computes the matrix exponential of the small projected matrix
+    via eigendecomposition (``numpy.linalg.eig`` + pointwise scalar exponentials).
+
+    Parameters
+    ----------
+    H, psi0, options :
+        Same as :class:`Arnoldi`. Note that `H` need not be Hermitian.
+
+    Options
+    -------
+    .. cfg:config :: ArnoldiEvolution
+        :include: Arnoldi
+
+        E_tol, which, num_ev :
+            Inherited but ignored.
+
+    Attributes
+    ----------
+    delta : float/complex or None
+        Prefactor of H in the exponential.
+    _result_norm : float
+        Norm of the result vector.
+    """
+
+    def __init__(self, H, psi0, options):
+        super().__init__(H, psi0, options)
+        self._result_norm = 1.0
+        self.delta = None
+        # Arnoldi._build_krylov does not set _psi0_norm; do it here.
+        self._psi0_norm = npc.norm(psi0)
+
+    def run(self, delta, normalize=None):
+        """Compute ``expm(delta * H).dot(psi0)`` using Arnoldi.
+
+        Parameters
+        ----------
+        delta : float/complex
+            Prefactor of H in the exponential. Note that the complex ``i`` is *not* included.
+        normalize : bool
+            Whether to normalize the result. Defaults to ``False``.
+            Unlike :class:`LanczosEvolution` (which defaults to ``np.real(delta) == 0``),
+            non-Hermitian evolution does not in general preserve the norm, so normalization
+            would strip physically meaningful decay or growth and is off by default.
+
+        Returns
+        -------
+        psi_f : :class:`~tenpy.linalg.np_conserved.Array`
+            Best approximation for ``expm(delta * H).dot(psi0)``.
+        N : int
+            Krylov space dimension used.
+        """
+        assert self.N_cache >= self.N_max  # all basis vectors required for back-transform
+        self.delta = delta
+        # Arnoldi._to_cache does not pop old entries, so we must clear state between calls.
+        self._cache = []
+        self._h_krylov[:] = 0.0
+        N = self._build_krylov()
+        if N > 1:
+            logger.debug('ArnoldiEvolution N=%d, |result[-1]|=%.3e', N,
+                         abs(self._result_krylov[N - 1, 0]))
+        else:
+            logger.debug('ArnoldiEvolution N=1, |h[0,0]|=%.3e', abs(self._h_krylov[0, 0]))
+        if N == 1:
+            result_full = self._result_krylov[0, 0] * self.psi0
+        else:
+            result_full = self._calc_result_full_evolution(N)
+        if normalize is None:
+            normalize = False
+        if normalize:
+            return result_full, N
+        return (self._psi0_norm * self._result_norm) * result_full, N
+
+    def _calc_result_krylov(self, k):
+        """Compute ``exp(delta * h[:k+1, :k+1]) @ e0`` via eigendecomposition.
+
+        For a general (non-Hermitian) matrix h with right eigenvectors V and eigenvalues E,
+        h = V diag(E) V^{-1}, so exp(delta h) e0 = V diag(exp(delta E)) (V^{-1} e0).
+        This mirrors :class:`LanczosEvolution` (which uses ``eigh`` and V^{-1}=V†),
+        but uses ``eig`` and an explicit solve instead of conjugate-transpose.
+        """
+        h = self._h_krylov
+        delta = self.delta
+        if k == 0:
+            exp_dE = np.exp(delta * h[0, 0])
+            self._result_norm = np.abs(exp_dE)
+            self._result_krylov = np.array([[exp_dE / self._result_norm]])
+        else:
+            E_kr, v_kr = np.linalg.eig(h[:k + 1, :k + 1])
+            # V^{-1} e0 = first column of V^{-1}; use solve for numerical stability
+            e0 = np.zeros(k + 1, dtype=complex)
+            e0[0] = 1.0
+            coeff = np.linalg.solve(v_kr, e0)
+            exp_dH_e0 = np.dot(v_kr, np.exp(E_kr * delta) * coeff)
+            self._result_norm = np.linalg.norm(exp_dH_e0)
+            # Shape (k+1, 1) to be compatible with Arnoldi._converged reading [:, 0].
+            self._result_krylov = (exp_dH_e0 / self._result_norm).reshape(-1, 1)
+
+    def _converged(self, k):
+        """Converged when the last coefficient of ``expm(delta*h)*e0`` is below `P_tol`."""
+        return np.abs(self._result_krylov[k, 0]) < self.P_tol
+
+    def _calc_result_full_evolution(self, N):
+        """Back-transform Krylov coefficients to the original (npc) basis."""
+        vf = self._result_krylov[:N, 0]  # 1-D coefficient array
+        cache = self._cache
+        assert len(cache) >= N
+        if isinstance(self.psi0, npc.Array):
+            psif = vf[0] * cache[0]
+        else:
+            assert isinstance(self.psi0, list)
+            psif = [p * vf[0] for p in cache[0]]
+        for k in range(1, N):
+            self.iadd_prefactor_other(psif, vf[k], cache[k])
+        psif_norm = npc.norm(psif)
+        if abs(1.0 - psif_norm) > 1.0e-5:
+            logger.warning('poorly conditioned H in ArnoldiEvolution! |psi|=%f', psif_norm)
+        self.iscale_prefactor(psif, 1.0 / psif_norm)
+        return psif
 
 
 class LanczosGroundState(KrylovBased):

--- a/tests/test_krylov_based.py
+++ b/tests/test_krylov_based.py
@@ -159,3 +159,78 @@ def test_arnoldi(n, which):
     ov = np.inner(psi0.to_ndarray().conj(), psi0_flat)
     print('|<psi0|psi0_flat>|=', abs(ov))
     assert abs(1.0 - abs(ov)) < tol
+
+
+@pytest.mark.parametrize('n', [1, 2, 4, 10, 20])
+def test_arnoldi_evolve(n, tol=5.0e-13):
+    # non-Hermitian matrix (standard_normal_complex gives an arbitrary complex matrix)
+    leg = gen_random_legcharge(ch, n)
+    H = npc.Array.from_func_square(rmat.standard_normal_complex, leg)
+    H_flat = H.to_ndarray()
+    H_Op = H  # use `matvec` of the array
+    qtotal = leg.to_qflat()[0]
+    psi_init = npc.Array.from_func(np.random.random, [leg], qtotal=qtotal)
+    psi_init_flat = psi_init.to_ndarray()
+    eng = krylov_based.ArnoldiEvolution(H_Op, psi_init, {'N_max': 20})
+    for delta in [-0.1j, 0.1j, 0.5j, 0.1, -0.05 - 0.1j]:
+        psi_final_flat = expm(H_flat * delta).dot(psi_init_flat)
+        norm = np.linalg.norm(psi_final_flat)
+        psi_final, N = eng.run(delta, normalize=False)
+        diff = np.linalg.norm(psi_final.to_ndarray() - psi_final_flat)
+        print(f'delta={delta}, N={N}, norm(diff)/norm = {diff / norm}')
+        assert diff / norm < tol
+        psi_final2, N = eng.run(delta, normalize=True)
+        assert npc.norm(psi_final / norm - psi_final2) < tol
+        # Default normalize=None should behave like normalize=False
+        psi_final_default, N = eng.run(delta)
+        assert npc.norm(psi_final_default - psi_final) < tol * npc.norm(psi_final)
+
+
+def test_arnoldi_evolve_dense(tol=5.0e-13):
+    """ArnoldiEvolution on a dense (trivial-charge) matrix, larger Krylov space."""
+    n = 30
+    H_np = np.random.randn(n, n) + 1j * np.random.randn(n, n)
+    H = npc.Array.from_ndarray_trivial(H_np, dtype=complex, labels=['p', 'p*'])
+    leg = H.legs[0]
+    psi_init_np = np.random.randn(n) + 1j * np.random.randn(n)
+    psi_init = npc.Array.from_ndarray_trivial(psi_init_np, dtype=complex, labels=['p'])
+    psi_init_flat = psi_init.to_ndarray()
+    eng = krylov_based.ArnoldiEvolution(H, psi_init, {'N_max': 30})
+    for delta in [-0.1j, 1.0j, 0.1, -0.05 - 0.1j]:
+        psi_final_flat = expm(H_np * delta).dot(psi_init_flat)
+        norm = np.linalg.norm(psi_final_flat)
+        psi_final, N = eng.run(delta, normalize=False)
+        diff = np.linalg.norm(psi_final.to_ndarray() - psi_final_flat)
+        print(f'dense n={n}, delta={delta}, N={N}, norm(diff)/norm = {diff / norm}')
+        assert diff / norm < tol
+    # For large delta (delta=1.0j), expect N > 1 (non-trivial Krylov expansion needed)
+    _, N_large = eng.run(1.0j, normalize=False)
+    assert N_large > 1
+
+
+def test_arnoldi_vs_lanczos_nonhermitian(tol_arnoldi=1.0e-10, tol_lanczos_wrong=1.0e-2):
+    """ArnoldiEvolution is accurate for non-Hermitian H; LanczosEvolution is not."""
+    n = 20
+    leg = gen_random_legcharge(ch, n)
+    # Anti-Hermitian H = 1j * G with G from GUE: H† = -H, so exp(delta*H) is unitary for real delta.
+    # This is non-Hermitian (imaginary eigenvalues), so LanczosEvolution's eigh is wrong.
+    G = npc.Array.from_func_square(rmat.GUE, leg)
+    H = 1j * G
+    H_flat = H.to_ndarray()
+    qtotal = leg.to_qflat()[0]
+    psi_init = npc.Array.from_func(np.random.random, [leg], qtotal=qtotal)
+    psi_init_flat = psi_init.to_ndarray()
+
+    delta = 1.0  # real delta; exp(1.0 * 1j * G) is unitary
+    psi_ref_flat = expm(H_flat * delta).dot(psi_init_flat)
+    norm_ref = np.linalg.norm(psi_ref_flat)
+
+    psi_arnoldi, _ = krylov_based.ArnoldiEvolution(H, psi_init, {'N_max': 20}).run(delta, normalize=False)
+    diff_arnoldi = np.linalg.norm(psi_arnoldi.to_ndarray() - psi_ref_flat)
+    print(f'ArnoldiEvolution diff/norm = {diff_arnoldi / norm_ref}')
+    assert diff_arnoldi / norm_ref < tol_arnoldi
+
+    psi_lanczos, _ = krylov_based.LanczosEvolution(H, psi_init, {}).run(delta, normalize=False)
+    diff_lanczos = np.linalg.norm(psi_lanczos.to_ndarray() - psi_ref_flat)
+    print(f'LanczosEvolution diff/norm = {diff_lanczos / norm_ref}  (expected to be WRONG)')
+    assert diff_lanczos / norm_ref > tol_lanczos_wrong

--- a/tests/test_tdvp.py
+++ b/tests/test_tdvp.py
@@ -10,7 +10,7 @@ from tenpy.networks.mps import MPS
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize('plus_hc_case', ['no +hc', 'hermitian +hc', 'non-hermitian +hc'])
+@pytest.mark.parametrize('plus_hc_case', ['no +hc', 'hermitian +hc', 'non-hermitian +hc', 'non-hermitian -hc'])
 def test_tdvp(plus_hc_case, eps=1.0e-5):
     """compare overlap from TDVP with TEBD"""
     L = 8
@@ -26,6 +26,8 @@ def test_tdvp(plus_hc_case, eps=1.0e-5):
     elif plus_hc_case == 'non-hermitian +hc':
         parameters['hz'] = parameters['hz'] + 1.0j * np.random.random(L)
         parameters['explicit_plus_hc'] = True
+    elif plus_hc_case == 'non-hermitian -hc':
+        parameters['hz'] = parameters['hz'] + 1.0j * np.random.random(L)
     else:
         raise ValueError
 
@@ -51,6 +53,11 @@ def test_tdvp(plus_hc_case, eps=1.0e-5):
         'trunc_params': {'chi_max': chi, 'svd_min': 1.0e-10, 'trunc_cut': None},
     }
 
+    if plus_hc_case == 'non-hermitian -hc':
+        tebd_params['preserve_norm'] = False
+        tdvp_params['preserve_norm'] = False
+        tdvp_params['lanczos_params'] = {'hermitian': False}
+
     # start by comparing TEBD and 2-site TDVP (increasing bond dimension)
     psi_tdvp = psi_tebd.copy()
     tebd_engine = tebd.TEBDEngine(psi_tebd, M, tebd_params)
@@ -59,7 +66,7 @@ def test_tdvp(plus_hc_case, eps=1.0e-5):
         tebd_engine.run()
         tdvp2_engine.run()
 
-        ov = psi_tebd.overlap(psi_tdvp)
+        ov = psi_tebd.overlap(psi_tdvp) / (psi_tebd.norm * psi_tdvp.norm)
         print(tdvp2_engine.evolved_time, 'ov = 1. - ', ov - 1.0)
         assert np.abs(1 - ov) < eps
         Sz_tebd = psi_tebd.expectation_value('Sz')
@@ -73,7 +80,7 @@ def test_tdvp(plus_hc_case, eps=1.0e-5):
     for _ in range(3):
         tebd_engine.run()
         tdvp1_engine.run()
-        ov = psi_tebd.overlap(psi_tdvp)
+        ov = psi_tebd.overlap(psi_tdvp) / (psi_tebd.norm * psi_tdvp.norm)
         print(tdvp1_engine.evolved_time, 'ov = 1. - ', ov - 1.0)
         assert np.abs(1 - np.abs(ov)) < 1e-5
         Sz_tebd = psi_tebd.expectation_value('Sz')


### PR DESCRIPTION
In order to enable Lindblad evolution using quantum trajectories for systems with long-ranged interactions, one needs TDVP to work for non-Hermitian Hamiltonians. The current bottleneck prohibiting this is the `LanczosEvolution` inside TDVP which assumes hermitian matrices. See also [this forum post](https://forum.tenpy.org/viewtopic.php?t=401) . Here I try to resolve this by introducing the following changes:

- With the help of an LLM I have implemented the class `ArnoldiEvolution` on top of the existing `Arnoldi` in exact analogue to `LanczosEvolution`. A newly introduced parameter `hermitian` which is stored in `lanczos_params` toggles the use of `ArnoldiEvolution` instead of `LanczosEvolution` if `hermitian=False`.

- Another ingredient for the quantum trajectories algorithm is tracking the norm of the state. Currently this was not done in TDVP, as far as I could tell. I have modified both `TwoSiteTDVPEngine` and `SingleSiteTDVPEngine` to correctly track the norm in `psi.norm`, in accordance with the flags `preserve_norm` and `normalize`.

I added corresponding tests for `ArnoldiEvolution` to the testsuite. Additionally, the attached example script tests the time evolution of a minimal non-hermitian BoseHubbard model using both TDVP and TEBD. See attached plots. They show the convergence behavior w.r.t $\chi,\Delta t$, the density distribution over time and the norm of the state, comparing TDVP against TEBD.    
As the differences between TEBD and TDVP have similar order of magnitude as the numerical error stemming from the convergence parameters, I concluded that they agree well.

<img width="1800" height="750" alt="bh_convergence" src="https://github.com/user-attachments/assets/e5cba162-5e89-48ed-8940-34dc1fe43d18" />
<img width="1800" height="750" alt="bh_density" src="https://github.com/user-attachments/assets/b72735ba-10bd-4c55-b572-aeb51727f8fe" />
<img width="1800" height="750" alt="bh_tebd_vs_tdvp" src="https://github.com/user-attachments/assets/2c20a2df-611f-4e3f-bfcd-bdcfdf76ce75" />
[non_hermitian_bose_hubbard_comparison.py](https://github.com/user-attachments/files/28110631/non_hermitian_bose_hubbard_comparison.py)
