### PR TITLE
Fixed Bug in tenpy.networks.site.GroupedSite

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - GroupedSite-bug
 
 jobs:
   build:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - GroupedSite-bug
   # PRs
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - GroupedSite-bug
   # PRs
   pull_request:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - GroupedSite-bug
   # PRs
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/pytest_old_numpy.yml
+++ b/.github/workflows/pytest_old_numpy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - GroupedSite-bug
 
 
 jobs:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - GroupedSite-bug
   # PRs
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -723,7 +723,6 @@ class GroupedSite(Site):
                 legs.append(leg)
         else:
             raise ValueError('Unknown option for `charges`: ' + repr(charges))
-        c2JWps = [getattr(s, 'charge_to_JW_parity', None) for s in sites]  # maybe keep it below
         if charges != 'same':
             sites = [copy.copy(s) for s in sites]  # avoid modifying the existing sites.
             # sort legs
@@ -771,9 +770,10 @@ class GroupedSite(Site):
 
         # propagate `charge_to_JW_parity` if safe/clear what it should be
         # read it into c2JWps for each site before calling Site.change_charge() deleting it
+        c2JWps = [getattr(s, 'charge_to_JW_parity', None) for s in sites] 
         if charges == 'same':
             # already same charges, so could/should have same `charge_to_JW_parity`
-            if all(p is not None and all(p == c2JWps[0]) for p in c2JWps):
+            if all(p is not None and np.array_equal(p , c2JWps[0]) for p in c2JWps):
                 self.charge_to_JW_parity = c2JWps[0]
         elif charges == 'independent':
             if all(p is not None for p in c2JWps):

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -770,7 +770,7 @@ class GroupedSite(Site):
 
         # propagate `charge_to_JW_parity` if safe/clear what it should be
         # read it into c2JWps for each site before calling Site.change_charge() deleting it
-        c2JWps = [getattr(s, 'charge_to_JW_parity', None) for s in sites]
+        c2JWps = [getattr(s, 'charge_to_JW_parity', None) for s in sites] 
         if charges == 'same':
             # already same charges, so could/should have same `charge_to_JW_parity`
             if all(p is not None and np.array_equal(p , c2JWps[0]) for p in c2JWps):

--- a/tenpy/networks/site.py
+++ b/tenpy/networks/site.py
@@ -770,7 +770,7 @@ class GroupedSite(Site):
 
         # propagate `charge_to_JW_parity` if safe/clear what it should be
         # read it into c2JWps for each site before calling Site.change_charge() deleting it
-        c2JWps = [getattr(s, 'charge_to_JW_parity', None) for s in sites] 
+        c2JWps = [getattr(s, 'charge_to_JW_parity', None) for s in sites]
         if charges == 'same':
             # already same charges, so could/should have same `charge_to_JW_parity`
             if all(p is not None and np.array_equal(p , c2JWps[0]) for p in c2JWps):


### PR DESCRIPTION
Fixed a bug in GroupedSite which would throw a 
```shell
TypeError: 'bool' object is not iterable
```
error when sites with different charge_to_JW_parity values were grouped. 

Example: 

```
ferm_site = SpinHalfFermionSite(cons_N='N', cons_Sz= 'Sz' )
spin_site = SpinHalfSite(conserve= 'Sz')
set_common_charges([ferm_site, spin_site], new_charges= 'same')
sites = [ferm_site, spin_site]

site = GroupedSite(sites, labels = ['e', 'i'] , charges = 'same')
```

Returns:
```shell
TypeError: 'bool' object is not iterable
``` 

Also moved the location ```c2JWps``` closer to where it is used for ease of read.