### PR TITLE
Fix t1 sign in Haldane FCI example

### DIFF
--- a/examples/chern_insulators/haldane_FCI.py
+++ b/examples/chern_insulators/haldane_FCI.py
@@ -117,7 +117,7 @@ def plot_results(data):
 
 
 if __name__ == '__main__':
-    t1_value = -1
+    t1_value = 1
 
     phi = np.arccos(3 * np.sqrt(3 / 43))
     t2_value = (np.sqrt(129) / 36) * t1_value * np.exp(1j * phi)  # optimal band flatness


### PR DESCRIPTION
The sign of t1 in the bosonic Haldane FCI example means that the flat Chern band is the higher energy band, not the lowest one. Changing the sign inverts the bands, which is desired to observe the FCI at 1/4 total filling. This PR fixes that typo.
This issue was reported in a thread of #558 for example.